### PR TITLE
[DevExpress] Fix ScrollView for multiline TextBox

### DIFF
--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
@@ -2,19 +2,19 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="SampleApp.DemoPages.ScrollViewerDemo">
   <Border Padding="10">
     <StackPanel>
-      <Grid ColumnDefinitions="Auto, 420, 420" RowDefinitions="Auto, 320, 320">
+      <Grid ColumnDefinitions="Auto, 400, 400" RowDefinitions="Auto, 320, 320">
         <TextBlock Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center">Default</TextBlock>
         <TextBlock Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center" Classes="code">Classes="MacOS_TransparentTrack"</TextBlock>
         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">Default</TextBlock>
         <Border Grid.Row="1" Grid.Column="1" Background="{DynamicResource BackgroundBrush}"
-                BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1" Width="400"
+                BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1" Width="380"
                 Height="300">
-          <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5 ">
-            <StackPanel Background="{DynamicResource BackgroundBrush}">
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5">
+            <StackPanel Background="{DynamicResource BackgroundBrush}" Width="400">
               <TextBlock>drwxr-xr-x  26 jdoe  staff     832 28 Jan 14:27 .</TextBlock>
               <TextBlock>drwxr-xr-x@ 17 jdoe  staff     544 29 Jan 11:59 ..</TextBlock>
               <TextBlock>-rw-r--r--@  1 jdoe  staff    6148 28 Jan 14:27 .DS_Store</TextBlock>
@@ -46,7 +46,7 @@
         </Border>
 
         <Border Grid.Row="1" Grid.Column="2" BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1"
-                Width="400" Height="300">
+                Width="380" Height="300">
           <ScrollViewer HorizontalScrollBarVisibility="Auto" Classes="MacOS_TransparentTrack">
             <Image Width="800" Height="600"
                    Source="avares://SampleApp/Assets/SampleImage.jpg" />
@@ -54,10 +54,11 @@
         </Border>
 
         <TextBlock Grid.Row="2" Grid.Column="0" HorizontalAlignment="Center" Classes="code" VerticalAlignment="Center">AllowAutoHide="False"</TextBlock>
-        <Border Grid.Row="2" Grid.Column="1" BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1"
-                Width="400" Height="300">
-          <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5 " AllowAutoHide="False">
-            <StackPanel Background="{DynamicResource BackgroundBrush}">
+        <Border Grid.Row="2" Grid.Column="1" Background="{DynamicResource BackgroundBrush}"
+                BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1" Width="380"
+                Height="300">
+          <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5" AllowAutoHide="False">
+            <StackPanel Background="{DynamicResource BackgroundBrush}" Width="400">
               <TextBlock>drwxr-xr-x  26 jdoe  staff     832 28 Jan 14:27 .</TextBlock>
               <TextBlock>drwxr-xr-x@ 17 jdoe  staff     544 29 Jan 11:59 ..</TextBlock>
               <TextBlock>-rw-r--r--@  1 jdoe  staff    6148 28 Jan 14:27 .DS_Store</TextBlock>
@@ -87,9 +88,8 @@
             </StackPanel>
           </ScrollViewer>
         </Border>
-
         <Border Grid.Row="2" Grid.Column="2" BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1"
-                Width="400" Height="300">
+                Width="380" Height="300">
           <ScrollViewer HorizontalScrollBarVisibility="Auto" Classes="MacOS_TransparentTrack" AllowAutoHide="False">
             <Image Width="800" Height="600"
                    Source="avares://SampleApp/Assets/SampleImage.jpg" />
@@ -100,6 +100,9 @@
         <Bold>Note:</Bold> MacOS hides scrollbars completely (depending on user settings), but they re-appear on scroll events.
         Since Avalonia ScrollBars only expand on pointerOver hiding them completely would be a bit confusing, so the Thumb sliders
         remain visible even when <TextBlock Classes="code" Text="AllowAutoHide=&quot;True&quot;" />.
+      </TextBlock>
+      <TextBlock TextWrapping="Wrap">
+        <Bold>Note:</Bold> ScrollViewer content needs explicit width to avoid cutting off the right edge.
       </TextBlock>
     </StackPanel>
   </Border>

--- a/samples/SampleApp/MainWindow.axaml
+++ b/samples/SampleApp/MainWindow.axaml
@@ -6,10 +6,12 @@
         xmlns:experiments="clr-namespace:SampleApp.Experiments"
         xmlns:vm="clr-namespace:SampleApp.ViewModels"
         xmlns:sampleApp="clr-namespace:SampleApp"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="450"
+        Width="1250"
+        Height="800"
         x:Class="SampleApp.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="Devolutions MacOS Theme Sampler">
+        Title="Devolutions Theme Sampler">
 
   <!-- TODO: move the margins into the theme ?? -->
   <Panel Classes="mainControl">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -99,6 +99,8 @@
   <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ControlBorderLowColorSolid}" />
   <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource TextBoxBorderBottomColor}" />
   <SolidColorBrush x:Key="TextBoxDisabledBorderSelectedBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
+  <Thickness x:Key="TextBoxPrefixPaddingFactors">1 1 0 1</Thickness>
+  <Thickness x:Key="TextBoxSufixPaddingFactors">0 1 1 1</Thickness>
 
   <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
   <SolidColorBrush x:Key="ComboBoxDropDownBorderBrushTransparent" Color="{DynamicResource ForegroundColor}"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ScrollViewer.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ScrollViewer.axaml
@@ -2,20 +2,76 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <Design.PreviewWith>
-    <ScrollViewer Width="200" Height="400"
-                  HorizontalScrollBarVisibility="Auto">
-      <StackPanel Spacing="20" Width="210">
-        <TextBlock>Item 1</TextBlock>
-        <TextBlock>Item 2</TextBlock>
-        <TextBlock>Item 3</TextBlock>
-        <TextBlock>Item 4</TextBlock>
-        <TextBlock>Item 5</TextBlock>
-        <TextBlock>Item 6</TextBlock>
-        <TextBlock>Item 7</TextBlock>
-        <TextBlock>Item 8</TextBlock>
-        <TextBlock>Item 9</TextBlock>
-      </StackPanel>
-    </ScrollViewer>
+    <StackPanel Spacing="20" Margin="10">
+      <Border Background="{DynamicResource BackgroundBrush}"
+              BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1" Width="330"
+              Height="300">
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5">
+          <StackPanel Background="{DynamicResource BackgroundBrush}">
+            <TextBlock>drwxr-xr-x  26 jdoe  staff     832 28 Jan 14:27 .</TextBlock>
+            <TextBlock>drwxr-xr-x@ 17 jdoe  staff     544 29 Jan 11:59 ..</TextBlock>
+            <TextBlock>-rw-r--r--@  1 jdoe  staff    6148 28 Jan 14:27 .DS_Store</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     534 27 Jan 15:29 Add.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     506 27 Jan 15:29 AddThin.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     536 27 Jan 15:29 Computer.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     909 27 Jan 15:29 CopyHost.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     795 27 Jan 15:29 CopyName.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     986 27 Jan 15:29 CopyPassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1169 27 Jan 15:29 CopyUserName.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1189 27 Jan 15:29 CopyUserNamePassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     749 27 Jan 15:29 Details.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     888 27 Jan 15:29 DisableUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     777 27 Jan 15:29 EnableUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     368 27 Jan 15:29 Folder.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     880 27 Jan 15:29 Help.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     488 27 Jan 15:29 HorizontalLine.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     564 27 Jan 15:29 More.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     579 27 Jan 15:29 Padlock.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     715 27 Jan 15:29 PasswordAnalyser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1013 27 Jan 15:29 PrivateKey.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1275 27 Jan 15:29 Properties.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     820 27 Jan 15:29 ResetPassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--@  1 jdoe  staff  147049 28 Jan 14:27 SampleImage.jpg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     729 27 Jan 15:29 UnlockUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     561 27 Jan 15:29 User.svg</TextBlock>
+          </StackPanel>
+        </ScrollViewer>
+      </Border>
+      <Border Background="{DynamicResource BackgroundBrush}"
+              BorderBrush="{DynamicResource ControlBorderMidColor}" BorderThickness="1" Width="330"
+              Height="300">
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" Padding="5 " AllowAutoHide="False">
+          <StackPanel Background="{DynamicResource BackgroundBrush}">
+            <TextBlock>drwxr-xr-x  26 jdoe  staff     832 28 Jan 14:27 .</TextBlock>
+            <TextBlock>drwxr-xr-x@ 17 jdoe  staff     544 29 Jan 11:59 ..</TextBlock>
+            <TextBlock>-rw-r--r--@  1 jdoe  staff    6148 28 Jan 14:27 .DS_Store</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     534 27 Jan 15:29 Add.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     506 27 Jan 15:29 AddThin.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     536 27 Jan 15:29 Computer.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     909 27 Jan 15:29 CopyHost.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     795 27 Jan 15:29 CopyName.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     986 27 Jan 15:29 CopyPassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1169 27 Jan 15:29 CopyUserName.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1189 27 Jan 15:29 CopyUserNamePassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     749 27 Jan 15:29 Details.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     888 27 Jan 15:29 DisableUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     777 27 Jan 15:29 EnableUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     368 27 Jan 15:29 Folder.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     880 27 Jan 15:29 Help.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     488 27 Jan 15:29 HorizontalLine.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     564 27 Jan 15:29 More.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     579 27 Jan 15:29 Padlock.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     715 27 Jan 15:29 PasswordAnalyser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1013 27 Jan 15:29 PrivateKey.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff    1275 27 Jan 15:29 Properties.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     820 27 Jan 15:29 ResetPassword.svg</TextBlock>
+            <TextBlock>-rw-r--r--@  1 jdoe  staff  147049 28 Jan 14:27 SampleImage.jpg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     729 27 Jan 15:29 UnlockUser.svg</TextBlock>
+            <TextBlock>-rw-r--r--   1 jdoe  staff     561 27 Jan 15:29 User.svg</TextBlock>
+          </StackPanel>
+        </ScrollViewer>
+      </Border>
+    </StackPanel>
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
@@ -62,10 +118,6 @@
     </Setter>
     <Style Selector="^[IsExpanded=true] /template/ Panel#PART_ScrollBarsSeparator">
       <Setter Property="Opacity" Value="1" />
-    </Style>
-    <Style Selector="^[AllowAutoHide=True] /template/ ScrollContentPresenter#PART_ContentPresenter">
-      <Setter Property="Grid.ColumnSpan" Value="2" />
-      <Setter Property="Grid.RowSpan" Value="2" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -11,7 +11,9 @@
         <TextBlock>Password:</TextBlock>
         <TextBox PasswordChar="*" Watermark="Enter your password" />
         <TextBlock>Notes:</TextBlock>
-        <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
+        <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
+          Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
+        </TextBox>
         <TextBox InnerLeftContent="http://" />
         <TextBox InnerRightContent=".com" />
         <TextBox
@@ -151,20 +153,28 @@
               MinWidth="{TemplateBinding MinWidth}"
               MinHeight="{TemplateBinding MinHeight}" />
             <Border
-              Margin="{TemplateBinding BorderThickness}"
-              Padding="{TemplateBinding Padding}">
+              Margin="{TemplateBinding BorderThickness}">
               <Grid ColumnDefinitions="Auto,*,Auto">
-                <ContentPresenter Grid.Column="0"
+                <ContentPresenter Name="PrefixContent"
+                                  Grid.Column="0"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Content="{TemplateBinding InnerLeftContent}" />
+                                  Content="{TemplateBinding InnerLeftContent}"
+                                  Padding="{Binding 
+                                            Padding, 
+                                            RelativeSource={RelativeSource TemplatedParent}, 
+                                            Converter={StaticResource ThicknessToSelectiveThicknessConverter},
+                                            ConverterParameter={StaticResource TextBoxPrefixPaddingFactors}}"
+                                  IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                 <ScrollViewer Name="PART_ScrollViewer"
                               Grid.Column="1"
+                              Margin="0 2 2 2"
                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                               VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                               IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                               AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
                               BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                  <Panel>
+                  <Panel
+                    Margin="{TemplateBinding Padding}">
                     <TextBlock Name="PART_Watermark"
                                Opacity="0.5"
                                FontSize="{DynamicResource ControlFontSize}"
@@ -210,9 +220,16 @@
                     </Style>
                   </ScrollViewer.Styles>
                 </ScrollViewer>
-                <ContentPresenter Grid.Column="2"
+                <ContentPresenter Name="SufixContent"
+                                  Grid.Column="2"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Content="{TemplateBinding InnerRightContent}" />
+                                  Padding="{Binding 
+                                            Padding, 
+                                            RelativeSource={RelativeSource TemplatedParent}, 
+                                            Converter={StaticResource ThicknessToSelectiveThicknessConverter},
+                                            ConverterParameter={StaticResource TextBoxSufixPaddingFactors}}"
+                                  Content="{TemplateBinding InnerRightContent}"
+                                  IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
               </Grid>
             </Border>
           </Panel>
@@ -232,6 +249,10 @@
       <Style Selector="^ /template/ Border#BottomBorderElement">
         <Setter Property="IsVisible" Value="False" />
       </Style>
+
+      <Style Selector="^ /template/ TextBlock#PART_Watermark, ^ /template/ TextBlock#PART_FloatingWatermark">
+        <Setter Property="Foreground" Value="{DynamicResource TextControlPlaceholderForegroundDisabled}" />
+      </Style>
     </Style>
 
 
@@ -246,6 +267,7 @@
     <Style Selector="^:error /template/ Border#PART_BorderElement">
       <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
     </Style>
+
 
     <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
       <Setter Property="InnerRightContent">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -157,66 +157,59 @@
                 <ContentPresenter Grid.Column="0"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                   Content="{TemplateBinding InnerLeftContent}" />
-                <DockPanel Name="PART_InnerDockPanel"
-                           Grid.Column="1">
-                  <TextBlock Name="PART_FloatingWatermark"
-                             Foreground="{DynamicResource SystemAccentColor}"
-                             IsVisible="False"
-                             Text="{TemplateBinding Watermark}"
-                             DockPanel.Dock="Top" />
-                  <ScrollViewer Name="PART_ScrollViewer"
-                                HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                                AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                                BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                    <Panel>
-                      <TextBlock Name="PART_Watermark"
-                                 Opacity="0.5"
-                                 FontSize="{DynamicResource ControlFontSize}"
-                                 Text="{TemplateBinding Watermark}"
-                                 TextAlignment="{TemplateBinding TextAlignment}"
-                                 TextWrapping="{TemplateBinding TextWrapping}"
-                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                        <TextBlock.IsVisible>
-                          <MultiBinding Converter="{x:Static BoolConverters.And}">
-                            <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                     Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                     Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                          </MultiBinding>
-                        </TextBlock.IsVisible>
-                      </TextBlock>
-                      <TextPresenter Name="PART_TextPresenter"
-                                     Text="{TemplateBinding Text, Mode=TwoWay}"
-                                     CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                     CaretIndex="{TemplateBinding CaretIndex}"
-                                     SelectionStart="{TemplateBinding SelectionStart}"
-                                     SelectionEnd="{TemplateBinding SelectionEnd}"
-                                     TextAlignment="{TemplateBinding TextAlignment}"
-                                     TextWrapping="{TemplateBinding TextWrapping}"
-                                     LineHeight="{TemplateBinding LineHeight}"
-                                     LetterSpacing="{TemplateBinding LetterSpacing}"
-                                     RevealPassword="{TemplateBinding RevealPassword}"
-                                     SelectionBrush="{TemplateBinding SelectionBrush}"
-                                     SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                     CaretBrush="{TemplateBinding CaretBrush}"
-                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                        <TextPresenter.PasswordChar>
-                          <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
-                                   Converter="{StaticResource CharToDevExpressPasswordCharConverter}" />
-                        </TextPresenter.PasswordChar>
-                      </TextPresenter>
-                    </Panel>
-                    <ScrollViewer.Styles>
-                      <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                        <Setter Property="Cursor" Value="IBeam" />
-                      </Style>
-                    </ScrollViewer.Styles>
-                  </ScrollViewer>
-                </DockPanel>
+                <ScrollViewer Name="PART_ScrollViewer"
+                              Grid.Column="1"
+                              HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                              IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                              AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                              BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                  <Panel>
+                    <TextBlock Name="PART_Watermark"
+                               Opacity="0.5"
+                               FontSize="{DynamicResource ControlFontSize}"
+                               Text="{TemplateBinding Watermark}"
+                               TextAlignment="{TemplateBinding TextAlignment}"
+                               TextWrapping="{TemplateBinding TextWrapping}"
+                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      <TextBlock.IsVisible>
+                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                          <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                                   Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                          <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                                   Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                        </MultiBinding>
+                      </TextBlock.IsVisible>
+                    </TextBlock>
+                    <TextPresenter Name="PART_TextPresenter"
+                                   Text="{TemplateBinding Text, Mode=TwoWay}"
+                                   CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                   CaretIndex="{TemplateBinding CaretIndex}"
+                                   SelectionStart="{TemplateBinding SelectionStart}"
+                                   SelectionEnd="{TemplateBinding SelectionEnd}"
+                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                   LineHeight="{TemplateBinding LineHeight}"
+                                   LetterSpacing="{TemplateBinding LetterSpacing}"
+                                   RevealPassword="{TemplateBinding RevealPassword}"
+                                   SelectionBrush="{TemplateBinding SelectionBrush}"
+                                   SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                   CaretBrush="{TemplateBinding CaretBrush}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      <TextPresenter.PasswordChar>
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
+                                 Converter="{StaticResource CharToDevExpressPasswordCharConverter}" />
+                      </TextPresenter.PasswordChar>
+                    </TextPresenter>
+                  </Panel>
+                  <ScrollViewer.Styles>
+                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                      <Setter Property="Cursor" Value="IBeam" />
+                    </Style>
+                  </ScrollViewer.Styles>
+                </ScrollViewer>
                 <ContentPresenter Grid.Column="2"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                   Content="{TemplateBinding InnerRightContent}" />
@@ -239,10 +232,6 @@
       <Style Selector="^ /template/ Border#BottomBorderElement">
         <Setter Property="IsVisible" Value="False" />
       </Style>
-
-      <Style Selector="^ /template/ TextBlock#PART_Watermark, ^ /template/ TextBlock#PART_FloatingWatermark">
-        <Setter Property="Foreground" Value="{DynamicResource TextControlPlaceholderForegroundDisabled}" />
-      </Style>
     </Style>
 
 
@@ -256,14 +245,6 @@
 
     <Style Selector="^:error /template/ Border#PART_BorderElement">
       <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-    </Style>
-
-    <Style Selector="^ /template/ TextBlock#PART_FloatingWatermark">
-      <Setter Property="Cursor" Value="IBeam" />
-    </Style>
-
-    <Style Selector="^[UseFloatingWatermark=true]:not(:empty) /template/ TextBlock#PART_FloatingWatermark">
-      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/ThicknessToSelectiveThicknessConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/ThicknessToSelectiveThicknessConverter.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+namespace Devolutions.AvaloniaTheme.DevExpress.Converters;
+
+public class ThicknessToSelectiveThicknessConverter : IValueConverter
+{
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (value is not Thickness thickness || parameter is not Thickness thicknessFactors)
+      return AvaloniaProperty.UnsetValue;
+
+    return new Thickness(
+      thickness.Left * thicknessFactors.Left,
+      thickness.Top * thicknessFactors.Top,
+      thickness.Right * thicknessFactors.Right,
+      thickness.Bottom * thicknessFactors.Bottom
+    );
+  }
+
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    throw new NotImplementedException();
+  }
+}

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/_index.axaml
@@ -6,4 +6,5 @@
   <converters:CharToDevExpressPasswordCharConverter x:Key="CharToDevExpressPasswordCharConverter" />
   <converters:RevealPasswordToFontSizeConverter x:Key="RevealPasswordToFontSizeConverter" />
   <converters:TabBorderVisibilityConverter x:Key="TabBorderVisibilityConverter" />
+  <converters:ThicknessToSelectiveThicknessConverter x:Key="ThicknessToSelectiveThicknessConverter" />
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -15,16 +15,9 @@
             <TextBlock>Password:</TextBlock>
             <TextBox PasswordChar="*" Watermark="Enter your password" />
             <TextBlock>Notes:</TextBlock>
-            <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" >We need to improve the UX of the network scanner, customers have asked for something more similar to Angry IP scanner.
-
-              There are a few other excellent tools with great UI to use for inspiration here, such as Fing and LanSweeper (we should research this as well).
-
-              Our scan actually does a lot more than Angry IP, but visually does not represent this very well, here are my thoughts on how we can improve our UI and make it even better than Angry IP:
-
-              Allow selecting the Network Interface to use to to scan, and better detect the “correct” default network interface, AngryIP has button “IP↑“ that lets you select the interface,
-
-              We could scan all network or only specific networks, this could go in hand with selecting a remote Gateway and an interface on the remote gateway to scan as well.
-              </TextBox>
+            <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
+              Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
+            </TextBox>
             <TextBox InnerLeftContent="http://" />
             <TextBox InnerRightContent=".com" />
             <TextBox


### PR DESCRIPTION
There seems to be a bug with the ScrollViewer that cuts off the right edge. Apparently it's by design and shouldn't happen when you set `AllowAutoHide=True` - but firstly it still happens then, secondly it shouldn't happen for `AllowAutoHide=False` either, and specifically for the DevExpressTheme it's exacerbated by the fact that 'hiding' the scrollbar doesn't actually increase the viewport size because the track is never hidden.

This fixes the issue for the multiline TextBox. In other scenarios you may need to apply an explicit width to force the right 'padding' you need. 