### PR TITLE
Remove dependency on specific Fluent version

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
         <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)"/>
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.8]"/>
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Since Avalonia itself is set to minimum 11.2.0 - fixing Fluent to a specific version higher than that creates package downgrade errors (which didn't become apparent straight away with #143, presumably due to various versions still being cached):

```
0>Devolutions.AvaloniaTheme.MacOS.csproj: Error NU1605 : Warning As Error: Detected package downgrade: Avalonia from 11.2.8 to 11.2.0. Reference the package directly from the project to select a different version. 
 Devolutions.AvaloniaTheme.MacOS -> Avalonia.Themes.Fluent 11.2.8 -> Avalonia (>= 11.2.8) 
 Devolutions.AvaloniaTheme.MacOS -> Avalonia (>= 11.2.0)
0>------- Finished building project: Devolutions.AvaloniaTheme.MacOS. Succeeded: False. Errors: 1. Warnings: 0
2>Devolutions.AvaloniaTheme.Linux.csproj: Error NU1605 : Warning As Error: Detected package downgrade: Avalonia from 11.2.8 to 11.2.0. Reference the package directly from the project to select a different version. 
 Devolutions.AvaloniaTheme.Linux -> Avalonia.Themes.Fluent 11.2.8 -> Avalonia (>= 11.2.8) 
 Devolutions.AvaloniaTheme.Linux -> Avalonia (>= 11.2.0)
2>------- Finished building project: Devolutions.AvaloniaTheme.Linux. Succeeded: False. Errors: 1. Warnings: 0
1>Devolutions.AvaloniaTheme.DevExpress.csproj: Error NU1605 : Warning As Error: Detected package downgrade: Avalonia from 11.2.8 to 11.2.0. Reference the package directly from the project to select a different version. 
 Devolutions.AvaloniaTheme.DevExpress -> Avalonia.Themes.Fluent 11.2.8 -> Avalonia (>= 11.2.8) 
 Devolutions.AvaloniaTheme.DevExpress -> Avalonia (>= 11.2.0)
1>------- Finished building project: Devolutions.AvaloniaTheme.DevExpress. Succeeded: False. Errors: 1. Warnings: 0
```