### PR TITLE
Remove Dependabot (not so useful in this repo)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "nuget"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Removing Dependabot (other than default Security alerts), since it's not so helpful in this repo and just creating noise: 

- It creates individual PRs the various Avalonia packages. But since these packages are always updated together, it's much easier to do a quick sanity check when all updates are on a single branch.
- It can't handle our decision to keep the themes backward compatible by specifying a _minimum_ version