### PR TITLE
[All themes] Change dark mode error indicator colour & fix TextBox error border in DevExpress

### DIFF
--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -2,6 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:SampleApp.ViewModels"
+             x:DataType="vm:TextBoxViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="SampleApp.DemoPages.TextBoxDemo">
 
@@ -11,29 +13,35 @@
             BorderThickness="{DynamicResource BorderThickness}"
             CornerRadius="{DynamicResource LayoutCornerRadius}"
             Background="{DynamicResource LayoutBackgroundLowBrush}">
-      <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-        <Label>_Name:</Label>
-        <TextBox Watermark="Enter your name" />
-        <Label>Password:</Label>
-        <TextBox PasswordChar="*" Watermark="Enter your password" />
-        <Label>Notes:</Label>
-        <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
-        <TextBox InnerLeftContent="http://" />
-        <TextBox InnerRightContent=".com" />
-        <TextBox
-          InnerLeftContent="http://"
-          InnerRightContent=".com" />
-        <TextBox Classes="clearButton">With 'Clear' button</TextBox>
-        <TextBox Watermark="Disabled with Watermark" IsEnabled="False" />
-        <TextBox IsEnabled="False">Disabled Filled</TextBox>
-        <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
-        <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-        <TextBlock Classes="Label">Custom Height:</TextBlock>
-        <Grid ColumnDefinitions="*, Auto" HorizontalAlignment="Stretch">
-          <TextBox Grid.Column="0" Watermark="Type here" Height="35" VerticalContentAlignment="Center" />
-          <Button Grid.Column="1" Content="..." HorizontalContentAlignment="Center" Height="35" Width="35"
-                  Margin="5 0 0 0 " />
-        </Grid>
+      <StackPanel Margin="20" Spacing="10" HorizontalAlignment="Left" Orientation="Horizontal">
+        <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
+          <Label>_Name:</Label>
+          <TextBox Watermark="Enter your name" />
+          <Label>Password:</Label>
+          <TextBox PasswordChar="*" Watermark="Enter your password" />
+          <Label>Notes:</Label>
+          <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
+          <TextBox InnerLeftContent="http://" />
+          <TextBox InnerRightContent=".com" />
+          <TextBox
+            InnerLeftContent="http://"
+            InnerRightContent=".com" />
+          <TextBox Classes="clearButton">With 'Clear' button</TextBox>
+          <TextBox Watermark="Disabled with Watermark" IsEnabled="False" />
+          <TextBox IsEnabled="False">Disabled Filled</TextBox>
+          <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
+          <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+          <TextBlock Classes="Label">Custom Height:</TextBlock>
+          <Grid ColumnDefinitions="*, Auto" HorizontalAlignment="Stretch">
+            <TextBox Grid.Column="0" Watermark="Type here" Height="35" VerticalContentAlignment="Center" />
+            <Button Grid.Column="1" Content="..." HorizontalContentAlignment="Center" Height="35" Width="35"
+                    Margin="5 0 0 0 " />
+          </Grid>
+        </StackPanel>
+        <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
+          <Label>Error Indicator:</Label>
+          <TextBox Watermark="Required Input" Text="{Binding RequiredInput}" />
+        </StackPanel>
       </StackPanel>
     </Border>
   </ScrollViewer>

--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia.Controls;
+using SampleApp.ViewModels;
 
 namespace SampleApp.DemoPages;
 
@@ -7,5 +8,6 @@ public partial class TextBoxDemo : UserControl
   public TextBoxDemo()
   {
     InitializeComponent();
+    DataContext = new TextBoxViewModel();
   }
 }

--- a/samples/SampleApp/ViewModels/TextBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/TextBoxViewModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SampleApp.ViewModels;
+
+public partial class TextBoxViewModel : ObservableValidator
+{
+  [ObservableProperty]
+  [Required(ErrorMessage = "This Input is required.", AllowEmptyStrings = false)]
+  [NotifyDataErrorInfo]
+  private string _requiredInput = string.Empty;
+}

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -10,6 +10,7 @@
       <Color x:Key="ForegroundColor">#000000</Color>
 
       <Color x:Key="AccentForegroundColor">#ffffff</Color>
+      <Color x:Key="ErrorTextColor">#C50500</Color>
 
       <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
       <Color x:Key="ControlBackgroundMidColor">#eaeaea</Color>
@@ -38,6 +39,7 @@
       <Color x:Key="ForegroundColor">#f5f5f5</Color>
 
       <Color x:Key="AccentForegroundColor">#deecf9</Color>
+      <Color x:Key="ErrorTextColor">#ed7083</Color>
 
       <Color x:Key="ControlBackgroundHighColor">#595959</Color>
 
@@ -74,6 +76,8 @@
 
   <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.90" />
   <SolidColorBrush x:Key="ForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
+
+  <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
 
   <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.06" />
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -264,8 +264,17 @@
       </Style>
     </Style>
 
-    <Style Selector="^:error /template/ Border#PART_BorderElement">
-      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    <Style Selector="^:error">
+      <Style Selector="^ /template/ Border#PART_BorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorderElement">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+      <Style Selector="^:focus /template/ Border#BottomBorderElement">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
     </Style>
 
 

--- a/src/Devolutions.AvaloniaTheme.Linux/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Accents/ThemeResources.axaml
@@ -8,13 +8,15 @@
       <Color x:Key='ScrollControlBackgroundColor'>#fcfcfc</Color>
       <Color x:Key='Border'>#d1d1d1</Color>
 
+      <Color x:Key="ErrorTextColor">#C50500</Color>
+
       <Color x:Key='InputBackgroundColor'>#ffffff</Color>
       <Color x:Key='InputBorderColor'>#d1d1d1</Color>
       <Color x:Key='InputDisabledBackgroundColor'>#fcfcfc</Color>
       <Color x:Key='InputDisabledForegroundColor'>#e1e1e1</Color>
 
       <Color x:Key='CheckboxPressedColor'>#bdbdbd</Color>
-      
+
       <Color x:Key='ButtonBackgroundColor'>#ffffff</Color>
       <Color x:Key='ButtonBackgroundHoverColor'>#f5f5f5</Color>
       <Color x:Key='ButtonBackgroundActiveColor'>#d6d6d6</Color>
@@ -26,7 +28,7 @@
       <Color x:Key='RepeatButtonBackgroundHoverColor'>#f5f5f5</Color>
       <Color x:Key='RepeatButtonBackgroundPressedColor'>#e6e6e6</Color>
       <Color x:Key='RepeatButtonBackgroundDisabledColor'>#ffffff</Color>
-      
+
       <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#fafafa" />
       <SolidColorBrush x:Key="DataGridAlternatingRowBackgroundBrush" Color="#f2f6fb" />
     </ResourceDictionary>
@@ -34,11 +36,13 @@
     <ResourceDictionary x:Key='Dark'>
       <Color x:Key='SystemAltHighColor'>#1f1f1f</Color>
       <Color x:Key='SystemBaseMediumColor'>#f5f5f5</Color>
-      
+
       <Color x:Key='ForegroundHighColor'>#fcfcfc</Color>
       <Color x:Key='BackgroundColor'>#2c2c2c</Color>
       <Color x:Key='ScrollControlBackgroundColor'>#272727</Color>
       <Color x:Key='Border'>#181818</Color>
+
+      <Color x:Key="ErrorTextColor">#ed7083</Color>
 
       <Color x:Key='InputBackgroundColor'>#282828</Color>
       <Color x:Key='InputBorderColor'>#181818</Color>
@@ -46,11 +50,11 @@
       <Color x:Key='InputDisabledBackgroundColor'>#2c2c2c</Color>
 
       <Color x:Key='CheckboxPressedColor'>#1b1b1b</Color>
-      
+
       <Color x:Key='ButtonBackgroundColor'>#373737</Color>
       <Color x:Key='ButtonBackgroundHoverColor'>#3c3c3c</Color>
       <Color x:Key='ButtonBackgroundActiveColor'>#151515</Color>
-      
+
       <Color x:Key='RepeatButtonIconShadowColor'>#090909</Color>
       <Color x:Key='RepeatButtonBackgroundHoverColor'>#313131</Color>
       <Color x:Key='RepeatButtonBackgroundPressedColor'>#232323</Color>
@@ -58,7 +62,7 @@
 
       <Color x:Key='DataGridColumnHeaderBackgroundColor'>#1f1f1f</Color>
       <Color x:Key='DataGridColumnHeaderForegroundColor'>#f5f5f5</Color>
-      
+
       <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="#252525" />
       <SolidColorBrush x:Key="DataGridAlternatingRowBackgroundBrush" Color="#2c2c2c" />
     </ResourceDictionary>
@@ -66,7 +70,7 @@
 
   <FontFamily x:Key="DefaultFontFamily">Open Sans, sanserif</FontFamily>
   <x:Double x:Key="DefaultFontSize">14</x:Double>
-  
+
   <Thickness x:Key="TextControlThemePadding">8,6,6,5</Thickness>
   <x:Double x:Key="TextControlThemeMinHeight">34</x:Double>
 
@@ -74,6 +78,8 @@
   <SolidColorBrush x:Key='ScrollControlBorder' Color="{DynamicResource Border}" />
 
   <SolidColorBrush x:Key='ForegroundHigh' Color="{DynamicResource ForegroundHighColor}" />
+  <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
+
   <SolidColorBrush x:Key='Background' Color="{DynamicResource BackgroundColor}" />
 
   <SolidColorBrush x:Key='InputBackground' Color="{DynamicResource InputBackgroundColor}" />
@@ -84,20 +90,20 @@
   <SolidColorBrush x:Key='TextControlBorder' Color="{DynamicResource InputBorderColor}" />
   <SolidColorBrush x:Key='TextControlBackground' Color="{DynamicResource InputBackgroundColor}" />
   <SolidColorBrush x:Key='TextControlBackgroundFocused' Color="{DynamicResource InputBackgroundColor}" />
-  
+
   <StaticResource x:Key='CheckBoxBorderBrushUnchecked' ResourceKey='InputBorder' />
   <StaticResource x:Key='CheckBoxCheckBackgroundStrokeUnchecked' ResourceKey='InputBorder' />
   <StaticResource x:Key='CheckBoxCheckBackgroundStrokeUncheckedPointerOver' ResourceKey='InputBorder' />
   <SolidColorBrush x:Key='CheckBoxCheckBackgroundStrokeUncheckedPressed' Color="{DynamicResource CheckboxPressedColor}" />
   <SolidColorBrush x:Key='CheckBoxCheckBackgroundFillUncheckedPressed' Color="{DynamicResource CheckboxPressedColor}" />
-  
+
   <SolidColorBrush x:Key='ButtonBackground' Color="{DynamicResource ButtonBackgroundColor}" />
   <SolidColorBrush x:Key='ButtonBackgroundPointerOver' Color="{DynamicResource ButtonBackgroundHoverColor}" />
   <SolidColorBrush x:Key='ButtonBackgroundPressed' Color="{DynamicResource ButtonBackgroundActiveColor}" />
   <StaticResource x:Key='ButtonBackgroundDisabled' ResourceKey='InputDisabledBackground' />
   <StaticResource x:Key='ButtonForegroundDisabled' ResourceKey='InputDisabledForeground' />
   <StaticResource x:Key='ButtonBorderDisabled' ResourceKey='InputBorder' />
-  
+
   <StaticResource x:Key='ComboBoxBackground' ResourceKey='ButtonBackground' />
   <StaticResource x:Key='ComboBoxBorderBrush' ResourceKey='InputBorder' />
   <StaticResource x:Key='ComboBoxBackgroundPointerOver' ResourceKey='ButtonBackgroundPointerOver' />
@@ -107,7 +113,7 @@
   <StaticResource x:Key='ComboBoxBackgroundDisabled' ResourceKey='InputDisabledBackground' />
   <StaticResource x:Key='ComboBoxForegroundDisabled' ResourceKey='InputDisabledForeground' />
   <StaticResource x:Key='ComboBoxBorderBrushDisabled' ResourceKey='InputBorder' />
-            
+
   <SolidColorBrush x:Key='RepeatButtonIconShadow' Color="{DynamicResource RepeatButtonIconShadowColor}" />
   <SolidColorBrush x:Key='RepeatButtonBackgroundHover' Color="{DynamicResource RepeatButtonBackgroundHoverColor}" />
   <SolidColorBrush x:Key='RepeatButtonBackgroundPressed' Color="{DynamicResource RepeatButtonBackgroundPressedColor}" />
@@ -117,11 +123,11 @@
   <SolidColorBrush x:Key='TableBorder' Color="{DynamicResource InputBorderColor}" />
 
   <Thickness x:Key='TabItemMargin'>10</Thickness>
-  
+
   <Thickness x:Key='ButtonPadding'>12,6</Thickness>
   <CornerRadius x:Key="ControlCornerRadius">5</CornerRadius>
   <x:Double x:Key="InputDefaultHeight">34</x:Double>
-  
+
   <x:Double x:Key="NumericUpDownMinWidth">96</x:Double>
 
   <!-- DEVELOPMENT ONLY -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -6,6 +6,7 @@
       <Color x:Key="ForegroundColor">#000000</Color>
 
       <Color x:Key="AccentForegroundColor">#ffffff</Color>
+      <Color x:Key="ErrorTextColor">#C50500</Color>
 
       <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
 
@@ -112,6 +113,7 @@
       <Color x:Key="ForegroundColor">#ffffff</Color>
 
       <Color x:Key="AccentForegroundColor">#deecf9</Color>
+      <Color x:Key="ErrorTextColor">#ed7083</Color>
 
       <Color x:Key="ControlBackgroundHighColor">#595959</Color>
 
@@ -257,6 +259,8 @@
   <!-- <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" /> -->
   <SolidColorBrush x:Key="ForegroundMidLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.34" />
   <!-- <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.25" /> -->
+
+  <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
 
   <SolidColorBrush x:Key="SelectionInActiveWindow" Color="{DynamicResource ForegroundColor}" Opacity="0.15" />
 


### PR DESCRIPTION
- Fix the DevExpress TextBox error-border which was missing along the bottom. 
- change the dark mode error colour from bright yellow to an off-red that should still offer sufficient contrast  

<img width="339" alt="Monosnap Devolutions Theme Sampler 2025-04-30 11-08-53" src="https://github.com/user-attachments/assets/2bf613b1-08b1-4270-90e0-43a6491bcc34" />
<img width="339" alt="Monosnap Devolutions Theme Sampler 2025-04-30 11-09-02" src="https://github.com/user-attachments/assets/77ddb224-e943-4012-aef8-70c81a8e368d" />
<img width="339" alt="Monosnap Devolutions Theme Sampler 2025-04-30 11-23-45" src="https://github.com/user-attachments/assets/f66c0adc-de50-43be-86e5-131f10d0e0d3" />
<img width="339" alt="Monosnap Devolutions Theme Sampler 2025-04-30 11-23-55" src="https://github.com/user-attachments/assets/6948d5b8-9c67-4716-a201-d02b221122d8" />
