### PR TITLE
Update Avalonia packages & make themes compatible with lower version projects

### DIFF
--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -9,16 +9,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.7" />
+        <PackageReference Include="Avalonia" Version="11.2.8"/>
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.8"/>
+        <PackageReference Include="Avalonia.Desktop" Version="11.2.8"/>
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.8"/>
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.7" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.8"/>
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7" />
+        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7.1"/>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
     </ItemGroup>
@@ -33,6 +33,6 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.MacOS\Devolutions.AvaloniaTheme.MacOS.csproj"/>
         <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.DevExpress\Devolutions.AvaloniaTheme.DevExpress.csproj"/>
-        <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.Linux\Devolutions.AvaloniaTheme.Linux.csproj" />
+        <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.Linux\Devolutions.AvaloniaTheme.Linux.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.7" />
+    <PackageReference Include="Avalonia" Version="[11.2.0,)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.7" />
+        <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
+        <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)"/>
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
         <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)"/>
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.8"/>
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This breaks from my usual package bumping routine and sets the Avalonia dependencies within the themes to use minimum version notation (`Version="[11.2.0,)"`) following best practices for nugets - meaning that the theme can pull in whatever version the consuming project is using, rather than forcing up- or downgrades for compatibility. 

One exception is the Fluent theme dependency, since projects using one of our themes typically would not use Fluent as well (and we wouldn't want to inadvertently pull in untested versions). 

Thanks to @Samuel-B-D for prompting me to learn a little bit more about how the version resolution works.