### PR TITLE
[WIP] Update SampleApp to Avalonia 11.3

### DIFF
--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -9,16 +9,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.2.8"/>
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.8"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.2.8"/>
-        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.8"/>
+        <PackageReference Include="Avalonia" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+        <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.8"/>
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7"/>
+        <PackageReference Include="Avalonia.Svg.Skia" Version="11.3.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
     </ItemGroup>


### PR DESCRIPTION
Updating the Sample app only, allowing the themes to work with older versions as well. 

Note that the app now generates compiler warnings because Avalonia.Svg.Skia and SkiaSharp still need to be set to require older versions under Linux (see [comment in the code](https://github.com/Devolutions/avalonia-extensions/blob/aa9cbb36f8ac9d739a62bad349afaa76f30f9f56/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj#L19-L27)

```
2>SampleApp.csproj: Warning NU1608 : Detected package version outside of dependency constraint: Devolutions.AvaloniaTheme.Linux requires Avalonia.Svg.Skia (>= 11.2.0 && < 11.2.7.1) but version Avalonia.Svg.Skia 11.3.0 was resolved.
2>SampleApp.csproj: Warning NU1608 : Detected package version outside of dependency constraint: Devolutions.AvaloniaTheme.Linux requires SkiaSharp (>= 2.88.9 && < 3.116.0) but version SkiaSharp 3.116.1 was resolved.
``` 


