### PR TITLE
Fix ComboBox button vertical alignment

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -139,7 +139,7 @@
                     </TransformGroup>
                   </StackPanel.RenderTransform>
                   <Path Width="9"
-                        Height="4.5"
+                        Height="4.4"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Data="{DynamicResource ChevronPath}"
@@ -154,7 +154,7 @@
                     </Path.Fill>
                   </Path>
                   <Path Width="9"
-                        Height="4.5"
+                        Height="4.4"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Data="{DynamicResource ChevronPath}"


### PR DESCRIPTION
I'm finally able to reproduce these rendering differences between Mac and Windows. Changing the chevron height by 0.1 pixel makes all the difference in Windows (forcing it to round down), and no perceivable difference under MacOS:

![image](https://github.com/user-attachments/assets/8eb79696-ddbe-46a9-ad20-bc1660d415c8)
 