### PR TITLE
[AvaloniaControls] Add new Controls project to publish script

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -13,9 +13,10 @@ on:
         required: true
         options:
           - all
-          - MacOS
-          - DevExpress
-          - Linux
+          - AvaloniaTheme.MacOS
+          - AvaloniaTheme.DevExpress
+          - AvaloniaTheme.Linux
+          - AvaloniaControls
       skip-publish:
         description: 'Skip publishing'
         required: true
@@ -72,7 +73,7 @@ jobs:
 
           $TargetPackage = '${{ inputs.target-package }}'
           if ([string]::IsNullOrEmpty($TargetPackage) -or $TargetPackage -eq 'all') {
-            $PackageList = "MacOS,DevExpress,Linux"
+            $PackageList = "AvaloniaTheme.MacOS,AvaloniaTheme.DevExpress,AvaloniaTheme.Linux,AvaloniaControls"
           } else {
             $PackageList = $TargetPackage
           }
@@ -116,7 +117,7 @@ jobs:
         run: |
           $PackageVersion = '${{ needs.preflight.outputs.package-version }}'
           $PackageList = '${{ needs.preflight.outputs.package-list }}'
-          $ProjectDirs = @($PackageList -Split ',' | ForEach-Object { ".\src\Devolutions.AvaloniaTheme.$_" })
+          $ProjectDirs = @($PackageList -Split ',' | ForEach-Object { ".\src\Devolutions.$_" })
           foreach ($ProjectDir in $ProjectDirs) {
             $csprojPath = (Get-Item "$ProjectDir\*.csproj" | Select-Object -First 1).FullName
             $csprojContent = Get-Content $csprojPath -Raw
@@ -128,7 +129,7 @@ jobs:
         shell: pwsh
         run: |
           $PackageList = '${{ needs.preflight.outputs.package-list }}'
-          $ProjectDirs = @($PackageList -Split ',' | ForEach-Object { ".\src\Devolutions.AvaloniaTheme.$_" })
+          $ProjectDirs = @($PackageList -Split ',' | ForEach-Object { ".\src\Devolutions.$_" })
           foreach ($ProjectDir in $ProjectDirs) {
             & dotnet pack $ProjectDir -o package
           }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -15,8 +15,7 @@
       <PackageReference Include="Avalonia" Version="[11.2.0,)" />
       <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
       <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
-
-      <PackageReference Include="Devolutions.AvaloniaControls" Version="*" />
+      <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
    </ItemGroup>
 
    <ItemGroup>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
    </ItemGroup>
 
-   <ItemGroup>
+   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
       <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
    </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -26,7 +26,7 @@
       <PackageReference Include="SkiaSharp" Version="[2.88.9,3.116.0)" />
        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
    </ItemGroup>
-   <ItemGroup>
+   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
       <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
    </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -24,7 +24,7 @@
             -->
       <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,11.2.7.1)" />
       <PackageReference Include="SkiaSharp" Version="[2.88.9,3.116.0)" />
-      <PackageReference Include="Devolutions.AvaloniaControls" Version="*" />
+       <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
    </ItemGroup>
    <ItemGroup>
       <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -15,7 +15,7 @@
       <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
       <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)" />
       <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
-      <PackageReference Include="Devolutions.AvaloniaControls" Version="*" />
+      <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
    </ItemGroup>
    <ItemGroup>
       <AvaloniaResource Include="Accents/Assets/**" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -20,7 +20,7 @@
    <ItemGroup>
       <AvaloniaResource Include="Accents/Assets/**" />
    </ItemGroup>
-   <ItemGroup>
+   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
       <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
    </ItemGroup>
 </Project>


### PR DESCRIPTION
- Pins each theme's dependency on the Controls to a minimum version. However these will need to be updated as controls and platform specific styles are added, to make sure the Theme has access to all controls it is supposed to style.
- Adds the AvaloniaControls project to each theme during development as a convenience when making changes in the controls 
- Adds AvaloniaControls to the options in the built script