### PR TITLE
Mac os/control spacing

### DIFF
--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -12,37 +12,74 @@
       <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
   </UserControl.Styles>
-  
-  <StackPanel Orientation="Vertical" Margin="10" Spacing="20" VerticalAlignment="Top">
-    <StackPanel Orientation="Horizontal" Margin="10" Spacing="10" VerticalAlignment="Top">
-      <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-      <Border><TextBox Watermark="TextBox" /></Border>
-      <Border><ComboBox SelectedIndex="2">
-        <ComboBoxItem>Option 1</ComboBoxItem>
-        <ComboBoxItem>Option 2</ComboBoxItem>
-        <ComboBoxItem>Option 3</ComboBoxItem>
-        <ComboBoxItem>Option 4</ComboBoxItem>
-      </ComboBox></Border>
-      <Border><NumericUpDown Value="0"
-                     Increment="1"
-                     Watermark="mm" /></Border>
-      <Border><Button Content="Button" /></Border>
-      <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
-    </StackPanel>
-    <StackPanel Orientation="Vertical" Width="90" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
-      <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-      <Border><TextBox Watermark="TextBox" /></Border>
-      <Border><ComboBox SelectedIndex="2">
-        <ComboBoxItem>Option 1</ComboBoxItem>
-        <ComboBoxItem>Option 2</ComboBoxItem>
-        <ComboBoxItem>Option 3</ComboBoxItem>
-        <ComboBoxItem>Option 4</ComboBoxItem>
-      </ComboBox></Border>
-      <Border><NumericUpDown Value="0"
-                             Increment="1"
-                             Watermark="mm" /></Border>
-      <Border><Button Content="Button" /></Border>
-      <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+  <StackPanel Margin="10">
+    <TextBlock Classes="h1" Text="Grid" />
+    <Grid RowDefinitions="*, *, *, *, *, *, *, *" 
+          ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" 
+          RowSpacing="5"
+          ColumnSpacing="10"
+          Margin="10" >
+        <Border Grid.Row="0" Grid.Column="0"><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
+        <Border Grid.Row="0" Grid.Column="1"><TextBox Watermark="TextBox" /></Border>
+        <Border Grid.Row="0" Grid.Column="2"><ComboBox SelectedIndex="2">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+        </ComboBox></Border>
+        <Border Grid.Row="0" Grid.Column="3"><NumericUpDown Value="0"
+                                                           Increment="1"
+                                                           Watermark="mm" /></Border>
+        <Border Grid.Row="0" Grid.Column="4"><Button Content="Button" /></Border>
+        <Border Grid.Row="0" Grid.Column="5"><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+
+      <Border Grid.Row="2" Grid.Column="0"><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
+        <Border Grid.Row="3" Grid.Column="0"><TextBox Watermark="TextBox" /></Border>
+        <Border Grid.Row="4" Grid.Column="0"><ComboBox SelectedIndex="2">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+        </ComboBox></Border>
+        <Border Grid.Row="5" Grid.Column="0"><NumericUpDown Value="0"
+                                                           Increment="1"
+                                                           Watermark="mm" /></Border>
+        <Border Grid.Row="6" Grid.Column="0"><Button Content="Button" /></Border>
+        <Border Grid.Row="7" Grid.Column=""><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+    </Grid>
+    
+    <TextBlock Classes="h1" Text="StackPanels" Margin="0 20 0 0 "/>
+    <StackPanel Orientation="Vertical" Margin="10" Spacing="20" VerticalAlignment="Top">
+      <StackPanel Orientation="Horizontal" Margin="10" Spacing="10" VerticalAlignment="Top">
+        <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
+        <Border><TextBox Watermark="TextBox" /></Border>
+        <Border><ComboBox SelectedIndex="2">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+        </ComboBox></Border>
+        <Border><NumericUpDown Value="0"
+                               Increment="1"
+                               Watermark="mm" /></Border>
+        <Border><Button Content="Button" /></Border>
+        <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+      </StackPanel>
+      <StackPanel Orientation="Vertical" Width="90" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
+        <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
+        <Border><TextBox Watermark="TextBox" /></Border>
+        <Border><ComboBox SelectedIndex="2">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+        </ComboBox></Border>
+        <Border><NumericUpDown Value="0"
+                               Increment="1"
+                               Watermark="mm" /></Border>
+        <Border><Button Content="Button" /></Border>
+        <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+      </StackPanel>
     </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml
@@ -6,7 +6,7 @@
              x:Class="SampleApp.DemoPages.TabControlDemo">
   <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
     <Border Width="500">
-      <TabControl TabStripPlacement="Left" Margin="5">
+      <TabControl TabStripPlacement="Left" >
         <TabItem Header="Tab 1">
           <TextBlock Text="Vertical tab view" />
         </TabItem>
@@ -17,7 +17,7 @@
       </TabControl>
     </Border>
     <Border Width="500">
-      <TabControl TabStripPlacement="Top" Margin="5">
+      <TabControl TabStripPlacement="Top" >
         <TabItem Header="General">
           <TextBlock Text="Horizontal tab view" />
         </TabItem>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -248,6 +248,9 @@
   <CornerRadius x:Key="SelectionCornerRadius">4</CornerRadius>
 
   <Thickness x:Key="BorderThickness">1</Thickness>
+  
+  <Thickness x:Key="InputControlsSpaceForFocusBorder">1.5</Thickness>
+  <Thickness x:Key="TabControlSpaceForFocusFactors">3</Thickness>
 
   <x:Double x:Key="DefaultFontSize">13</x:Double>
   <x:Double x:Key="ControlFontSize">13</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -31,7 +31,8 @@
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel>
+        <Panel Name="ReservedSpaceForFocus" 
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
           <Border Name="BackgroundElement"
                   Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -45,72 +45,74 @@
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Grid ColumnDefinitions="Auto,*" MinHeight="20"
-              ClipToBounds="False">
-          <Border Name="FocusBorderElement"
-                  VerticalAlignment="Center"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  CornerRadius="5" >
-            <Border Name="border"
-                            Width="14"
-                            Height="14"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            BoxShadow="{DynamicResource ControlBackgroundRecessedShadow}">
-              <Panel>
-                <Path Name="CheckMark"
-                      Width="9"
-                      Height="9"
-                      HorizontalAlignment="Center"
-                      VerticalAlignment="Center"
-                      Data="{DynamicResource CheckMarkPath}"
-                      FlowDirection="LeftToRight"
-                      Stretch="Fill">
-                  <Path.Fill>
-                    <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                      <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
-                               Converter="{x:Static BoolConverters.Not}" />
-                      <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
-                      <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
-                    </MultiBinding>
-                  </Path.Fill>
-                </Path>
-                <Rectangle Name="indeterminateMark"
-                           Width="8"
-                           Height="2"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-
-                           Stretch="Uniform">
-                  <Rectangle.Fill>
-                    <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
-                      <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
-                               Converter="{x:Static BoolConverters.Not}" />
-                      <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
-                      <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
-                    </MultiBinding>
-                  </Rectangle.Fill>
-                </Rectangle>
-              </Panel>
+        <Panel Name="ReservedSpaceForFocus" 
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <Grid ColumnDefinitions="Auto,*" MinHeight="20"
+                ClipToBounds="False">
+            <Border Name="FocusBorderElement"
+                    VerticalAlignment="Center"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    CornerRadius="5" >
+              <Border Name="border"
+                              Width="14"
+                              Height="14"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Background="{TemplateBinding Background}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}"
+                              CornerRadius="{TemplateBinding CornerRadius}"
+                              BoxShadow="{DynamicResource ControlBackgroundRecessedShadow}">
+                <Panel>
+                  <Path Name="CheckMark"
+                        Width="9"
+                        Height="9"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{DynamicResource CheckMarkPath}"
+                        FlowDirection="LeftToRight"
+                        Stretch="Fill">
+                    <Path.Fill>
+                      <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                                 Converter="{x:Static BoolConverters.Not}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                      </MultiBinding>
+                    </Path.Fill>
+                  </Path>
+                  <Rectangle Name="indeterminateMark"
+                             Width="8"
+                             Height="2"
+                             HorizontalAlignment="Center"
+                             VerticalAlignment="Center"
+                             Stretch="Uniform">
+                    <Rectangle.Fill>
+                      <MultiBinding Converter="{StaticResource BooleanToChoiceConverter}">
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" Path="IsActive"
+                                 Converter="{x:Static BoolConverters.Not}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentInactiveHighBrush}" />
+                        <Binding Source="{StaticResource ControlForegroundAccentHighBrush}" />
+                      </MultiBinding>
+                    </Rectangle.Fill>
+                  </Rectangle>
+                </Panel>
+              </Border>
             </Border>
-          </Border>
-          <ContentPresenter Name="PART_ContentPresenter"
-                            Grid.Column="1"
-                            Margin="{TemplateBinding Padding}"
-                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Content="{TemplateBinding Content}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            IsVisible="{TemplateBinding Content,
-                                                        Converter={x:Static ObjectConverters.IsNotNull}}"
-                            RecognizesAccessKey="True"
-                            TextWrapping="Wrap"
-                            TextElement.Foreground="{TemplateBinding Foreground}" />
-        </Grid>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Grid.Column="1"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              IsVisible="{TemplateBinding Content,
+                                                          Converter={x:Static ObjectConverters.IsNotNull}}"
+                              RecognizesAccessKey="True"
+                              TextWrapping="Wrap"
+                              TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Grid>
+        </Panel>
       </ControlTemplate>
     </Setter>
     

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -18,7 +18,7 @@
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
         </ComboBox>
-        <ComboBox MaxDropDownHeight="100" PlaceholderText="Chose one">
+        <ComboBox MaxDropDownHeight="100" PlaceholderText="Choose one">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
@@ -89,7 +89,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="VerticalAlignment" Value="Center" />
-    <Setter Property="Padding" Value="8 1 10 2" />
+    <Setter Property="Padding" Value="8 1 6 2" />
     <Setter Property="MinHeight" Value="20" />
     <Setter Property="PlaceholderForeground" Value="{DynamicResource ThemeForegroundBrush}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
@@ -110,9 +110,9 @@
               <TextBlock Name="PlaceholderTextBlock"
                          Grid.Column="0"
                          Margin="{TemplateBinding Padding}"
+                         Foreground="{TemplateBinding Foreground}"
                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                         Foreground="{TemplateBinding Foreground}"
                          IsVisible="{TemplateBinding SelectionBoxItem,
                                                    Converter={x:Static ObjectConverters.IsNull}}"
                          Text="{TemplateBinding PlaceholderText}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -98,7 +98,8 @@
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Panel ClipToBounds="False">
+        <Panel Name="ReservedSpaceForFocus" 
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
           <Border Name="border"
                   Background="{TemplateBinding Background}"
                   BorderThickness="{DynamicResource ButtonBorderThickness}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/NumericUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/NumericUpDown.axaml
@@ -61,39 +61,40 @@
 
   <ControlTheme x:Key="{x:Type NumericUpDown}" TargetType="NumericUpDown">
     <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Template">
       <ControlTemplate>
-        <DataValidationErrors ClipToBounds="False">
-          <ButtonSpinner Name="PART_Spinner"
-                         ClipToBounds="False"
-                         Background="{TemplateBinding Background}"
-                         BorderThickness="{TemplateBinding BorderThickness}"
-                         BorderBrush="{TemplateBinding BorderBrush}"
-                         CornerRadius="{TemplateBinding CornerRadius}"
-                         IsTabStop="False"
-                         Padding="0"
-                         MinWidth="0"
-                         HorizontalContentAlignment="Stretch"
-                         VerticalContentAlignment="Stretch"
-                         AllowSpin="{TemplateBinding AllowSpin}"
-                         ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
-                         ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
-            <TextBox Name="PART_TextBox"
-                     ClipToBounds="False"
-                     Watermark="{TemplateBinding Watermark}"
-                     IsReadOnly="{TemplateBinding IsReadOnly}"
-                     IsEnabled="{TemplateBinding IsEnabled}"
-                     VerticalAlignment="Center"
-                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                     Text="{TemplateBinding Text}"
-                     TextAlignment="{TemplateBinding TextAlignment}"
-                     AcceptsReturn="False"
-                     TextWrapping="NoWrap"
-                     InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
-                     InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
-          </ButtonSpinner>
-        </DataValidationErrors>
+          <DataValidationErrors ClipToBounds="False">
+            <ButtonSpinner Name="PART_Spinner"
+                           ClipToBounds="False"
+                           Background="{TemplateBinding Background}"
+                           BorderThickness="{TemplateBinding BorderThickness}"
+                           BorderBrush="{TemplateBinding BorderBrush}"
+                           CornerRadius="{TemplateBinding CornerRadius}"
+                           IsTabStop="False"
+                           Padding="0"
+                           MinWidth="0"
+                           HorizontalContentAlignment="Stretch"
+                           VerticalContentAlignment="Stretch"
+                           AllowSpin="{TemplateBinding AllowSpin}"
+                           ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
+                           ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
+              <TextBox Name="PART_TextBox"
+                       ClipToBounds="False"
+                       Watermark="{TemplateBinding Watermark}"
+                       IsReadOnly="{TemplateBinding IsReadOnly}"
+                       IsEnabled="{TemplateBinding IsEnabled}"
+                       VerticalAlignment="Center"
+                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                       Text="{TemplateBinding Text}"
+                       TextAlignment="{TemplateBinding TextAlignment}"
+                       AcceptsReturn="False"
+                       TextWrapping="NoWrap"
+                       InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
+                       InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
+            </ButtonSpinner>
+          </DataValidationErrors>
       </ControlTemplate>
     </Setter>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -62,6 +62,11 @@
                       ClipToBounds="False"
                       UseLayoutRounding="False"
                       DockPanel.Dock="{TemplateBinding TabStripPlacement}">
+                <Border.Margin>
+                  <Binding Source="{StaticResource InputControlsSpaceForFocusBorder}"
+                           Converter="{StaticResource ThicknessToSelectiveThicknessConverter}"
+                           ConverterParameter="{StaticResource TabControlSpaceForFocusFactors}" />
+                </Border.Margin>
                 <ItemsPresenter Name="PART_ItemsPresenter"
                                 ClipToBounds="False"
                                 ItemsPanel="{TemplateBinding ItemsPanel}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -126,115 +126,116 @@
     <Setter Property="ScrollViewer.AllowAutoHide" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <DataValidationErrors ClipToBounds="False">
-          <Border ClipToBounds="False">
-            <Panel ClipToBounds="False">
-              <Border Name="PART_BorderElement"
-                      Height="{TemplateBinding Height}"
-                      BorderThickness="{TemplateBinding BorderThickness}"
-                      BorderBrush="{TemplateBinding BorderBrush}"
-                      Background="{TemplateBinding Background}"
-                      CornerRadius="{TemplateBinding CornerRadius}"
-                      Padding="2 0 2 0 ">
-                <Grid ColumnDefinitions="Auto,*,Auto">
-                  <ContentPresenter Name="PrefixContent"
-                                    Grid.Column="0"
-                                    Content="{TemplateBinding InnerLeftContent}"
-                                    Padding="3 2 3 1"
-                                    VerticalAlignment="Center">
-                    <ContentPresenter.IsVisible>
-                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                    </ContentPresenter.IsVisible>
-                  </ContentPresenter>
-                  <DockPanel Name="PART_InnerDockPanel"
-                             Grid.Column="1"
-                             Margin="2 2 3 1 ">
-                    <ScrollViewer Name="PART_ScrollViewer"
-                                  Margin="0 0 -4 0"
-                                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                                  BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                      <Panel>
-                        <TextBlock Name="PART_Watermark"
-                                   Foreground="{DynamicResource ForegroundLowBrush}"
-                                   FontSize="{DynamicResource ControlFontSize}"
-                                   Text="{TemplateBinding Watermark}"
-                                   TextAlignment="{TemplateBinding TextAlignment}"
-                                   TextWrapping="{TemplateBinding TextWrapping}"
-                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                   VerticalAlignment="Center">
-                          <TextBlock.IsVisible>
-                            <MultiBinding Converter="{x:Static BoolConverters.And}">
-                              <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                              <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                            </MultiBinding>
-                          </TextBlock.IsVisible>
-                        </TextBlock>
-                        <TextPresenter Name="PART_TextPresenter"
-                                       Text="{TemplateBinding Text, Mode=TwoWay}"
-                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                       CaretIndex="{TemplateBinding CaretIndex}"
-                                       SelectionStart="{TemplateBinding SelectionStart}"
-                                       SelectionEnd="{TemplateBinding SelectionEnd}"
-                                       TextAlignment="{TemplateBinding TextAlignment}"
-                                       TextWrapping="{TemplateBinding TextWrapping}"
-                                       LineHeight="{TemplateBinding LineHeight}"
-                                       LetterSpacing="{TemplateBinding LetterSpacing}"
-                                       RevealPassword="{TemplateBinding RevealPassword}"
-                                       SelectionBrush="{TemplateBinding SelectionBrush}"
-                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                       CaretBrush="{TemplateBinding CaretBrush}"
-                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalAlignment="Center">
-                          <TextPresenter.PasswordChar>
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
-                                     Converter="{StaticResource CharToMacOsPasswordCharConverter}" />
-                          </TextPresenter.PasswordChar>
-                        </TextPresenter>
-                      </Panel>
-                      <ScrollViewer.Styles>
-                        <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                          <Setter Property="Cursor" Value="IBeam" />
-                        </Style>
-                      </ScrollViewer.Styles>
-                    </ScrollViewer>
-                  </DockPanel>
-                  <ContentPresenter Name="SuffixContent"
-                                    Grid.Column="2"
-                                    Padding="3 2 3 1"
-                                    Content="{TemplateBinding InnerRightContent}"
-                                    VerticalAlignment="Center">
-                    <ContentPresenter.IsVisible>
-                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                    </ContentPresenter.IsVisible>
-                  </ContentPresenter>
-                </Grid>
-              </Border>
-              <Border Name="BottomBorder"
-                      BorderThickness="0 0 0 0.6"
-                      BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
-                      BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                      CornerRadius="{TemplateBinding CornerRadius}"
-                      Margin="0.6 0  " />
-              <Border Name="BottomBorderShadow"
-                      BorderThickness="0 0 0 0.6"
-                      BorderBrush="{TemplateBinding BorderBrush}"
-                      CornerRadius="{TemplateBinding CornerRadius}"
-                      BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                      Margin="0.6 0 0.6 -0.6 " />
-              <Border Name="FocusBorderElement"
-                      Margin="{StaticResource FocusBorderMargin}"
-                      BorderThickness="{StaticResource FocusBorderThickness}"
-                      CornerRadius="2" />
-            </Panel>
-          </Border>
-        </DataValidationErrors>
+        <Panel Name="ReservedSpaceForFocus" 
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <DataValidationErrors ClipToBounds="False">
+              <Panel ClipToBounds="False">
+                <Border Name="PART_BorderElement"
+                        Height="{TemplateBinding Height}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Padding="2 0 2 0 ">
+                  <Grid ColumnDefinitions="Auto,*,Auto">
+                    <ContentPresenter Name="PrefixContent"
+                                      Grid.Column="0"
+                                      Content="{TemplateBinding InnerLeftContent}"
+                                      Padding="3 2 3 1"
+                                      VerticalAlignment="Center">
+                      <ContentPresenter.IsVisible>
+                        <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                                 Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                      </ContentPresenter.IsVisible>
+                    </ContentPresenter>
+                    <DockPanel Name="PART_InnerDockPanel"
+                               Grid.Column="1"
+                               Margin="2 2 3 1 ">
+                      <ScrollViewer Name="PART_ScrollViewer"
+                                    Margin="0 0 -4 0"
+                                    HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                    VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                    IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                                    AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                                    BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                        <Panel>
+                          <TextBlock Name="PART_Watermark"
+                                     Foreground="{DynamicResource ForegroundLowBrush}"
+                                     FontSize="{DynamicResource ControlFontSize}"
+                                     Text="{TemplateBinding Watermark}"
+                                     TextAlignment="{TemplateBinding TextAlignment}"
+                                     TextWrapping="{TemplateBinding TextWrapping}"
+                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                     VerticalAlignment="Center">
+                            <TextBlock.IsVisible>
+                              <MultiBinding Converter="{x:Static BoolConverters.And}">
+                                <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                                         Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                                         Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                              </MultiBinding>
+                            </TextBlock.IsVisible>
+                          </TextBlock>
+                          <TextPresenter Name="PART_TextPresenter"
+                                         Text="{TemplateBinding Text, Mode=TwoWay}"
+                                         CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                         CaretIndex="{TemplateBinding CaretIndex}"
+                                         SelectionStart="{TemplateBinding SelectionStart}"
+                                         SelectionEnd="{TemplateBinding SelectionEnd}"
+                                         TextAlignment="{TemplateBinding TextAlignment}"
+                                         TextWrapping="{TemplateBinding TextWrapping}"
+                                         LineHeight="{TemplateBinding LineHeight}"
+                                         LetterSpacing="{TemplateBinding LetterSpacing}"
+                                         RevealPassword="{TemplateBinding RevealPassword}"
+                                         SelectionBrush="{TemplateBinding SelectionBrush}"
+                                         SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                         CaretBrush="{TemplateBinding CaretBrush}"
+                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                         VerticalAlignment="Center">
+                            <TextPresenter.PasswordChar>
+                              <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
+                                       Converter="{StaticResource CharToMacOsPasswordCharConverter}" />
+                            </TextPresenter.PasswordChar>
+                          </TextPresenter>
+                        </Panel>
+                        <ScrollViewer.Styles>
+                          <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                            <Setter Property="Cursor" Value="IBeam" />
+                          </Style>
+                        </ScrollViewer.Styles>
+                      </ScrollViewer>
+                    </DockPanel>
+                    <ContentPresenter Name="SuffixContent"
+                                      Grid.Column="2"
+                                      Padding="3 2 3 1"
+                                      Content="{TemplateBinding InnerRightContent}"
+                                      VerticalAlignment="Center">
+                      <ContentPresenter.IsVisible>
+                        <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                                 Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                      </ContentPresenter.IsVisible>
+                    </ContentPresenter>
+                  </Grid>
+                </Border>
+                <Border Name="BottomBorder"
+                        BorderThickness="0 0 0 0.6"
+                        BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
+                        BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Margin="0.6 0  " />
+                <Border Name="BottomBorderShadow"
+                        BorderThickness="0 0 0 0.6"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                        Margin="0.6 0 0.6 -0.6 " />
+                <Border Name="FocusBorderElement"
+                        Margin="{StaticResource FocusBorderMargin}"
+                        BorderThickness="{StaticResource FocusBorderThickness}"
+                        CornerRadius="2" />
+              </Panel>
+          </DataValidationErrors>
+        </Panel>
       </ControlTemplate>
     </Setter>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Converters/ThicknessToSelectiveThicknessConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Converters/ThicknessToSelectiveThicknessConverter.cs
@@ -8,9 +8,10 @@ public class ThicknessToSelectiveThicknessConverter : IValueConverter
 {
   public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
   {
+    Console.WriteLine($"thickness: {value}, parameter {parameter}");
     if (value is not Thickness thickness || parameter is not Thickness thicknessFactors)
       return AvaloniaProperty.UnsetValue;
-
+    Console.WriteLine($"thickness.Top {thickness.Top}, thicknessFactors.Top {thicknessFactors.Top}");
     return new Thickness(
       thickness.Left * thicknessFactors.Left,
       thickness.Top * thicknessFactors.Top,


### PR DESCRIPTION
Re-adds a margin around all input controls to accommodate the focus outline. 

This allows us to add controls to a grid (which now supports row-/column-spacing) without any additional properties to be set. (Otherwise the grid itself or potentially other parent containers would always have set `clipToBounds=False` - which is easy to forget, especially for controls that don't show their focus highlight except for keyboard tabbing)