### PR TITLE
Use new Accelerate Dev Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,21 @@ Custom Avalonia Themes developed by [Devolutions](https://devolutions.net/)
 
 ➡️ [DevExpress Theme](https://github.com/Devolutions/avalonia-themes/blob/master/src/Devolutions.AvaloniaTheme.DevExpress/README.md)
 
+➡️ [Linux Theme](https://github.com/Devolutions/avalonia-themes/blob/master/src/Devolutions.AvaloniaTheme.Linux/README.md)
+
+# Sample App
+
+Contributers can use the SampleApp to test, debug and document styles for the various controls under each theme.
+
+## Debugging
+
+The SampleApp attaches the Avalonia Dev Tools for inspecting controls (open with F12).
+
+If you own a licence for the new Dev Tools in _Avalonia Accelerate_, you can set an environment variable in your IDE's debug configuration. 
+For example, in Rider: 
+
+- Open **Run > Edit Configurations**
+- Pick your configuration for the SampleApp 
+- In the **Environment Variables** field add `USE_AVALONIA_ACCELERATE_TOOLS=true`
+
+The F12 key then opens the new Dev Tools, and F10 opens the old version 

--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -20,6 +20,10 @@ public class App : Application
   {
     AvaloniaXamlLoader.Load(this);
     
+#if DEBUG
+    this.AttachDeveloperTools();
+#endif
+
     if (!Avalonia.Controls.Design.IsDesignMode)
     {
       Styles.Clear();

--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -19,10 +19,6 @@ public class App : Application
   public override void Initialize()
   {
     AvaloniaXamlLoader.Load(this);
-    
-#if DEBUG
-    this.AttachDeveloperTools();
-#endif
 
     if (!Avalonia.Controls.Design.IsDesignMode)
     {

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
+using AvaloniaUI.DiagnosticsSupport;
 
 namespace SampleApp;
 
@@ -10,9 +11,6 @@ public partial class MainWindow : Window
   public MainWindow()
   {
     InitializeComponent();
-#if DEBUG
-    this.AttachDevTools();
-#endif
   }
 
   private void Themes_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -1,8 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
 using Avalonia.Styling;
-using AvaloniaUI.DiagnosticsSupport;
 
 namespace SampleApp;
 
@@ -11,6 +11,9 @@ public partial class MainWindow : Window
   public MainWindow()
   {
     InitializeComponent();
+#if DEBUG
+    this.AttachDevTools(new KeyGesture(Key.F10));
+#endif
   }
 
   private void Themes_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -12,7 +13,20 @@ public partial class MainWindow : Window
   {
     InitializeComponent();
 #if DEBUG
-    this.AttachDevTools(new KeyGesture(Key.F10));
+    bool useAccelerate = Environment.GetEnvironmentVariable("USE_AVALONIA_ACCELERATE_TOOLS")?.ToLowerInvariant() == "true";
+    
+    if (useAccelerate)
+    {
+      // Enable Accelerate dev tools (AvaloniaUI.DiagnosticsSupport) - requiring a licence to use
+      (Application.Current as App)?.AttachDeveloperTools(); 
+      // Enable original free dev tools (Avalonia.Diagnostics) as an additional option available on F10
+      this.AttachDevTools(new KeyGesture(Key.F10));
+    }
+    else
+    {
+      // Enable original free dev tools (Avalonia.Diagnostics)
+      this.AttachDevTools(); 
+    }
 #endif
   }
 

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -8,6 +8,10 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <AvaloniaNameGeneratorAttachDevTools>false</AvaloniaNameGeneratorAttachDevTools>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.3.0" />
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
@@ -16,8 +20,16 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!--Add both, Classic and Accelerate Dev Tools -->
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.0.3" >
+            <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+            <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
-        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.0.3" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
     </ItemGroup>

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <!-- Prevent automatic attachment of regular free dev tools to avoid duplicate mapping of F12 key -->
         <AvaloniaNameGeneratorAttachDevTools>false</AvaloniaNameGeneratorAttachDevTools>
     </PropertyGroup>
 

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -13,12 +13,11 @@
         <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
         <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
         <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.0.3" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
     </ItemGroup>


### PR DESCRIPTION
Install new Accelerate Dev Tools and allow users with an appropriate licence to enable them by setting an environment variable: `USE_AVALONIA_ACCELERATE_TOOLS=true` (F12 defaults to new tools then, F10 opens the old ones). 

Everyone else continues to have access to the original free dev tools.