### PR TITLE
Prevent DevTools exception during theme switching

### DIFF
--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -14,6 +14,7 @@ public class App : Application
   private Styles? linuxYaruStyles;
   private Styles? devExpressStyles;
   private Styles? macOsStyles;
+  private bool devToolsAttached = false;
   public static Theme? CurrentTheme { get; set; }
   
   public override void Initialize()
@@ -95,6 +96,14 @@ public class App : Application
     if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) desktop.MainWindow = new MainWindow() { DataContext = new MainWindowViewModel() };
 
     base.OnFrameworkInitializationCompleted();
+  }
+
+  public void AttacheDevToolsOnce()
+  {
+    if (devToolsAttached) return;
+    
+    this.AttachDeveloperTools();
+    devToolsAttached = true;
   }
 }
 

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -18,7 +18,7 @@ public partial class MainWindow : Window
     if (useAccelerate)
     {
       // Enable Accelerate dev tools (AvaloniaUI.DiagnosticsSupport) - requiring a licence to use
-      (Application.Current as App)?.AttachDeveloperTools(); 
+      (Application.Current as App)?.AttacheDevToolsOnce(); 
       // Enable original free dev tools (Avalonia.Diagnostics) as an additional option available on F10
       this.AttachDevTools(new KeyGesture(Key.F10));
     }


### PR DESCRIPTION
When our runtime theme-switching reopens the MainWindow, the code for attaching dev tools is run again - causing Avalonia to throw an exception because the Accelerate dev tools are already attached to the App. Since there seems no way to check, I just added a boolean flag to keep track and prevent multiple calls to `AttachDeveloperTools`