### PR TITLE
Apply new code formatting & syntax rules everywhere

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.xml]
+indent_style = space
+indent_size = 2

--- a/avalonia-extensions.sln.DotSettings
+++ b/avalonia-extensions.sln.DotSettings
@@ -59,8 +59,8 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_EXPR_METHOD_ON_SINGLE_LINE/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">145</s:Int64>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/INDENT_SIZE/@EntryValue">3</s:Int64>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/TAB_WIDTH/@EntryValue">3</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/INDENT_SIZE/@EntryValue">2</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/TAB_WIDTH/@EntryValue">2</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/WRAP_LIMIT/@EntryValue">182</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String>

--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -1,27 +1,28 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="SampleApp.App">
-    <Application.Resources>
-        <Styles x:Key="LinuxYaruStyles">
-            <StyleInclude Source="avares://Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml" />
-            <StyleInclude Source="/Styles.axaml" />
-        </Styles>
-        <Styles x:Key="DevExpressStyles">
-            <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml" />
-            <StyleInclude Source="/Styles.axaml" />
-        </Styles>
-        <Styles x:Key="MacOsStyles">
-            <StyleInclude Source="avares://Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml" />
-            <StyleInclude Source="/Styles.axaml" />
-        </Styles>
-    </Application.Resources>
-    
-    <!-- KEPT FOR DESIGNER! -->
-    <Application.Styles>
-        <!-- <FluentTheme /> -->
-        <StyleInclude Source="avares://Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml" />
-        <!-- <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml" /> -->
-        <!-- <StyleInclude Source="avares://Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml" /> -->
-        <StyleInclude Source="/Styles.axaml" />
-    </Application.Styles>
+
+  <Application.Resources>
+    <Styles x:Key="LinuxYaruStyles">
+      <StyleInclude Source="avares://Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml" />
+      <StyleInclude Source="/Styles.axaml" />
+    </Styles>
+    <Styles x:Key="DevExpressStyles">
+      <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml" />
+      <StyleInclude Source="/Styles.axaml" />
+    </Styles>
+    <Styles x:Key="MacOsStyles">
+      <StyleInclude Source="avares://Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml" />
+      <StyleInclude Source="/Styles.axaml" />
+    </Styles>
+  </Application.Resources>
+
+  <!-- KEPT FOR DESIGNER! -->
+  <Application.Styles>
+    <!-- <FluentTheme /> -->
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml" />
+    <!-- <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml" /> -->
+    <!-- <StyleInclude Source="avares://Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml" /> -->
+    <StyleInclude Source="/Styles.axaml" />
+  </Application.Styles>
 </Application>

--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -1,109 +1,101 @@
+namespace SampleApp;
+
 using System;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Avalonia.Svg.Skia;
-using SampleApp.ViewModels;
-
-namespace SampleApp;
+using ViewModels;
 
 public class App : Application
 {
   private readonly Styles themeStylesContainer = new();
-  private Styles? linuxYaruStyles;
   private Styles? devExpressStyles;
+  private Styles? linuxYaruStyles;
   private Styles? macOsStyles;
-  private bool devToolsAttached = false;
+  private bool devToolsAttached;
   public static Theme? CurrentTheme { get; set; }
-  
+
   public override void Initialize()
   {
     AvaloniaXamlLoader.Load(this);
 
-    if (!Avalonia.Controls.Design.IsDesignMode)
+    if (!Design.IsDesignMode)
     {
-      Styles.Clear();
-      Styles.Add(themeStylesContainer);
+      this.Styles.Clear();
+      this.Styles.Add(this.themeStylesContainer);
     }
-    
+
     this.linuxYaruStyles = this.Resources["LinuxYaruStyles"] as Styles;
     this.devExpressStyles = this.Resources["DevExpressStyles"] as Styles;
     this.macOsStyles = this.Resources["MacOsStyles"] as Styles;
 
-    GC.KeepAlive(typeof(Avalonia.Svg.Skia.Svg).Assembly);
+    GC.KeepAlive(typeof(Svg).Assembly);
     GC.KeepAlive(typeof(SvgImageExtension).Assembly);
 
-    if (!Avalonia.Controls.Design.IsDesignMode)
+    if (!Design.IsDesignMode)
     {
       Theme theme;
       if (OperatingSystem.IsWindows())
-      {
         theme = new DevExpressTheme();
-      }
       else if (OperatingSystem.IsMacOS())
-      {
         theme = new MacOsTheme();
-      }
       else if (OperatingSystem.IsLinux())
-      {
         theme = new LinuxYaruTheme();
-      }
       else
-      {
         theme = new MacOsTheme();
-      }
-    
+
       SetTheme(theme);
     }
   }
 
   public static void SetTheme(Theme theme)
   {
-    var app = (App)Current!;
-    var previousTheme = CurrentTheme;
+    App app = (App)Current!;
+    Theme? previousTheme = CurrentTheme;
     CurrentTheme = theme;
 
-    var reopenWindow = previousTheme != null && previousTheme.Name != theme.Name;
-    
-    var styles = theme switch
+    bool reopenWindow = previousTheme != null && previousTheme.Name != theme.Name;
+
+    Styles? styles = theme switch
     {
       LinuxYaruTheme => app.linuxYaruStyles,
       DevExpressTheme => app.devExpressStyles,
       MacOsTheme => app.macOsStyles,
-      _ => null,
+      _ => null
     };
 
     app.themeStylesContainer.Clear();
     app.themeStylesContainer.AddRange(styles!);
 
     if (reopenWindow)
-    {
       if (app.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
       {
-        var oldWindow = desktopLifetime.MainWindow;
-        var dataContext = oldWindow?.DataContext;
-        var newWindow = new MainWindow() { DataContext = dataContext };
+        Window? oldWindow = desktopLifetime.MainWindow;
+        object? dataContext = oldWindow?.DataContext;
+        MainWindow newWindow = new() { DataContext = dataContext };
         desktopLifetime.MainWindow = newWindow;
         newWindow.Show();
         oldWindow?.Close();
       }
-    }
   }
 
   public override void OnFrameworkInitializationCompleted()
   {
-    if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) desktop.MainWindow = new MainWindow() { DataContext = new MainWindowViewModel() };
+    if (this.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+      desktop.MainWindow = new MainWindow { DataContext = new MainWindowViewModel() };
 
     base.OnFrameworkInitializationCompleted();
   }
 
   public void AttacheDevToolsOnce()
   {
-    if (devToolsAttached) return;
-    
+    if (this.devToolsAttached) return;
+
     this.AttachDeveloperTools();
-    devToolsAttached = true;
+    this.devToolsAttached = true;
   }
 }
 
@@ -115,19 +107,15 @@ public abstract class Theme
   {
     if (obj is null) return false;
     if (ReferenceEquals(this, obj)) return true;
-    if (obj.GetType() != GetType()) return false;
-    return Equals((Theme)obj);
+    if (obj.GetType() != this.GetType()) return false;
+    return this.Equals((Theme)obj);
   }
 
-  protected bool Equals(Theme other)
-  {
-    return Name == other.Name;
-  }
+  protected bool Equals(Theme other) =>
+    this.Name == other.Name;
 
-  public override int GetHashCode()
-  {
-    return Name.GetHashCode();
-  }
+  public override int GetHashCode() =>
+    this.Name.GetHashCode();
 }
 
 public class LinuxYaruTheme : Theme

--- a/samples/SampleApp/DemoPages/ButtonDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ButtonDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ButtonDemo : UserControl
 {
   public ButtonDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/CheckBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/CheckBoxDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class CheckBoxDemo : UserControl
 {
   public CheckBoxDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/ComboBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ComboBoxDemo.axaml.cs
@@ -1,11 +1,11 @@
-using Avalonia.Controls;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ComboBoxDemo : UserControl
 {
   public ComboBoxDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/ContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/ContextMenuDemo.axaml
@@ -23,5 +23,4 @@
     <TextBlock Margin="10">Right-click anywhere in this space</TextBlock>
   </Border>
 
-
 </UserControl>

--- a/samples/SampleApp/DemoPages/ContextMenuDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ContextMenuDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ContextMenuDemo : UserControl
 {
   public ContextMenuDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ControlAlignment">
-  
+
   <UserControl.Styles>
     <Style Selector="StackPanel > Border">
       <!-- <Setter Property="BorderBrush" Value="BlueViolet" /> -->
@@ -14,71 +14,119 @@
   </UserControl.Styles>
   <StackPanel Margin="10">
     <TextBlock Classes="h1" Text="Grid" />
-    <Grid RowDefinitions="*, *, *, *, *, *, *, *" 
-          ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" 
+    <Grid RowDefinitions="*, *, *, *, *, *, *, *"
+          ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
           RowSpacing="5"
           ColumnSpacing="10"
-          Margin="10" >
-        <Border Grid.Row="0" Grid.Column="0"><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-        <Border Grid.Row="0" Grid.Column="1"><TextBox Watermark="TextBox" /></Border>
-        <Border Grid.Row="0" Grid.Column="2"><ComboBox SelectedIndex="2">
+          Margin="10">
+      <Border Grid.Row="0" Grid.Column="0">
+        <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
+      </Border>
+      <Border Grid.Row="0" Grid.Column="1">
+        <TextBox Watermark="TextBox" />
+      </Border>
+      <Border Grid.Row="0" Grid.Column="2">
+        <ComboBox SelectedIndex="2">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4</ComboBoxItem>
-        </ComboBox></Border>
-        <Border Grid.Row="0" Grid.Column="3"><NumericUpDown Value="0"
-                                                           Increment="1"
-                                                           Watermark="mm" /></Border>
-        <Border Grid.Row="0" Grid.Column="4"><Button Content="Button" /></Border>
-        <Border Grid.Row="0" Grid.Column="5"><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+        </ComboBox>
+      </Border>
+      <Border Grid.Row="0" Grid.Column="3">
+        <NumericUpDown Value="0"
+                       Increment="1"
+                       Watermark="mm" />
+      </Border>
+      <Border Grid.Row="0" Grid.Column="4">
+        <Button Content="Button" />
+      </Border>
+      <Border Grid.Row="0" Grid.Column="5">
+        <CheckBox Content="Checkbox" IsChecked="True" />
+      </Border>
 
-      <Border Grid.Row="2" Grid.Column="0"><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-        <Border Grid.Row="3" Grid.Column="0"><TextBox Watermark="TextBox" /></Border>
-        <Border Grid.Row="4" Grid.Column="0"><ComboBox SelectedIndex="2">
+      <Border Grid.Row="2" Grid.Column="0">
+        <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
+      </Border>
+      <Border Grid.Row="3" Grid.Column="0">
+        <TextBox Watermark="TextBox" />
+      </Border>
+      <Border Grid.Row="4" Grid.Column="0">
+        <ComboBox SelectedIndex="2">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4</ComboBoxItem>
-        </ComboBox></Border>
-        <Border Grid.Row="5" Grid.Column="0"><NumericUpDown Value="0"
-                                                           Increment="1"
-                                                           Watermark="mm" /></Border>
-        <Border Grid.Row="6" Grid.Column="0"><Button Content="Button" /></Border>
-        <Border Grid.Row="7" Grid.Column=""><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+        </ComboBox>
+      </Border>
+      <Border Grid.Row="5" Grid.Column="0">
+        <NumericUpDown Value="0"
+                       Increment="1"
+                       Watermark="mm" />
+      </Border>
+      <Border Grid.Row="6" Grid.Column="0">
+        <Button Content="Button" />
+      </Border>
+      <Border Grid.Row="7" Grid.Column="">
+        <CheckBox Content="Checkbox" IsChecked="True" />
+      </Border>
     </Grid>
-    
-    <TextBlock Classes="h1" Text="StackPanels" Margin="0 20 0 0 "/>
+
+    <TextBlock Classes="h1" Text="StackPanels" Margin="0 20 0 0 " />
     <StackPanel Orientation="Vertical" Margin="10" Spacing="20" VerticalAlignment="Top">
       <StackPanel Orientation="Horizontal" Margin="10" Spacing="10" VerticalAlignment="Top">
-        <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-        <Border><TextBox Watermark="TextBox" /></Border>
-        <Border><ComboBox SelectedIndex="2">
-          <ComboBoxItem>Option 1</ComboBoxItem>
-          <ComboBoxItem>Option 2</ComboBoxItem>
-          <ComboBoxItem>Option 3</ComboBoxItem>
-          <ComboBoxItem>Option 4</ComboBoxItem>
-        </ComboBox></Border>
-        <Border><NumericUpDown Value="0"
-                               Increment="1"
-                               Watermark="mm" /></Border>
-        <Border><Button Content="Button" /></Border>
-        <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+        <Border>
+          <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
+        </Border>
+        <Border>
+          <TextBox Watermark="TextBox" />
+        </Border>
+        <Border>
+          <ComboBox SelectedIndex="2">
+            <ComboBoxItem>Option 1</ComboBoxItem>
+            <ComboBoxItem>Option 2</ComboBoxItem>
+            <ComboBoxItem>Option 3</ComboBoxItem>
+            <ComboBoxItem>Option 4</ComboBoxItem>
+          </ComboBox>
+        </Border>
+        <Border>
+          <NumericUpDown Value="0"
+                         Increment="1"
+                         Watermark="mm" />
+        </Border>
+        <Border>
+          <Button Content="Button" />
+        </Border>
+        <Border>
+          <CheckBox Content="Checkbox" IsChecked="True" />
+        </Border>
       </StackPanel>
       <StackPanel Orientation="Vertical" Width="90" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
-        <Border><TextBlock VerticalAlignment="Center">TextBlock</TextBlock></Border>
-        <Border><TextBox Watermark="TextBox" /></Border>
-        <Border><ComboBox SelectedIndex="2">
-          <ComboBoxItem>Option 1</ComboBoxItem>
-          <ComboBoxItem>Option 2</ComboBoxItem>
-          <ComboBoxItem>Option 3</ComboBoxItem>
-          <ComboBoxItem>Option 4</ComboBoxItem>
-        </ComboBox></Border>
-        <Border><NumericUpDown Value="0"
-                               Increment="1"
-                               Watermark="mm" /></Border>
-        <Border><Button Content="Button" /></Border>
-        <Border><CheckBox Content="Checkbox" IsChecked="True"></CheckBox></Border>
+        <Border>
+          <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
+        </Border>
+        <Border>
+          <TextBox Watermark="TextBox" />
+        </Border>
+        <Border>
+          <ComboBox SelectedIndex="2">
+            <ComboBoxItem>Option 1</ComboBoxItem>
+            <ComboBoxItem>Option 2</ComboBoxItem>
+            <ComboBoxItem>Option 3</ComboBoxItem>
+            <ComboBoxItem>Option 4</ComboBoxItem>
+          </ComboBox>
+        </Border>
+        <Border>
+          <NumericUpDown Value="0"
+                         Increment="1"
+                         Watermark="mm" />
+        </Border>
+        <Border>
+          <Button Content="Button" />
+        </Border>
+        <Border>
+          <CheckBox Content="Checkbox" IsChecked="True" />
+        </Border>
       </StackPanel>
     </StackPanel>
   </StackPanel>

--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml.cs
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ControlAlignment : UserControl
 {
   public ControlAlignment()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/DataGridDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/DataGridDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class DataGridDemo : UserControl
 {
   public DataGridDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
@@ -5,96 +5,96 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.EditableComboBoxDemo">
 
-   <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
-      <Grid ColumnDefinitions="Auto 190" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto">
-         <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
-            <Bold>Preferred Usage Pattern: </Bold>
-         </TextBlock>
-         <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Top" Margin="0 5 10 15">
-            - Default mode (platform-specific)
-         </TextBlock>
-         <EditableComboBox Grid.Column="1" Grid.Row="1" VerticalAlignment="Top" Margin="10 0 20 0">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3 (Default)</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 4</EditableComboBoxItem>
-         </EditableComboBox>
+  <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
+    <Grid ColumnDefinitions="Auto 190" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto">
+      <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
+        <Bold>Preferred Usage Pattern: </Bold>
+      </TextBlock>
+      <TextBlock Grid.Column="0" Grid.Row="1" VerticalAlignment="Top" Margin="0 5 10 15">
+        - Default mode (platform-specific)
+      </TextBlock>
+      <EditableComboBox Grid.Column="1" Grid.Row="1" VerticalAlignment="Top" Margin="10 0 20 0">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3 (Default)</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 4</EditableComboBoxItem>
+      </EditableComboBox>
 
-         <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" Margin="0 5 10 15">
-            - watermark:
-         </TextBlock>
-         <EditableComboBox Grid.Column="1" Grid.Row="2" Watermark="Chose one" VerticalAlignment="Top" Margin="10 0 20 0">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 4</EditableComboBoxItem>
-         </EditableComboBox>
+      <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" Margin="0 5 10 15">
+        - watermark:
+      </TextBlock>
+      <EditableComboBox Grid.Column="1" Grid.Row="2" Watermark="Chose one" VerticalAlignment="Top" Margin="10 0 20 0">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 4</EditableComboBoxItem>
+      </EditableComboBox>
 
-         <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Top" Margin="0 5 10 15">
-            - Disabled
-         </TextBlock>
-         <EditableComboBox Grid.Column="1" Grid.Row="3" IsEnabled="False" VerticalAlignment="Top"
-                           Margin="10 0 20 0">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3</EditableComboBoxItem>
-         </EditableComboBox>
+      <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Top" Margin="0 5 10 15">
+        - Disabled
+      </TextBlock>
+      <EditableComboBox Grid.Column="1" Grid.Row="3" IsEnabled="False" VerticalAlignment="Top"
+                        Margin="10 0 20 0">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3</EditableComboBoxItem>
+      </EditableComboBox>
 
-         <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" Margin="0 5 10 15">
-            - Scrolling options list
-         </TextBlock>
-         <EditableComboBox
-            Grid.Column="1" Grid.Row="4"
-            MaxDropDownHeight="100" VerticalAlignment="Top"
-            Margin="10 0 20 20">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 4</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 5</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 6</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 7</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 8</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 9</EditableComboBoxItem>
-         </EditableComboBox>
+      <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" Margin="0 5 10 15">
+        - Scrolling options list
+      </TextBlock>
+      <EditableComboBox
+        Grid.Column="1" Grid.Row="4"
+        MaxDropDownHeight="100" VerticalAlignment="Top"
+        Margin="10 0 20 20">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 4</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 5</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 6</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 7</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 8</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 9</EditableComboBoxItem>
+      </EditableComboBox>
 
-         <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Top" Margin="0 5 10 15">
-            - "Immediate" mode:<LineBreak />(default in the DevExpress theme)
-         </TextBlock>
-         <EditableComboBox
-            Grid.Column="1" Grid.Row="5"
-            VerticalAlignment="Top"
-            Mode="Immediate"
-            Margin="10 0 20 20">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 4</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 5</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 6</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 7</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 8</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 9</EditableComboBoxItem>
-         </EditableComboBox>
+      <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Top" Margin="0 5 10 15">
+        - "Immediate" mode:<LineBreak />(default in the DevExpress theme)
+      </TextBlock>
+      <EditableComboBox
+        Grid.Column="1" Grid.Row="5"
+        VerticalAlignment="Top"
+        Mode="Immediate"
+        Margin="10 0 20 20">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 4</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 5</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 6</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 7</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 8</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 9</EditableComboBoxItem>
+      </EditableComboBox>
 
-         <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" Margin="0 5 10 15">
-            - "Filter" mode:<LineBreak />
-         </TextBlock>
-         <EditableComboBox
-            Grid.Column="1" Grid.Row="6"
-            VerticalAlignment="Top"
-            Mode="Filter"
-            Margin="10 0 20 20">
-            <EditableComboBoxItem>Option 1</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 2</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 3</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 4</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 5</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 6</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 7</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 8</EditableComboBoxItem>
-            <EditableComboBoxItem>Option 9</EditableComboBoxItem>
-         </EditableComboBox>
-      </Grid>
-   </Border>
+      <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" Margin="0 5 10 15">
+        - "Filter" mode:<LineBreak />
+      </TextBlock>
+      <EditableComboBox
+        Grid.Column="1" Grid.Row="6"
+        VerticalAlignment="Top"
+        Mode="Filter"
+        Margin="10 0 20 20">
+        <EditableComboBoxItem>Option 1</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 2</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 3</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 4</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 5</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 6</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 7</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 8</EditableComboBoxItem>
+        <EditableComboBoxItem>Option 9</EditableComboBoxItem>
+      </EditableComboBox>
+    </Grid>
+  </Border>
 </UserControl>

--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml.cs
@@ -1,11 +1,11 @@
-using Avalonia.Controls;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class EditableComboBoxDemo : UserControl
 {
-    public EditableComboBoxDemo()
-    {
-        InitializeComponent();
-    }
+  public EditableComboBoxDemo()
+  {
+    this.InitializeComponent();
+  }
 }

--- a/samples/SampleApp/DemoPages/GridSplitterDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/GridSplitterDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class GridSplitterDemo : UserControl
 {
   public GridSplitterDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/MenuDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class MenuDemo : UserControl
 {
   public MenuDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/MenuFlyoutDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuFlyoutDemo.axaml.cs
@@ -1,11 +1,11 @@
-using Avalonia.Controls;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class MenuFlyoutDemo : UserControl
 {
   public MenuFlyoutDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/NumericUpDownDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/NumericUpDownDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class NumericUpDownDemo : UserControl
 {
   public NumericUpDownDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/Overview.axaml
+++ b/samples/SampleApp/DemoPages/Overview.axaml
@@ -4,99 +4,100 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.Overview">
-   <StackPanel Margin="10">
-      <TextBlock Classes="h1" Text="{Binding $parent[Window].Title}" />
-      <TextBlock FontSize="15" LineSpacing="2" TextWrapping="Wrap">
-         Elements in this sampler are styled with a partial
-         <TextBlock Classes="code" FontSize="16" Text="Avalonia.MacOS" />
-         theme, built upon <TextBlock Classes="code" FontSize="16" Text="Avalonia.Fluent" />. <LineBreak />
-         <LineBreak />
-         <Bold>Note:</Bold> at the moment the base theme is not just a
-         fallback for everything not implemented yet in the MacOS theme, but may in some instances provide
-         the base template to attach styles to (currently the case for buttons) and in most cases there may
-         also still be references to colour &amp; other resources provided by Fluent.
-         We still need to research what the drawbacks to this approach might be ...
-      </TextBlock>
-      <TabControl TabStripPlacement="Top" Margin="0 25 0 0">
-         <TabItem Header="Tab 1">
-            <StackPanel Orientation="Horizontal" Spacing="20">
-               <StackPanel>
-                  <TextBox Watermark="Name" />
-                  <TextBox Watermark="YourDomain"
-                           InnerLeftContent="http://"
-                           InnerRightContent=".com" />
-                  <TextBox Classes="clearButton">With 'Clear' button</TextBox>
-                  <TextBox Watermark="Disabled" IsEnabled="False" />
-                  <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
-                  <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-               </StackPanel>
-               <StackPanel Margin="15 5">
-                  <CheckBox IsChecked="False">Unchecked</CheckBox>
-                  <CheckBox IsChecked="True">Checked</CheckBox>
-                  <CheckBox IsThreeState="True" IsChecked="{x:Null}">Partially checked</CheckBox>
-                  <CheckBox IsEnabled="False">Unchecked</CheckBox>
-                  <CheckBox IsChecked="True" IsEnabled="False">Checked</CheckBox>
-                  <CheckBox
-                     IsChecked="{x:Null}"
-                     IsEnabled="False"
-                     IsThreeState="True">
-                     Partially checked
-                  </CheckBox>
-               </StackPanel>
-               <StackPanel Orientation="Horizontal">
-                  <ComboBox PlaceholderText="Chose one" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
-                     <ComboBoxItem>Option 1</ComboBoxItem>
-                     <ComboBoxItem>Option 2</ComboBoxItem>
-                     <ComboBoxItem>Option 3</ComboBoxItem>
-                     <ComboBoxItem>Option 4</ComboBoxItem>
-                  </ComboBox>
-                  <StackPanel>
-                     <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0">
-                        <ComboBoxItem>Option 1</ComboBoxItem>
-                        <ComboBoxItem>Option 2</ComboBoxItem>
-                        <ComboBoxItem>Option 3</ComboBoxItem>
-                        <ComboBoxItem>Option 4</ComboBoxItem>
-                     </ComboBox>
-                     <Border Margin="0 50">
-                        <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
-                           <ComboBoxItem>Option 1</ComboBoxItem>
-                           <ComboBoxItem>Option 2</ComboBoxItem>
-                           <ComboBoxItem>Option 3</ComboBoxItem>
-                           <ComboBoxItem>Option 4</ComboBoxItem>
-                        </ComboBox>
-                     </Border>
-                  </StackPanel>
-                  <StackPanel Width="100" HorizontalAlignment="Left">
-                     <Button Margin="5" Classes="accent" VerticalAlignment="Center">Ok</Button>
-                     <Button Margin="5" VerticalAlignment="Center" Content="Cancel" />
-                     <Button Margin="5" VerticalAlignment="Center" Classes="accent" IsEnabled="False">Submit</Button>
-                  </StackPanel>
-                  <StackPanel Width="200" HorizontalAlignment="Left" Spacing="5">
-                     <SplitButton Content="Splitted" Classes="accent">
-                        <SplitButton.Flyout>
-                           <MenuFlyout>
-                              <MenuItem Header="A" />
-                              <MenuItem Header="B" />
-                              <MenuItem Header="C" />
-                           </MenuFlyout>
-                        </SplitButton.Flyout>
-                     </SplitButton>
 
-                     <SplitButton Content="SplitButton">
-                        <SplitButton.Flyout>
-                           <Flyout>Hello</Flyout>
-                        </SplitButton.Flyout>
-                     </SplitButton>
-
-                     <SplitButton IsEnabled="False">Disabled</SplitButton>
-                  </StackPanel>
-               </StackPanel>
-
+  <StackPanel Margin="10">
+    <TextBlock Classes="h1" Text="{Binding $parent[Window].Title}" />
+    <TextBlock FontSize="15" LineSpacing="2" TextWrapping="Wrap">
+      Elements in this sampler are styled with a partial
+      <TextBlock Classes="code" FontSize="16" Text="Avalonia.MacOS" />
+      theme, built upon <TextBlock Classes="code" FontSize="16" Text="Avalonia.Fluent" />. <LineBreak />
+      <LineBreak />
+      <Bold>Note:</Bold> at the moment the base theme is not just a
+      fallback for everything not implemented yet in the MacOS theme, but may in some instances provide
+      the base template to attach styles to (currently the case for buttons) and in most cases there may
+      also still be references to colour &amp; other resources provided by Fluent.
+      We still need to research what the drawbacks to this approach might be ...
+    </TextBlock>
+    <TabControl TabStripPlacement="Top" Margin="0 25 0 0">
+      <TabItem Header="Tab 1">
+        <StackPanel Orientation="Horizontal" Spacing="20">
+          <StackPanel>
+            <TextBox Watermark="Name" />
+            <TextBox Watermark="YourDomain"
+                     InnerLeftContent="http://"
+                     InnerRightContent=".com" />
+            <TextBox Classes="clearButton">With 'Clear' button</TextBox>
+            <TextBox Watermark="Disabled" IsEnabled="False" />
+            <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
+            <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+          </StackPanel>
+          <StackPanel Margin="15 5">
+            <CheckBox IsChecked="False">Unchecked</CheckBox>
+            <CheckBox IsChecked="True">Checked</CheckBox>
+            <CheckBox IsThreeState="True" IsChecked="{x:Null}">Partially checked</CheckBox>
+            <CheckBox IsEnabled="False">Unchecked</CheckBox>
+            <CheckBox IsChecked="True" IsEnabled="False">Checked</CheckBox>
+            <CheckBox
+              IsChecked="{x:Null}"
+              IsEnabled="False"
+              IsThreeState="True">
+              Partially checked
+            </CheckBox>
+          </StackPanel>
+          <StackPanel Orientation="Horizontal">
+            <ComboBox PlaceholderText="Chose one" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
+              <ComboBoxItem>Option 1</ComboBoxItem>
+              <ComboBoxItem>Option 2</ComboBoxItem>
+              <ComboBoxItem>Option 3</ComboBoxItem>
+              <ComboBoxItem>Option 4</ComboBoxItem>
+            </ComboBox>
+            <StackPanel>
+              <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0">
+                <ComboBoxItem>Option 1</ComboBoxItem>
+                <ComboBoxItem>Option 2</ComboBoxItem>
+                <ComboBoxItem>Option 3</ComboBoxItem>
+                <ComboBoxItem>Option 4</ComboBoxItem>
+              </ComboBox>
+              <Border Margin="0 50">
+                <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
+                  <ComboBoxItem>Option 1</ComboBoxItem>
+                  <ComboBoxItem>Option 2</ComboBoxItem>
+                  <ComboBoxItem>Option 3</ComboBoxItem>
+                  <ComboBoxItem>Option 4</ComboBoxItem>
+                </ComboBox>
+              </Border>
             </StackPanel>
-         </TabItem>
-         <TabItem Header="Tab 2">Content 1</TabItem>
-         <TabItem Header="Tab 3" IsEnabled="False">Content 1</TabItem>
-         <TabItem Header="Tab 4">Content 1</TabItem>
-      </TabControl>
-   </StackPanel>
+            <StackPanel Width="100" HorizontalAlignment="Left">
+              <Button Margin="5" Classes="accent" VerticalAlignment="Center">Ok</Button>
+              <Button Margin="5" VerticalAlignment="Center" Content="Cancel" />
+              <Button Margin="5" VerticalAlignment="Center" Classes="accent" IsEnabled="False">Submit</Button>
+            </StackPanel>
+            <StackPanel Width="200" HorizontalAlignment="Left" Spacing="5">
+              <SplitButton Content="Splitted" Classes="accent">
+                <SplitButton.Flyout>
+                  <MenuFlyout>
+                    <MenuItem Header="A" />
+                    <MenuItem Header="B" />
+                    <MenuItem Header="C" />
+                  </MenuFlyout>
+                </SplitButton.Flyout>
+              </SplitButton>
+
+              <SplitButton Content="SplitButton">
+                <SplitButton.Flyout>
+                  <Flyout>Hello</Flyout>
+                </SplitButton.Flyout>
+              </SplitButton>
+
+              <SplitButton IsEnabled="False">Disabled</SplitButton>
+            </StackPanel>
+          </StackPanel>
+
+        </StackPanel>
+      </TabItem>
+      <TabItem Header="Tab 2">Content 1</TabItem>
+      <TabItem Header="Tab 3" IsEnabled="False">Content 1</TabItem>
+      <TabItem Header="Tab 4">Content 1</TabItem>
+    </TabControl>
+  </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/Overview.axaml.cs
+++ b/samples/SampleApp/DemoPages/Overview.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class Overview : UserControl
 {
   public Overview()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="SampleApp.DemoPages.ScrollViewerDemo">
+
   <Border Padding="10">
     <StackPanel>
       <Grid ColumnDefinitions="Auto, 400, 400" RowDefinitions="Auto, 320, 320">

--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ScrollViewerDemo : UserControl
 {
   public ScrollViewerDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml
@@ -4,9 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.TabControlDemo">
+
+
   <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
     <Border Width="500">
-      <TabControl TabStripPlacement="Left" >
+      <TabControl TabStripPlacement="Left">
         <TabItem Header="Tab 1">
           <TextBlock Text="Vertical tab view" />
         </TabItem>
@@ -17,7 +19,7 @@
       </TabControl>
     </Border>
     <Border Width="500">
-      <TabControl TabStripPlacement="Top" >
+      <TabControl TabStripPlacement="Top">
         <TabItem Header="General">
           <TextBlock Text="Horizontal tab view" />
         </TabItem>

--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class TabControlDemo : UserControl
 {
   public TabControlDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml.cs
@@ -1,13 +1,13 @@
-using Avalonia.Controls;
-using SampleApp.ViewModels;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
+using ViewModels;
 
 public partial class TextBoxDemo : UserControl
 {
   public TextBoxDemo()
   {
-    InitializeComponent();
-    DataContext = new TextBoxViewModel();
+    this.InitializeComponent();
+    this.DataContext = new TextBoxViewModel();
   }
 }

--- a/samples/SampleApp/DemoPages/ToggleSwitchDemo.axaml
+++ b/samples/SampleApp/DemoPages/ToggleSwitchDemo.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ToggleSwitchDemo">
+
   <StackPanel>
     <ToggleSwitch>Toggle with Title</ToggleSwitch>
     <ToggleSwitch Theme="{DynamicResource ButtonToggleSwitch}">Toggle</ToggleSwitch>

--- a/samples/SampleApp/DemoPages/ToggleSwitchDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ToggleSwitchDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ToggleSwitchDemo : UserControl
 {
   public ToggleSwitchDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/ToolTipDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ToolTipDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class ToolTipDemo : UserControl
 {
   public ToolTipDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/DemoPages/TreeViewDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/TreeViewDemo.axaml.cs
@@ -1,11 +1,11 @@
-using Avalonia.Controls;
-
 namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
 
 public partial class TreeViewDemo : UserControl
 {
   public TreeViewDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/Experiments/SystemColoursDemo.axaml.cs
+++ b/samples/SampleApp/Experiments/SystemColoursDemo.axaml.cs
@@ -1,13 +1,11 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
-
 namespace SampleApp.Experiments;
+
+using Avalonia.Controls;
 
 public partial class SystemColoursDemo : UserControl
 {
   public SystemColoursDemo()
   {
-    InitializeComponent();
+    this.InitializeComponent();
   }
 }

--- a/samples/SampleApp/Experiments/ToggleButtonExperiments.axaml
+++ b/samples/SampleApp/Experiments/ToggleButtonExperiments.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.Experiments.ToggleButtonExperiments">
+
   <Grid RowDefinitions="50, 50" ColumnDefinitions="Auto, 10, Auto">
     <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Built-in Toggle Button: </TextBlock>
     <ToggleButton Grid.Row="0" Grid.Column="2">Test</ToggleButton>

--- a/samples/SampleApp/Experiments/ToggleButtonExperiments.axaml.cs
+++ b/samples/SampleApp/Experiments/ToggleButtonExperiments.axaml.cs
@@ -1,19 +1,19 @@
+namespace SampleApp.Experiments;
+
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-
-namespace SampleApp.Experiments;
 
 public partial class ToggleButtonExperiments : UserControl
 {
   public ToggleButtonExperiments()
   {
-    InitializeComponent();
-    ToggleButton.Cursor = new Cursor(StandardCursorType.Cross);
+    this.InitializeComponent();
+    this.ToggleButton.Cursor = new Cursor(StandardCursorType.Cross);
   }
 
   private void Button_OnClickHandler(object? sender, RoutedEventArgs e)
   {
-    ToggleButton.Content = ToggleButton.Content?.ToString() == "On" ? "Off" : "On";
+    this.ToggleButton.Content = this.ToggleButton.Content?.ToString() == "On" ? "Off" : "On";
   }
 }

--- a/samples/SampleApp/MainWindow.axaml
+++ b/samples/SampleApp/MainWindow.axaml
@@ -13,120 +13,120 @@
         x:DataType="vm:MainWindowViewModel"
         Title="Devolutions Theme Sampler">
 
-   <!-- TODO: move the margins into the theme ?? -->
-   <Panel Classes="mainControl">
-      <TabControl TabStripPlacement="Left" VerticalAlignment="Stretch">
-         <TabItem IsSelected="True">
-            <TabItem.Header>
-               <TextBlock FontWeight="600">Overview</TextBlock>
-            </TabItem.Header>
-            <demoPages:Overview />
-         </TabItem>
-         <TabItem Header="Button">
-            <demoPages:ButtonDemo />
-         </TabItem>
-         <TabItem Header="CheckBox">
-            <demoPages:CheckBoxDemo />
-         </TabItem>
-         <TabItem Header="ComboBox">
-            <demoPages:ComboBoxDemo />
-         </TabItem>
-         <TabItem Header="EditableComboBox">
-            <demoPages:EditableComboBoxDemo />
-         </TabItem>
-         <TabItem Header="ContextMenu">
-            <demoPages:ContextMenuDemo />
-         </TabItem>
-         <TabItem Header="DataGrid">
-            <demoPages:DataGridDemo>
-               <demoPages:DataGridDemo.DataContext>
-                  <vm:DataGridViewModel />
-               </demoPages:DataGridDemo.DataContext>
-            </demoPages:DataGridDemo>
-         </TabItem>
-         <TabItem Header="Menu">
-            <demoPages:MenuDemo />
-         </TabItem>
-         <TabItem Header="GridSplitter">
-            <demoPages:GridSplitterDemo />
-         </TabItem>
-         <TabItem Header="MenuFlyout">
-            <demoPages:MenuFlyoutDemo />
-         </TabItem>
-         <TabItem Header="NumericUpDown">
-            <demoPages:NumericUpDownDemo />
-         </TabItem>
-         <TabItem Header="ScrollViewer">
-            <demoPages:ScrollViewerDemo />
-         </TabItem>
-         <TabItem Header="TabControl">
-            <demoPages:TabControlDemo />
-         </TabItem>
-         <TabItem Header="TextBox">
-            <demoPages:TextBoxDemo />
-         </TabItem>
-         <TabItem Header="Toggle Switch [WIP]">
-            <demoPages:ToggleSwitchDemo />
-         </TabItem>
-         <TabItem Header="TreeView">
-            <demoPages:TreeViewDemo />
-         </TabItem>
-         <TabItem Header="ToolTip">
-            <demoPages:ToolTipDemo />
-         </TabItem>
-         <TabItem Header="✜ Control Alignment">
-            <demoPages:ControlAlignment />
-         </TabItem>
+  <!-- TODO: move the margins into the theme ?? -->
+  <Panel Classes="mainControl">
+    <TabControl TabStripPlacement="Left" VerticalAlignment="Stretch">
+      <TabItem IsSelected="True">
+        <TabItem.Header>
+          <TextBlock FontWeight="600">Overview</TextBlock>
+        </TabItem.Header>
+        <demoPages:Overview />
+      </TabItem>
+      <TabItem Header="Button">
+        <demoPages:ButtonDemo />
+      </TabItem>
+      <TabItem Header="CheckBox">
+        <demoPages:CheckBoxDemo />
+      </TabItem>
+      <TabItem Header="ComboBox">
+        <demoPages:ComboBoxDemo />
+      </TabItem>
+      <TabItem Header="EditableComboBox">
+        <demoPages:EditableComboBoxDemo />
+      </TabItem>
+      <TabItem Header="ContextMenu">
+        <demoPages:ContextMenuDemo />
+      </TabItem>
+      <TabItem Header="DataGrid">
+        <demoPages:DataGridDemo>
+          <demoPages:DataGridDemo.DataContext>
+            <vm:DataGridViewModel />
+          </demoPages:DataGridDemo.DataContext>
+        </demoPages:DataGridDemo>
+      </TabItem>
+      <TabItem Header="Menu">
+        <demoPages:MenuDemo />
+      </TabItem>
+      <TabItem Header="GridSplitter">
+        <demoPages:GridSplitterDemo />
+      </TabItem>
+      <TabItem Header="MenuFlyout">
+        <demoPages:MenuFlyoutDemo />
+      </TabItem>
+      <TabItem Header="NumericUpDown">
+        <demoPages:NumericUpDownDemo />
+      </TabItem>
+      <TabItem Header="ScrollViewer">
+        <demoPages:ScrollViewerDemo />
+      </TabItem>
+      <TabItem Header="TabControl">
+        <demoPages:TabControlDemo />
+      </TabItem>
+      <TabItem Header="TextBox">
+        <demoPages:TextBoxDemo />
+      </TabItem>
+      <TabItem Header="Toggle Switch [WIP]">
+        <demoPages:ToggleSwitchDemo />
+      </TabItem>
+      <TabItem Header="TreeView">
+        <demoPages:TreeViewDemo />
+      </TabItem>
+      <TabItem Header="ToolTip">
+        <demoPages:ToolTipDemo />
+      </TabItem>
+      <TabItem Header="✜ Control Alignment">
+        <demoPages:ControlAlignment />
+      </TabItem>
 
 
-         <TabItem>
-            <TabItem.Header>
-               <StackPanel Orientation="Horizontal">
-                  <Svg Path="/Assets/Padlock.svg" Height="16" Width="16" Margin="-2 -2 2 0" Css=".st0 {fill : #3E6CB0; }" />
-                  <TextBlock Text="Experiments" />
-               </StackPanel>
-            </TabItem.Header>
-            <TabControl>
-               <TabItem Header="System Colours">
-                  <experiments:SystemColoursDemo />
-               </TabItem>
-               <TabItem Header="Toggle Buttons">
-                  <experiments:ToggleButtonExperiments />
-               </TabItem>
-            </TabControl>
-         </TabItem>
+      <TabItem>
+        <TabItem.Header>
+          <StackPanel Orientation="Horizontal">
+            <Svg Path="/Assets/Padlock.svg" Height="16" Width="16" Margin="-2 -2 2 0" Css=".st0 {fill : #3E6CB0; }" />
+            <TextBlock Text="Experiments" />
+          </StackPanel>
+        </TabItem.Header>
+        <TabControl>
+          <TabItem Header="System Colours">
+            <experiments:SystemColoursDemo />
+          </TabItem>
+          <TabItem Header="Toggle Buttons">
+            <experiments:ToggleButtonExperiments />
+          </TabItem>
+        </TabControl>
+      </TabItem>
 
-         <TabItem Header="Settings">
-            <TabItem.Template>
-               <ControlTemplate>
-                  <Button x:Name="SettingsButton" Content="Settings">
-                     <Button.Flyout>
-                        <Flyout>
-                           <StackPanel Width="152" Spacing="8">
-                              <ComboBox x:Name="ThemeVariants"
-                                        HorizontalAlignment="Stretch"
-                                        DisplayMemberBinding="{Binding Key, x:DataType=ThemeVariant}"
-                                        SelectedIndex="0"
-                                        SelectionChanged="ThemeVariants_OnSelectionChanged">
-                                 <ComboBox.Items>
-                                    <ThemeVariant>Default</ThemeVariant>
-                                    <ThemeVariant>Light</ThemeVariant>
-                                    <ThemeVariant>Dark</ThemeVariant>
-                                 </ComboBox.Items>
-                              </ComboBox>
-                              <ComboBox x:Name="Themes"
-                                        HorizontalAlignment="Stretch"
-                                        DisplayMemberBinding="{Binding Name, x:DataType=sampleApp:Theme}"
-                                        ItemsSource="{Binding AvailableThemes}"
-                                        SelectedItem="{Binding CurrentTheme}"
-                                        SelectionChanged="Themes_OnSelectionChanged" />
-                           </StackPanel>
-                        </Flyout>
-                     </Button.Flyout>
-                  </Button>
-               </ControlTemplate>
-            </TabItem.Template>
-         </TabItem>
-      </TabControl>
-   </Panel>
+      <TabItem Header="Settings">
+        <TabItem.Template>
+          <ControlTemplate>
+            <Button x:Name="SettingsButton" Content="Settings">
+              <Button.Flyout>
+                <Flyout>
+                  <StackPanel Width="152" Spacing="8">
+                    <ComboBox x:Name="ThemeVariants"
+                              HorizontalAlignment="Stretch"
+                              DisplayMemberBinding="{Binding Key, x:DataType=ThemeVariant}"
+                              SelectedIndex="0"
+                              SelectionChanged="ThemeVariants_OnSelectionChanged">
+                      <ComboBox.Items>
+                        <ThemeVariant>Default</ThemeVariant>
+                        <ThemeVariant>Light</ThemeVariant>
+                        <ThemeVariant>Dark</ThemeVariant>
+                      </ComboBox.Items>
+                    </ComboBox>
+                    <ComboBox x:Name="Themes"
+                              HorizontalAlignment="Stretch"
+                              DisplayMemberBinding="{Binding Name, x:DataType=sampleApp:Theme}"
+                              ItemsSource="{Binding AvailableThemes}"
+                              SelectedItem="{Binding CurrentTheme}"
+                              SelectionChanged="Themes_OnSelectionChanged" />
+                  </StackPanel>
+                </Flyout>
+              </Button.Flyout>
+            </Button>
+          </ControlTemplate>
+        </TabItem.Template>
+      </TabItem>
+    </TabControl>
+  </Panel>
 </Window>

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -1,3 +1,5 @@
+namespace SampleApp;
+
 using System;
 using Avalonia;
 using Avalonia.Controls;
@@ -5,46 +7,38 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Styling;
 
-namespace SampleApp;
-
 public partial class MainWindow : Window
 {
   public MainWindow()
   {
-    InitializeComponent();
+    this.InitializeComponent();
 #if DEBUG
     bool useAccelerate = Environment.GetEnvironmentVariable("USE_AVALONIA_ACCELERATE_TOOLS")?.ToLowerInvariant() == "true";
-    
+
     if (useAccelerate)
     {
       // Enable Accelerate dev tools (AvaloniaUI.DiagnosticsSupport) - requiring a licence to use
-      (Application.Current as App)?.AttacheDevToolsOnce(); 
+      (Application.Current as App)?.AttacheDevToolsOnce();
       // Enable original free dev tools (Avalonia.Diagnostics) as an additional option available on F10
       this.AttachDevTools(new KeyGesture(Key.F10));
     }
     else
     {
       // Enable original free dev tools (Avalonia.Diagnostics)
-      this.AttachDevTools(); 
+      this.AttachDevTools();
     }
 #endif
   }
 
   private void Themes_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
   {
-      var cb = sender as SelectingItemsControl;
-      if (cb?.SelectedItem is Theme newTheme)
-      {
-          App.SetTheme(newTheme);
-      }
+    SelectingItemsControl? cb = sender as SelectingItemsControl;
+    if (cb?.SelectedItem is Theme newTheme) App.SetTheme(newTheme);
   }
 
   private void ThemeVariants_OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
   {
-      var cb = sender as SelectingItemsControl;
-      if (cb?.SelectedItem is ThemeVariant themeVariant)
-      {
-          Application.Current!.RequestedThemeVariant = themeVariant;
-      }
+    SelectingItemsControl? cb = sender as SelectingItemsControl;
+    if (cb?.SelectedItem is ThemeVariant themeVariant) Application.Current!.RequestedThemeVariant = themeVariant;
   }
 }

--- a/samples/SampleApp/Models/DataGridItem.cs
+++ b/samples/SampleApp/Models/DataGridItem.cs
@@ -4,10 +4,10 @@ public class DataGridItem
 {
   public DataGridItem(string itemType, string commonName, string accountName, string lastModified)
   {
-    ItemType = itemType;
-    CommonName = commonName;
-    AccountName = accountName;
-    LastModified = lastModified;
+    this.ItemType = itemType;
+    this.CommonName = commonName;
+    this.AccountName = accountName;
+    this.LastModified = lastModified;
   }
 
   public string ItemType { get; set; }

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,21 +1,21 @@
-﻿using Avalonia;
+﻿namespace SampleApp;
+
 using System;
+using Avalonia;
 
-namespace SampleApp;
-
-class Program
+internal class Program
 {
-    // Initialization code. Don't use any Avalonia, third-party APIs or any
-    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-    // yet and stuff might break.
-    [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+  // Initialization code. Don't use any Avalonia, third-party APIs or any
+  // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+  // yet and stuff might break.
+  [STAThread]
+  public static void Main(string[] args) => BuildAvaloniaApp()
+    .StartWithClassicDesktopLifetime(args);
 
-    // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
-            .UsePlatformDetect()
-            .WithInterFont()
-            .LogToTrace();
+  // Avalonia configuration, don't remove; also used by visual designer.
+  public static AppBuilder BuildAvaloniaApp()
+    => AppBuilder.Configure<App>()
+      .UsePlatformDetect()
+      .WithInterFont()
+      .LogToTrace();
 }

--- a/samples/SampleApp/SampleApp.csproj
+++ b/samples/SampleApp/SampleApp.csproj
@@ -1,56 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-   <PropertyGroup>
-      <OutputType>WinExe</OutputType>
-      <TargetFramework>net9.0</TargetFramework>
-      <Nullable>enable</Nullable>
-      <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
-      <ApplicationManifest>app.manifest</ApplicationManifest>
-      <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-   </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+  </PropertyGroup>
 
-   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-      <!-- Prevent automatic attachment of regular free dev tools to avoid duplicate mapping of F12 key -->
-      <AvaloniaNameGeneratorAttachDevTools>false</AvaloniaNameGeneratorAttachDevTools>
-   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- Prevent automatic attachment of regular free dev tools to avoid duplicate mapping of F12 key -->
+    <AvaloniaNameGeneratorAttachDevTools>false</AvaloniaNameGeneratorAttachDevTools>
+  </PropertyGroup>
 
-   <ItemGroup>
-      <PackageReference Include="Avalonia" Version="11.3.0" />
-      <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
-      <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
-      <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
-   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.3.0"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0"/>
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0"/>
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0"/>
+  </ItemGroup>
 
-   <ItemGroup>
-      <!--Add both, Classic and Accelerate Dev Tools-->
-      <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
-      <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.0.3">
-         <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-         <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-      </PackageReference>
-   </ItemGroup>
+  <ItemGroup>
+    <!--Add both, Classic and Accelerate Dev Tools-->
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0"/>
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.0.3">
+      <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
+      <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 
-   <ItemGroup>
-      <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7" /><!-- Frozen until fixed on linux -->
-      <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-      <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
-   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Svg.Skia" Version="11.2.7"/><!-- Frozen until fixed on linux -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
+    <!-- <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2024.12.4" /> -->
+  </ItemGroup>
 
-   <ItemGroup>
-      <None Remove="Assets\**" />
-      <AvaloniaResource Include="Assets\**" />
-   </ItemGroup>
+  <ItemGroup>
+    <None Remove="Assets\**"/>
+    <AvaloniaResource Include="Assets\**"/>
+  </ItemGroup>
 
-   <!-- Temporary link for development. 
-        (To use the published nuget, uncomment PackageReference above (update version) or install with Nuget manager) -->
-   <ItemGroup>
-      <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.MacOS\Devolutions.AvaloniaTheme.MacOS.csproj" />
-      <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.DevExpress\Devolutions.AvaloniaTheme.DevExpress.csproj" />
-      <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.Linux\Devolutions.AvaloniaTheme.Linux.csproj" />
-   </ItemGroup>
-   <ItemGroup>
-      <Compile Update="DemoPages\EditableComboBoxDemo.axaml.cs">
-         <DependentUpon>EditableComboBoxDemo.axaml</DependentUpon>
-         <SubType>Code</SubType>
-      </Compile>
-   </ItemGroup>
+  <!-- Temporary link for development. 
+       (To use the published nuget, uncomment PackageReference above (update version) or install with Nuget manager) -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.MacOS\Devolutions.AvaloniaTheme.MacOS.csproj"/>
+    <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.DevExpress\Devolutions.AvaloniaTheme.DevExpress.csproj"/>
+    <ProjectReference Include="..\..\src\Devolutions.AvaloniaTheme.Linux\Devolutions.AvaloniaTheme.Linux.csproj"/>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="DemoPages\EditableComboBoxDemo.axaml.cs">
+      <DependentUpon>EditableComboBoxDemo.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/samples/SampleApp/ViewModels/DataGridViewModel.cs
+++ b/samples/SampleApp/ViewModels/DataGridViewModel.cs
@@ -1,25 +1,25 @@
+namespace SampleApp.ViewModels;
+
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
-using SampleApp.Models;
-
-namespace SampleApp.ViewModels;
+using Models;
 
 public class DataGridViewModel : ObservableObject
 {
   public DataGridViewModel()
   {
-    var items = new List<DataGridItem>
+    List<DataGridItem> items = new()
     {
-      new("computer", "PDQ-VM", "PDQ-VM$", "6/26/2023"),
-      new("user", "AD TEST Guy2", "ADGuysam", "5/2/2023"),
-      new("user", "krbtgt", "krbtgt", "11/10/2021"),
-      new("computer", "WIN11-VM-BT", "WIN11-VM-BT$", "11/12/2021"),
-      new("computer", "RDS6", "RDS6$", "30/03/2021"),
-      new("computer", "MSSQL1", "MSSQL1$", "14/10/2024"),
-      new("computer", "ITMANGER-DRIVE", "ITMANGER-DRIVE$", "13/10/2021")
+      new DataGridItem("computer", "PDQ-VM", "PDQ-VM$", "6/26/2023"),
+      new DataGridItem("user", "AD TEST Guy2", "ADGuysam", "5/2/2023"),
+      new DataGridItem("user", "krbtgt", "krbtgt", "11/10/2021"),
+      new DataGridItem("computer", "WIN11-VM-BT", "WIN11-VM-BT$", "11/12/2021"),
+      new DataGridItem("computer", "RDS6", "RDS6$", "30/03/2021"),
+      new DataGridItem("computer", "MSSQL1", "MSSQL1$", "14/10/2024"),
+      new DataGridItem("computer", "ITMANGER-DRIVE", "ITMANGER-DRIVE$", "13/10/2021")
     };
-    Items = new ObservableCollection<DataGridItem>(items);
+    this.Items = new ObservableCollection<DataGridItem>(items);
   }
 
   public ObservableCollection<DataGridItem> Items { get; }

--- a/samples/SampleApp/ViewModels/MainWindowViewModel.cs
+++ b/samples/SampleApp/ViewModels/MainWindowViewModel.cs
@@ -1,22 +1,21 @@
+namespace SampleApp.ViewModels;
+
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 
-namespace SampleApp.ViewModels;
-
 public partial class MainWindowViewModel : ObservableObject
 {
-    [ObservableProperty]
-    private Theme[] availableThemes = [
-        new LinuxYaruTheme(),
-        new DevExpressTheme(),
-        new MacOsTheme(),
-    ];
-    
-    [ObservableProperty]
-    private Theme currentTheme;
+  [ObservableProperty] private Theme[] availableThemes =
+  [
+    new LinuxYaruTheme(),
+    new DevExpressTheme(),
+    new MacOsTheme()
+  ];
 
-    public MainWindowViewModel()
-    {
-        this.CurrentTheme = AvailableThemes.FirstOrDefault(t => Equals(t, App.CurrentTheme!))!;
-    }
+  [ObservableProperty] private Theme currentTheme;
+
+  public MainWindowViewModel()
+  {
+    this.CurrentTheme = this.AvailableThemes.FirstOrDefault(t => Equals(t, App.CurrentTheme!))!;
+  }
 }

--- a/samples/SampleApp/ViewModels/TextBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/TextBoxViewModel.cs
@@ -1,12 +1,10 @@
+namespace SampleApp.ViewModels;
+
 using System.ComponentModel.DataAnnotations;
 using CommunityToolkit.Mvvm.ComponentModel;
 
-namespace SampleApp.ViewModels;
-
 public partial class TextBoxViewModel : ObservableValidator
 {
-  [ObservableProperty]
-  [Required(ErrorMessage = "This Input is required.", AllowEmptyStrings = false)]
-  [NotifyDataErrorInfo]
+  [ObservableProperty] [Required(ErrorMessage = "This Input is required.", AllowEmptyStrings = false)] [NotifyDataErrorInfo]
   private string _requiredInput = string.Empty;
 }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml
@@ -1,572 +1,572 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   x:ClassModifier="internal">
-   <Design.PreviewWith>
-      <Panel Width="400" Height="400">
-         <EditableComboBox
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Watermark="test">
-            <EditableComboBoxItem Value="tesfsdfast df asdf asdf as fd" />
-         </EditableComboBox>
-      </Panel>
-   </Design.PreviewWith>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:ClassModifier="internal">
+  <Design.PreviewWith>
+    <Panel Width="400" Height="400">
+      <EditableComboBox
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Watermark="test">
+        <EditableComboBoxItem Value="tesfsdfast df asdf asdf as fd" />
+      </EditableComboBox>
+    </Panel>
+  </Design.PreviewWith>
 
-   <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
-   <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
-   <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
-   <x:Double x:Key="EditableComboBoxHeight">32</x:Double>
-   <x:Double x:Key="EditableComboBoxItemsHeight">32</x:Double>
-   <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushFocused" Color="{DynamicResource SystemAccentColor}" />
+  <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
+  <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
+  <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
+  <x:Double x:Key="EditableComboBoxHeight">32</x:Double>
+  <x:Double x:Key="EditableComboBoxItemsHeight">32</x:Double>
+  <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushFocused" Color="{DynamicResource SystemAccentColor}" />
 
-   <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
-   </MenuFlyout>
-   <MenuFlyout x:Key="HorizontalTextBoxContextFlyout" FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
-               ItemContainerTheme="{StaticResource HorizontalMenuItem}">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" />
-   </MenuFlyout>
+  <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
+  </MenuFlyout>
+  <MenuFlyout x:Key="HorizontalTextBoxContextFlyout" FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
+              ItemContainerTheme="{StaticResource HorizontalMenuItem}">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" />
+  </MenuFlyout>
 
-   <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" x:DataType="EditableComboBoxItem">
-      <Setter Property="IsHitTestVisible" Value="True" />
-      <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
+  <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" x:DataType="EditableComboBoxItem">
+    <Setter Property="IsHitTestVisible" Value="True" />
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Padding" Value="{DynamicResource ComboBoxItemThemePadding}" />
+    <Setter Property="Height" Value="{DynamicResource EditableComboBoxItemsHeight}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_Background" Padding="{TemplateBinding Padding}">
+          <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Stretch">
+            <SearchHighlightTextBlock
+              Name="PART_Text"
+              Content="{TemplateBinding Value}"
+              Search="{TemplateBinding FilterHighlightText}"
+              VerticalAlignment="Center" />
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^ /template/ Border#PART_Background">
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Padding" Value="{DynamicResource ComboBoxItemThemePadding}" />
-      <Setter Property="Height" Value="{DynamicResource EditableComboBoxItemsHeight}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="PART_Background" Padding="{TemplateBinding Padding}">
-               <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Stretch">
-                  <SearchHighlightTextBlock
-                     Name="PART_Text"
-                     Content="{TemplateBinding Value}"
-                     Search="{TemplateBinding FilterHighlightText}"
-                     VerticalAlignment="Center" />
-               </StackPanel>
-            </Border>
-         </ControlTemplate>
-      </Setter>
+    </Style>
 
-      <Style Selector="^ /template/ Border#PART_Background">
-         <Setter Property="Background" Value="Transparent" />
+    <Style Selector="^:pointerover /template/ Border#PART_Background">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Style Selector="^ TextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />
       </Style>
+    </Style>
 
-      <Style Selector="^:pointerover /template/ Border#PART_Background">
-         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
-         <Style Selector="^ TextBlock#PART_Text">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />
-         </Style>
+    <Style Selector="^[IsSelected=True] /template/ Border#PART_Background">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Style Selector="^ TextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />
       </Style>
+    </Style>
 
-      <Style Selector="^[IsSelected=True] /template/ Border#PART_Background">
-         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
-         <Style Selector="^ TextBlock#PART_Text">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />
-         </Style>
+    <Style Selector="^:disabled /template/ Border#PART_Background">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
+      <Style Selector="^ TextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
       </Style>
+    </Style>
 
-      <Style Selector="^:disabled /template/ Border#PART_Background">
-         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
-         <Style Selector="^ TextBlock#PART_Text">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
-         </Style>
+
+    <Style Selector="^:pressed /template/ TextBlock">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPressed}" />
+      <Style Selector="^ TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPressed}" />
       </Style>
+    </Style>
+  </ControlTheme>
 
-
-      <Style Selector="^:pressed /template/ TextBlock">
-         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPressed}" />
-         <Style Selector="^ TextBlock">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPressed}" />
-         </Style>
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}"
-                 TargetType="EditableComboBox+InnerTextBox">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="CornerRadius" Value="0" />
-      <Setter Property="MinHeight" Value="0" />
-      <Setter Property="MinWidth" Value="1" />
-      <Setter Property="Cursor" Value="IBeam" />
-      <Setter Property="Margin"
-              Value="{Binding 
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}"
+                TargetType="EditableComboBox+InnerTextBox">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="MinWidth" Value="1" />
+    <Setter Property="Cursor" Value="IBeam" />
+    <Setter Property="Margin"
+            Value="{Binding 
             Padding, 
             RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
             Converter={x:Static DevoConverters.ThicknessExtractor}, 
             ConverterParameter={x:Static ThicknessSubset.AllButRight}
         }" />
-      <Setter Property="Padding" Value="0" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ContextFlyout"
-              Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DockPanel x:Name="PART_InnerDockPanel"
-                       Margin="{TemplateBinding Padding}">
-               <TextBlock
-                  Name="PART_FloatingWatermark"
-                  Foreground="{DynamicResource SystemAccentColor}"
-                  IsVisible="False"
-                  Text="{TemplateBinding Watermark}"
-                  DockPanel.Dock="Top" />
-               <ScrollViewer
-                  Name="PART_ScrollViewer"
-                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                  BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                  <Panel>
-                     <TextBlock
-                        Name="PART_Watermark"
-                        Opacity="0.5"
-                        Text="{TemplateBinding Watermark}"
-                        TextAlignment="{TemplateBinding TextAlignment}"
-                        TextWrapping="{TemplateBinding TextWrapping}"
-                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                        <TextBlock.IsVisible>
-                           <MultiBinding Converter="{x:Static BoolConverters.And}">
-                              <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                              <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                           </MultiBinding>
-                        </TextBlock.IsVisible>
-                     </TextBlock>
-                     <TextPresenter
-                        Name="PART_TextPresenter"
-                        Text="{TemplateBinding Text, Mode=TwoWay}"
-                        CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                        CaretIndex="{TemplateBinding CaretIndex}"
-                        SelectionStart="{TemplateBinding SelectionStart}"
-                        SelectionEnd="{TemplateBinding SelectionEnd}"
-                        TextAlignment="{TemplateBinding TextAlignment}"
-                        TextWrapping="{TemplateBinding TextWrapping}"
-                        LineHeight="{TemplateBinding LineHeight}"
-                        LetterSpacing="{TemplateBinding LetterSpacing}"
-                        PasswordChar="{TemplateBinding PasswordChar}"
-                        RevealPassword="{TemplateBinding RevealPassword}"
-                        SelectionBrush="{TemplateBinding SelectionBrush}"
-                        SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                        CaretBrush="{TemplateBinding CaretBrush}"
-                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                  </Panel>
-               </ScrollViewer>
-            </DockPanel>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ContextFlyout"
+            Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel x:Name="PART_InnerDockPanel"
+                   Margin="{TemplateBinding Padding}">
+          <TextBlock
+            Name="PART_FloatingWatermark"
+            Foreground="{DynamicResource SystemAccentColor}"
+            IsVisible="False"
+            Text="{TemplateBinding Watermark}"
+            DockPanel.Dock="Top" />
+          <ScrollViewer
+            Name="PART_ScrollViewer"
+            HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+            VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+            IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+            AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+            BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+            <Panel>
+              <TextBlock
+                Name="PART_Watermark"
+                Opacity="0.5"
+                Text="{TemplateBinding Watermark}"
+                TextAlignment="{TemplateBinding TextAlignment}"
+                TextWrapping="{TemplateBinding TextWrapping}"
+                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                <TextBlock.IsVisible>
+                  <MultiBinding Converter="{x:Static BoolConverters.And}">
+                    <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                             Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                             Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                  </MultiBinding>
+                </TextBlock.IsVisible>
+              </TextBlock>
+              <TextPresenter
+                Name="PART_TextPresenter"
+                Text="{TemplateBinding Text, Mode=TwoWay}"
+                CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                CaretIndex="{TemplateBinding CaretIndex}"
+                SelectionStart="{TemplateBinding SelectionStart}"
+                SelectionEnd="{TemplateBinding SelectionEnd}"
+                TextAlignment="{TemplateBinding TextAlignment}"
+                TextWrapping="{TemplateBinding TextWrapping}"
+                LineHeight="{TemplateBinding LineHeight}"
+                LetterSpacing="{TemplateBinding LetterSpacing}"
+                PasswordChar="{TemplateBinding PasswordChar}"
+                RevealPassword="{TemplateBinding RevealPassword}"
+                SelectionBrush="{TemplateBinding SelectionBrush}"
+                SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                CaretBrush="{TemplateBinding CaretBrush}"
+                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </Panel>
+          </ScrollViewer>
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}" TargetType="EditableComboBox+InnerComboBox">
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="MaxDropDownHeight" Value="504" />
-      <Setter Property="Foreground"
-              Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Background"
-              Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderBrush"
-              Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderThickness"
-              Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="CornerRadius"
-              Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Padding"
-              Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="MinHeight"
-              Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerLeftContent"
-              Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerRightContent"
-              Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors>
-               <Grid ColumnDefinitions="Auto,*,32,Auto" HorizontalAlignment="Stretch">
-                  <Border x:Name="Background"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="4"
-                          Background="{TemplateBinding Background}"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="{TemplateBinding BorderThickness}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
-                  <Border x:Name="HighlightBackground"
-                          Grid.Column="0"
-                          Grid.ColumnSpan="4"
-                          Background="Transparent"
-                          BorderBrush="{DynamicResource ComboBoxBackgroundBorderBrushFocused}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          IsVisible="False" />
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}" TargetType="EditableComboBox+InnerComboBox">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="MaxDropDownHeight" Value="504" />
+    <Setter Property="Foreground"
+            Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Background"
+            Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderBrush"
+            Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderThickness"
+            Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="CornerRadius"
+            Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Padding"
+            Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="MinHeight"
+            Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerLeftContent"
+            Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerRightContent"
+            Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors>
+          <Grid ColumnDefinitions="Auto,*,32,Auto" HorizontalAlignment="Stretch">
+            <Border x:Name="Background"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="4"
+                    Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
+            <Border x:Name="HighlightBackground"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="4"
+                    Background="Transparent"
+                    BorderBrush="{DynamicResource ComboBoxBackgroundBorderBrushFocused}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    IsVisible="False" />
 
-                  <ItemsControl
-                     Name="PART_InnerLeftContent"
-                     Grid.Column="0"
-                     ItemsSource="{TemplateBinding InnerLeftContent}">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <StackPanel Name="PART_InnerLeftContentPanel" Orientation="Horizontal"
-                                       Margin="2 2 0 2" />
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                  </ItemsControl>
+            <ItemsControl
+              Name="PART_InnerLeftContent"
+              Grid.Column="0"
+              ItemsSource="{TemplateBinding InnerLeftContent}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Name="PART_InnerLeftContentPanel" Orientation="Horizontal"
+                              Margin="2 2 0 2" />
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+            </ItemsControl>
 
-                  <ContentPresenter x:Name="PART_TextBoxPresenter"
-                                    Grid.Column="1" />
+            <ContentPresenter x:Name="PART_TextBoxPresenter"
+                              Grid.Column="1" />
 
-                  <Border x:Name="DropDownOverlay"
-                          Grid.Column="2"
-                          Background="Transparent"
-                          Margin="0,1,1,1"
-                          Width="30"
-                          IsVisible="False"
-                          HorizontalAlignment="Right" />
+            <Border x:Name="DropDownOverlay"
+                    Grid.Column="2"
+                    Background="Transparent"
+                    Margin="0,1,1,1"
+                    Width="30"
+                    IsVisible="False"
+                    HorizontalAlignment="Right" />
 
-                  <PathIcon x:Name="DropDownGlyph"
-                            Grid.Column="2"
-                            UseLayoutRounding="False"
-                            IsHitTestVisible="False"
-                            Height="12"
-                            Width="12"
-                            Margin="0,0,10,0"
-                            HorizontalAlignment="Right"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
-                            Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z" />
+            <PathIcon x:Name="DropDownGlyph"
+                      Grid.Column="2"
+                      UseLayoutRounding="False"
+                      IsHitTestVisible="False"
+                      Height="12"
+                      Width="12"
+                      Margin="0,0,10,0"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Center"
+                      Foreground="{DynamicResource ComboBoxDropDownGlyphForeground}"
+                      Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z" />
 
-                  <ItemsControl
-                     Grid.Column="3"
-                     Name="PART_InnerRightContent"
-                     ItemsSource="{TemplateBinding InnerRightContent}">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <StackPanel Name="PART_InnerRightContentPanel" Orientation="Horizontal"
-                                       Margin="0 2 3 2" />
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                  </ItemsControl>
+            <ItemsControl
+              Grid.Column="3"
+              Name="PART_InnerRightContent"
+              ItemsSource="{TemplateBinding InnerRightContent}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Name="PART_InnerRightContentPanel" Orientation="Horizontal"
+                              Margin="0 2 3 2" />
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+            </ItemsControl>
 
-                  <!-- ReSharper disable once Xaml.MissingGridIndex -->
-                  <Popup
-                     Name="PART_Popup"
-                     WindowManagerAddShadowHint="False"
-                     IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
-                     MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                     MaxWidth="{TemplateBinding MaxDropDownWidth}"
-                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                     Placement="AnchorAndGravity"
-                     PlacementAnchor="BottomLeft"
-                     PlacementGravity="BottomRight"
-                     HorizontalAlignment="Stretch"
-                     HorizontalOffset="0"
-                     VerticalOffset="0"
-                     IsLightDismissEnabled="True"
-                     OverlayDismissEventPassThrough="True"
-                     InheritsTransform="True">
-                     <Panel>
-                        <Border
-                           x:Name="PopupBorder"
-                           Background="{DynamicResource ComboBoxDropDownBackground}"
-                           BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                           BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                           Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                           HorizontalAlignment="Stretch"
-                           CornerRadius="{DynamicResource OverlayCornerRadius}">
-                           <ScrollViewer
-                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                              IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}">
-                              <ItemsPresenter
-                                 Name="PART_ItemsPresenter"
-                                 Margin="{DynamicResource ComboBoxDropdownContentMargin}"
-                                 ItemsPanel="{TemplateBinding ItemsPanel}" />
-                           </ScrollViewer>
-                        </Border>
-                        <Border
-                           x:Name="PopupTabMask"
-                           Background="{x:Null}"
-                           BorderBrush="{DynamicResource ComboBoxDropDownBackground}"
-                           Margin="{
+            <!-- ReSharper disable once Xaml.MissingGridIndex -->
+            <Popup
+              Name="PART_Popup"
+              WindowManagerAddShadowHint="False"
+              IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+              MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
+              MaxWidth="{TemplateBinding MaxDropDownWidth}"
+              MaxHeight="{TemplateBinding MaxDropDownHeight}"
+              Placement="AnchorAndGravity"
+              PlacementAnchor="BottomLeft"
+              PlacementGravity="BottomRight"
+              HorizontalAlignment="Stretch"
+              HorizontalOffset="0"
+              VerticalOffset="0"
+              IsLightDismissEnabled="True"
+              OverlayDismissEventPassThrough="True"
+              InheritsTransform="True">
+              <Panel>
+                <Border
+                  x:Name="PopupBorder"
+                  Background="{DynamicResource ComboBoxDropDownBackground}"
+                  BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                  BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
+                  Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+                  HorizontalAlignment="Stretch"
+                  CornerRadius="{DynamicResource OverlayCornerRadius}">
+                  <ScrollViewer
+                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                    IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}">
+                    <ItemsPresenter
+                      Name="PART_ItemsPresenter"
+                      Margin="{DynamicResource ComboBoxDropdownContentMargin}"
+                      ItemsPanel="{TemplateBinding ItemsPanel}" />
+                  </ScrollViewer>
+                </Border>
+                <Border
+                  x:Name="PopupTabMask"
+                  Background="{x:Null}"
+                  BorderBrush="{DynamicResource ComboBoxDropDownBackground}"
+                  Margin="{
                               Binding PopupBorderMaskMargin,
                               RelativeSource={RelativeSource TemplatedParent}
                            }"
-                           Width="{
+                  Width="{
                               Binding PopupBorderMaskWidth,
                               RelativeSource={RelativeSource TemplatedParent}
                            }"
-                           Padding="0"
-                           HorizontalAlignment="Left"
-                           CornerRadius="0" />
-                     </Panel>
-                  </Popup>
-               </Grid>
-            </DataValidationErrors>
-         </ControlTemplate>
-      </Setter>
+                  Padding="0"
+                  HorizontalAlignment="Left"
+                  CornerRadius="0" />
+              </Panel>
+            </Popup>
+          </Grid>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
 
-      <Style Selector="^ /template/ Border#HighlightBackground">
-         <Setter Property="BorderThickness"
-                 Value="{
+    <Style Selector="^ /template/ Border#HighlightBackground">
+      <Setter Property="BorderThickness"
+              Value="{
                 Binding FocusedBorderThickness, 
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}
             }" />
-      </Style>
-      <Style Selector="^:dropdownopen /template/ Border#HighlightBackground">
-         <Setter Property="BorderThickness"
-                 Value="{
+    </Style>
+    <Style Selector="^:dropdownopen /template/ Border#HighlightBackground">
+      <Setter Property="BorderThickness"
+              Value="{
                 Binding FocusedBorderThickness, 
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
                 Converter={x:Static DevoConverters.ThicknessExtractor}, 
                 ConverterParameter={x:Static ThicknessSubset.AllButBottom}
             }" />
-      </Style>
-      <Style Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#HighlightBackground">
-         <Setter Property="BorderThickness"
-                 Value="{
+    </Style>
+    <Style Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#HighlightBackground">
+      <Setter Property="BorderThickness"
+              Value="{
                 Binding FocusedBorderThickness, 
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
                 Converter={x:Static DevoConverters.ThicknessExtractor}, 
                 ConverterParameter={x:Static ThicknessSubset.AllButTop}
             }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:is-split-between-screens /template/ Border#HighlightBackground">
-         <Setter Property="BorderThickness"
-                 Value="{
+    <Style Selector="^:is-split-between-screens /template/ Border#HighlightBackground">
+      <Setter Property="BorderThickness"
+              Value="{
                 Binding FocusedBorderThickness, 
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}
             }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style Selector="^">
+      <Setter Property="CornerRadius"
+              Value="{
                 Binding CornerRadius, 
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}
             }" />
-      </Style>
+    </Style>
 
-      <Style
-         Selector="^:dropdownopen /template/ Border#Background, ^:dropdownopen /template/ Border#HighlightBackground">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style
+      Selector="^:dropdownopen /template/ Border#Background, ^:dropdownopen /template/ Border#HighlightBackground">
+      <Setter Property="CornerRadius"
+              Value="{
                 Binding CornerRadius,
                 RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
                 Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                 ConverterParameter={x:Static CornerRadiusSubset.Top}
             }" />
-      </Style>
-      <Style
-         Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#Background, ^:dropdownopen:dropdown-open-from-top /template/ Border#HighlightBackground">
-         <Setter Property="CornerRadius"
-                 Value="{
+    </Style>
+    <Style
+      Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#Background, ^:dropdownopen:dropdown-open-from-top /template/ Border#HighlightBackground">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius,
                         RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.Bottom}
                     }" />
-      </Style>
+    </Style>
 
-      <Style
-         Selector="^:is-split-between-screens /template/ Border#Background, ^:is-split-between-screens /template/ Border#HighlightBackground">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style
+      Selector="^:is-split-between-screens /template/ Border#Background, ^:is-split-between-screens /template/ Border#HighlightBackground">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius,
                         RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}
                     }" />
-      </Style>
+    </Style>
 
-      <!-- Error State -->
-      <Style Selector="^:error /template/ Border#Background">
-         <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-      </Style>
+    <!-- Error State -->
+    <Style Selector="^:error /template/ Border#Background">
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    </Style>
 
-      <!--  Focus Pressed State  -->
-      <Style Selector="^:focused:pressed">
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
-         </Style>
+    <!--  Focus Pressed State  -->
+    <Style Selector="^:focused:pressed">
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocusedPressed}" />
       </Style>
+    </Style>
 
-      <!--  Focused State  -->
-      <Style Selector="^:focus-within:not(.no-focus-border)">
-         <Style Selector="^ /template/ Border#HighlightBackground">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
-         </Style>
+    <!--  Focused State  -->
+    <Style Selector="^:focus-within:not(.no-focus-border)">
+      <Style Selector="^ /template/ Border#HighlightBackground">
+        <Setter Property="IsVisible" Value="True" />
       </Style>
-
-      <!--  Disabled State  -->
-      <Style Selector="^:disabled">
-         <Style Selector="^ /template/ Border#Background">
-            <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-         </Style>
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
-         </Style>
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundFocused}" />
       </Style>
+    </Style>
 
-      <!--  Popup styling -->
-      <Style Selector="^:dropdownopen /template/ Border#PopupBorder">
-         <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBackgroundBorderBrushFocused}" />
-         <Setter Property="BorderThickness" Value="{TemplateBinding FocusedBorderThickness}" />
+    <!--  Disabled State  -->
+    <Style Selector="^:disabled">
+      <Style Selector="^ /template/ Border#Background">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
       </Style>
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
+      </Style>
+    </Style>
 
-      <Style Selector="^:not(:dropdown-open-from-top):not(:dropdown-overflow-left):not(:dropdown-overflow-right) /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <!--  Popup styling -->
+    <Style Selector="^:dropdownopen /template/ Border#PopupBorder">
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBackgroundBorderBrushFocused}" />
+      <Setter Property="BorderThickness" Value="{TemplateBinding FocusedBorderThickness}" />
+    </Style>
+
+    <Style Selector="^:not(:dropdown-open-from-top):not(:dropdown-overflow-left):not(:dropdown-overflow-right) /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius,
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.Bottom}
                     }" />
-      </Style>
-      <Style Selector="^:not(:dropdown-open-from-top):not(:dropdown-overflow-left):dropdown-overflow-right /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    </Style>
+    <Style Selector="^:not(:dropdown-open-from-top):not(:dropdown-overflow-left):dropdown-overflow-right /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.AllButTopLeft}
                     }" />
-      </Style>
-      <Style Selector="^:not(:dropdown-open-from-top):dropdown-overflow-left:not(:dropdown-overflow-right) /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    </Style>
+    <Style Selector="^:not(:dropdown-open-from-top):dropdown-overflow-left:not(:dropdown-overflow-right) /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.AllButTopRight}
                     }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:dropdown-open-from-top:not(:dropdown-overflow-left):not(:dropdown-overflow-right) /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style Selector="^:dropdown-open-from-top:not(:dropdown-overflow-left):not(:dropdown-overflow-right) /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius,
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.Top}
                     }" />
-      </Style>
-      <Style Selector="^:dropdown-open-from-top:not(:dropdown-overflow-left):dropdown-overflow-right /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    </Style>
+    <Style Selector="^:dropdown-open-from-top:not(:dropdown-overflow-left):dropdown-overflow-right /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.AllButBottomLeft}
                     }" />
-      </Style>
-      <Style Selector="^:dropdown-open-from-top:dropdown-overflow-left:not(:dropdown-overflow-right) /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    </Style>
+    <Style Selector="^:dropdown-open-from-top:dropdown-overflow-left:not(:dropdown-overflow-right) /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent},
                         Converter={x:Static DevoConverters.CornerRadiusExtractor}, 
                         ConverterParameter={x:Static CornerRadiusSubset.AllButBottomRight}
                     }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:dropdown-overflow-left:dropdown-overflow-right /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style Selector="^:dropdown-overflow-left:dropdown-overflow-right /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent}
                     }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:is-split-between-screens /template/ Border#PopupBorder">
-         <Setter Property="CornerRadius"
-                 Value="{
+    <Style Selector="^:is-split-between-screens /template/ Border#PopupBorder">
+      <Setter Property="CornerRadius"
+              Value="{
                         Binding CornerRadius, 
                         RelativeSource={RelativeSource TemplatedParent}
                     }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:dropdownopen:not(:dropdown-open-from-top) /template/ Border#PopupTabMask">
-         <Setter
-            Property="BorderThickness"
-            Value="{
+    <Style Selector="^:dropdownopen:not(:dropdown-open-from-top) /template/ Border#PopupTabMask">
+      <Setter
+        Property="BorderThickness"
+        Value="{
                Binding FocusedBorderThickness, 
                RelativeSource={RelativeSource TemplatedParent},
                Converter={x:Static DevoConverters.ThicknessExtractor}, 
                ConverterParameter={x:Static ThicknessSubset.Top}
             }" />
-      </Style>
-      <Style Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#PopupTabMask">
-         <Setter
-            Property="BorderThickness"
-            Value="{
+    </Style>
+    <Style Selector="^:dropdownopen:dropdown-open-from-top /template/ Border#PopupTabMask">
+      <Setter
+        Property="BorderThickness"
+        Value="{
                Binding FocusedBorderThickness, 
                RelativeSource={RelativeSource TemplatedParent},
                Converter={x:Static DevoConverters.ThicknessExtractor}, 
                ConverterParameter={x:Static ThicknessSubset.Bottom}
             }" />
-      </Style>
+    </Style>
 
-      <Style Selector="^:is-split-between-screens /template/ Border#PopupTabMask">
-         <Setter
-            Property="BorderThickness"
-            Value="{
+    <Style Selector="^:is-split-between-screens /template/ Border#PopupTabMask">
+      <Setter
+        Property="BorderThickness"
+        Value="{
                Binding FocusedBorderThickness, 
                RelativeSource={RelativeSource TemplatedParent}
             }" />
-      </Style>
-   </ControlTheme>
+    </Style>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox">
-      <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
-      <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
-      <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
-      <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
-      <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
-      <Setter Property="ContextFlyout" Value="{x:Null}" />
-      <Setter Property="Focusable" Value="True" />
-      <Setter Property="IsTabStop" Value="True" />
-      <Setter Property="ClipToBounds" Value="False" />
+  <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox">
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextControlSelectionHighlightColor}" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ContextFlyout" Value="{x:Null}" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="ClipToBounds" Value="False" />
 
-      <Setter Property="Padding" Value="10 0 0 0" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="MaxDropDownHeight" Value="504" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="MinWidth" Value="{DynamicResource EditableComboBoxMinWidth}" />
-      <Setter Property="Height" Value="{DynamicResource EditableComboBoxHeight}" />
-      <Setter Property="HorizontalAlignment" Value="Left" />
-      <Setter Property="VerticalAlignment" Value="Top" />
-   </ControlTheme>
+    <Setter Property="Padding" Value="10 0 0 0" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="MaxDropDownHeight" Value="504" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="MinWidth" Value="{DynamicResource EditableComboBoxMinWidth}" />
+    <Setter Property="Height" Value="{DynamicResource EditableComboBoxHeight}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Top" />
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -17,587 +17,588 @@ using Avalonia.VisualTree;
 [PseudoClasses(PC_DropdownOpen, PC_Pressed)]
 public partial class EditableComboBox : ItemsControl, IInputElement
 {
-    public const string PC_DropdownOpen = ":dropdownopen";
+  public const string PC_DropdownOpen = ":dropdownopen";
 
-    public const string PC_Pressed = ":pressed";
+  public const string PC_Pressed = ":pressed";
 
-    public static readonly StyledProperty<TimeSpan> CaretBlinkIntervalProperty =
-        AvaloniaProperty.Register<EditableComboBox, TimeSpan>(nameof(CaretBlinkInterval), TimeSpan.FromMilliseconds(500));
+  public static readonly StyledProperty<TimeSpan> CaretBlinkIntervalProperty =
+    AvaloniaProperty.Register<EditableComboBox, TimeSpan>(nameof(CaretBlinkInterval), TimeSpan.FromMilliseconds(500));
 
-    public static readonly StyledProperty<IBrush?> CaretBrushProperty = AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(CaretBrush));
+  public static readonly StyledProperty<IBrush?> CaretBrushProperty = AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(CaretBrush));
 
-    public static readonly StyledProperty<int> CaretIndexProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(CaretIndex));
+  public static readonly StyledProperty<int> CaretIndexProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(CaretIndex));
 
-    public new static readonly StyledProperty<bool> FocusableProperty =
-        AvaloniaProperty.Register<EditableComboBox, bool>(nameof(Focusable), true);
+  public new static readonly StyledProperty<bool> FocusableProperty =
+    AvaloniaProperty.Register<EditableComboBox, bool>(nameof(Focusable), true);
 
-    public static readonly StyledProperty<bool> IsDropDownOpenProperty =
-        AvaloniaProperty.Register<EditableComboBox, bool>(nameof(IsDropDownOpen));
+  public static readonly StyledProperty<bool> IsDropDownOpenProperty =
+    AvaloniaProperty.Register<EditableComboBox, bool>(nameof(IsDropDownOpen));
 
-    public new static readonly StyledProperty<bool> IsTabStopProperty =
-        AvaloniaProperty.Register<EditableComboBox, bool>(nameof(IsTabStop), true);
+  public new static readonly StyledProperty<bool> IsTabStopProperty =
+    AvaloniaProperty.Register<EditableComboBox, bool>(nameof(IsTabStop), true);
 
-    public static readonly StyledProperty<int> MaxLengthProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(MaxLength));
+  public static readonly StyledProperty<int> MaxLengthProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(MaxLength));
 
-    public static readonly StyledProperty<IBrush?> SelectionBrushProperty =
-        AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(SelectionBrush));
+  public static readonly StyledProperty<IBrush?> SelectionBrushProperty =
+    AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(SelectionBrush));
 
-    public static readonly StyledProperty<int> SelectionEndProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(SelectionEnd));
+  public static readonly StyledProperty<int> SelectionEndProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(SelectionEnd));
 
-    public static readonly StyledProperty<IBrush?> SelectionForegroundBrushProperty =
-        AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(SelectionForegroundBrush));
+  public static readonly StyledProperty<IBrush?> SelectionForegroundBrushProperty =
+    AvaloniaProperty.Register<EditableComboBox, IBrush?>(nameof(SelectionForegroundBrush));
 
-    public static readonly StyledProperty<int> SelectionStartProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(SelectionStart));
+  public static readonly StyledProperty<int> SelectionStartProperty = AvaloniaProperty.Register<EditableComboBox, int>(nameof(SelectionStart));
 
-    public static readonly StyledProperty<string?> WatermarkProperty = AvaloniaProperty.Register<EditableComboBox, string?>(nameof(Watermark));
+  public static readonly StyledProperty<string?> WatermarkProperty = AvaloniaProperty.Register<EditableComboBox, string?>(nameof(Watermark));
 
-    public static readonly StyledProperty<string?> ValueProperty = AvaloniaProperty.Register<EditableComboBox, string?>(
-        nameof(Value),
-        coerce: CoerceText,
-        defaultBindingMode: BindingMode.TwoWay,
-        enableDataValidation: true);
+  public static readonly StyledProperty<string?> ValueProperty = AvaloniaProperty.Register<EditableComboBox, string?>(
+    nameof(Value),
+    coerce: CoerceText,
+    defaultBindingMode: BindingMode.TwoWay,
+    enableDataValidation: true);
 
-    public static readonly StyledProperty<bool> ClearOnOpenProperty = AvaloniaProperty.Register<EditableComboBox, bool>(nameof(ClearOnOpen));
+  public static readonly StyledProperty<bool> ClearOnOpenProperty = AvaloniaProperty.Register<EditableComboBox, bool>(nameof(ClearOnOpen));
 
-    public static readonly StyledProperty<Thickness> FocusedBorderThicknessProperty = AvaloniaProperty.Register<EditableComboBox, Thickness>(
-        nameof(FocusedBorderThickness),
-        Application.Current?.FindResource("TextControlBorderThemeThicknessFocused") as Thickness? ?? new Thickness(2));
+  public static readonly StyledProperty<Thickness> FocusedBorderThicknessProperty = AvaloniaProperty.Register<EditableComboBox, Thickness>(
+    nameof(FocusedBorderThickness),
+    Application.Current?.FindResource("TextControlBorderThemeThicknessFocused") as Thickness? ?? new Thickness(2));
 
-    public static readonly StyledProperty<IBrush?> IconDefaultFillProperty = AvaloniaProperty.Register<EditableComboBox, IBrush?>(
-        nameof(IconDefaultFill),
-        Application.Current?.FindResource("SvgInputIconFill") as IBrush);
+  public static readonly StyledProperty<IBrush?> IconDefaultFillProperty = AvaloniaProperty.Register<EditableComboBox, IBrush?>(
+    nameof(IconDefaultFill),
+    Application.Current?.FindResource("SvgInputIconFill") as IBrush);
 
-    public static readonly DirectProperty<EditableComboBox, IEnumerable> InnerLeftContentProperty =
-        AvaloniaProperty.RegisterDirect<EditableComboBox, IEnumerable>(
-            nameof(InnerLeftContent),
-            static o => o.InnerLeftContent,
-            static (o, v) => o.InnerLeftContent = v);
+  public static readonly DirectProperty<EditableComboBox, IEnumerable> InnerLeftContentProperty =
+    AvaloniaProperty.RegisterDirect<EditableComboBox, IEnumerable>(
+      nameof(InnerLeftContent),
+      static o => o.InnerLeftContent,
+      static (o, v) => o.InnerLeftContent = v);
 
-    public static readonly DirectProperty<EditableComboBox, IEnumerable> InnerRightContentProperty =
-        AvaloniaProperty.RegisterDirect<EditableComboBox, IEnumerable>(
-            nameof(InnerRightContent),
-            static o => o.InnerRightContent,
-            static (o, v) => o.InnerRightContent = v);
+  public static readonly DirectProperty<EditableComboBox, IEnumerable> InnerRightContentProperty =
+    AvaloniaProperty.RegisterDirect<EditableComboBox, IEnumerable>(
+      nameof(InnerRightContent),
+      static o => o.InnerRightContent,
+      static (o, v) => o.InnerRightContent = v);
 
-    public static readonly StyledProperty<double> MaxDropDownWidthProperty =
-        AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownWidth), 500);
+  public static readonly StyledProperty<double> MaxDropDownWidthProperty =
+    AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownWidth), 500);
 
-    public static readonly StyledProperty<double> MaxDropDownHeightProperty =
-        AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownHeight), 200);
+  public static readonly StyledProperty<double> MaxDropDownHeightProperty =
+    AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownHeight), 200);
 
-    public static readonly StyledProperty<EditableComboBoxMode> ModeProperty =
-        AvaloniaProperty.Register<EditableComboBox, EditableComboBoxMode>(nameof(Mode));
+  public static readonly StyledProperty<EditableComboBoxMode> ModeProperty =
+    AvaloniaProperty.Register<EditableComboBox, EditableComboBoxMode>(nameof(Mode));
 
-    private readonly AvaloniaList<object?> filteredItems = new();
+  private readonly AvaloniaList<object?> filteredItems = new();
 
-    private readonly InnerComboBox innerComboBox;
+  private readonly InnerComboBox innerComboBox;
 
-    private readonly InnerTextBox innerTextBox;
+  private readonly InnerTextBox innerTextBox;
 
-    private EditableComboBoxItem[] realizedItems = [];
+  private EditableComboBoxItem[] realizedItems = [];
 
-    static EditableComboBox()
+  static EditableComboBox()
+  {
+    ItemsControl.FocusableProperty.Unregister(typeof(EditableComboBox));
+    ItemsControl.IsTabStopProperty.Unregister(typeof(EditableComboBox));
+
+    InputElement.FocusableProperty.OverrideDefaultValue<EditableComboBox>(true);
+  }
+
+  public EditableComboBox()
+  {
+    this.innerTextBox = new InnerTextBox
     {
-        ItemsControl.FocusableProperty.Unregister(typeof(EditableComboBox));
-        ItemsControl.IsTabStopProperty.Unregister(typeof(EditableComboBox));
+      Name = "PART_InnerTextBox",
+      Focusable = true
+    };
+    this.BindProperty(this.innerTextBox, TextBox.TextProperty, "Value", true);
+    this.BindProperty(this.innerTextBox, TextBox.CaretIndexProperty, twoWay: true);
+    this.BindProperty(this.innerTextBox, TextBox.SelectionStartProperty, twoWay: true);
+    this.BindProperty(this.innerTextBox, TextBox.SelectionEndProperty, twoWay: true);
+    this.BindProperty(this.innerTextBox, TextBox.CaretBlinkIntervalProperty);
+    this.BindProperty(this.innerTextBox, TextBox.SelectionBrushProperty);
+    this.BindProperty(this.innerTextBox, TextBox.SelectionForegroundBrushProperty);
+    this.BindProperty(this.innerTextBox, TextBox.CaretBrushProperty);
 
-        InputElement.FocusableProperty.OverrideDefaultValue<EditableComboBox>(true);
-    }
+    this.innerTextBox.TextChanged += this.OnTextChanged;
+    this.GetObservable(WatermarkProperty).Subscribe(watermark => this.innerTextBox.Watermark = watermark);
 
-    public EditableComboBox()
+    this.innerComboBox = new InnerComboBox(this, this.innerTextBox)
     {
-        this.innerTextBox = new InnerTextBox
+      Name = "PART_InnerComboBox",
+      Focusable = false,
+      IsTabStop = false,
+      AutoScrollToSelectedItem = true,
+
+      ItemsSource = this.filteredItems
+    };
+
+    this.BindProperty(this.innerComboBox, ComboBox.IsDropDownOpenProperty, twoWay: true);
+    this.BindProperty(this.innerComboBox, InnerComboBox.FocusedBorderThicknessProperty, twoWay: false);
+    this.BindProperty(this.innerComboBox, InnerComboBox.MaxDropDownWidthProperty, twoWay: false);
+    this.BindProperty(this.innerComboBox, InnerComboBox.MaxDropDownHeightProperty, twoWay: false);
+    this.GetObservable(ModeProperty).Subscribe(mode => this.innerComboBox.ValueFilterDropdown = mode == EditableComboBoxMode.Filter);
+    this.innerComboBox.SelectionChanged += this.OnSelectionChanged;
+    this.innerComboBox.GetObservable(ComboBox.IsDropDownOpenProperty).Subscribe(this.OnInnerDropDownOpenChanged);
+
+    this.Template = new FuncControlTemplate((_, namescope) =>
+    {
+      this.innerTextBox.RegisterInNameScope(namescope);
+      this.innerComboBox.RegisterInNameScope(namescope);
+      return new DataValidationErrors
+      {
+        Content = this.innerComboBox,
+        ClipToBounds = false
+      };
+    });
+
+    this.Items.CollectionChanged += (_, _) => this.FillItems();
+    this.GetObservable(ItemsSourceProperty).Subscribe(_ => this.FillItems());
+    this.GetObservable(ValueProperty).Subscribe(_ => this.FilterItems());
+  }
+
+  public TimeSpan CaretBlinkInterval
+  {
+    get => this.GetValue(CaretBlinkIntervalProperty);
+    set => this.SetValue(CaretBlinkIntervalProperty, value);
+  }
+
+  public IBrush? CaretBrush
+  {
+    get => this.GetValue(CaretBrushProperty);
+    set => this.SetValue(CaretBrushProperty, value);
+  }
+
+  public int CaretIndex
+  {
+    get => this.GetValue(CaretIndexProperty);
+    set => this.SetValue(CaretIndexProperty, value);
+  }
+
+  public bool ClearOnOpen
+  {
+    get => this.GetValue(ClearOnOpenProperty);
+    set => this.SetValue(ClearOnOpenProperty, value);
+  }
+
+  public new bool Focusable
+  {
+    get => this.innerTextBox.Focusable;
+    set => this.innerTextBox.Focusable = value;
+  }
+
+
+  public Thickness FocusedBorderThickness
+  {
+    get => this.GetValue(FocusedBorderThicknessProperty);
+    set => this.SetValue(FocusedBorderThicknessProperty, value);
+  }
+
+  public IBrush? IconDefaultFill
+  {
+    get => this.GetValue(IconDefaultFillProperty);
+    set => this.SetValue(IconDefaultFillProperty, value);
+  }
+
+  public IEnumerable InnerLeftContent { get; set; } = new AvaloniaList<Control>();
+
+  public IEnumerable InnerRightContent { get; set; } = new AvaloniaList<Control>();
+
+  public bool IsDropDownOpen
+  {
+    get => this.GetValue(IsDropDownOpenProperty);
+    set => this.SetValue(IsDropDownOpenProperty, value);
+  }
+
+  public new bool IsTabStop
+  {
+    get => this.innerTextBox.IsTabStop;
+    set => this.innerTextBox.IsTabStop = value;
+  }
+
+  public double MaxDropDownHeight
+  {
+    get => this.GetValue(MaxDropDownHeightProperty);
+    set => this.SetValue(MaxDropDownHeightProperty, value);
+  }
+
+  public double MaxDropDownWidth
+  {
+    get => this.GetValue(MaxDropDownWidthProperty);
+    set => this.SetValue(MaxDropDownWidthProperty, value);
+  }
+
+  public int MaxLength
+  {
+    get => this.GetValue(MaxLengthProperty);
+    set => this.SetValue(MaxLengthProperty, value);
+  }
+
+  public EditableComboBoxMode Mode
+  {
+    get => this.GetValue(ModeProperty);
+    set => this.SetValue(ModeProperty, value);
+  }
+
+  public IBrush? SelectionBrush
+  {
+    get => this.GetValue(SelectionBrushProperty);
+    set => this.SetValue(SelectionBrushProperty, value);
+  }
+
+  public int SelectionEnd
+  {
+    get => this.GetValue(SelectionEndProperty);
+    set => this.SetValue(SelectionEndProperty, value);
+  }
+
+  public IBrush? SelectionForegroundBrush
+  {
+    get => this.GetValue(SelectionForegroundBrushProperty);
+    set => this.SetValue(SelectionForegroundBrushProperty, value);
+  }
+
+  public int SelectionStart
+  {
+    get => this.GetValue(SelectionStartProperty);
+    set => this.SetValue(SelectionStartProperty, value);
+  }
+
+  public string? Value
+  {
+    get => this.GetValue(ValueProperty);
+    set => this.SetValue(ValueProperty, value);
+  }
+
+  public string? Watermark
+  {
+    get => this.GetValue(WatermarkProperty);
+    set => this.SetValue(WatermarkProperty, value);
+  }
+
+  public new bool Focus(NavigationMethod method = NavigationMethod.Unspecified, KeyModifiers keyModifiers = KeyModifiers.None) =>
+    this.innerTextBox.Focus(method, keyModifiers);
+
+  internal bool UpdateValueFromItemPointerEvent(EditableComboBoxItem source, PointerEventArgs e)
+  {
+    this.Value = source.Value;
+    this.innerTextBox.SelectAll();
+    this.innerTextBox.Watermark = this.Watermark;
+    return true;
+  }
+
+  protected virtual string? CoerceText(string? value) =>
+    value;
+
+  protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
+  {
+    recycleKey = null;
+    return false;
+  }
+
+  protected override void OnGotFocus(GotFocusEventArgs e)
+  {
+    if (e.Handled) return;
+
+    if (e.Source is InnerTextBox) this.innerTextBox.Focus();
+  }
+
+  protected override void OnInitialized()
+  {
+    this.innerTextBox.Watermark = this.Watermark;
+    this.FillItems();
+  }
+
+  protected override void OnKeyDown(KeyEventArgs e)
+  {
+    base.OnKeyDown(e);
+
+    if (e.Handled) return;
+
+    bool isUp = e.Key == Key.Up;
+    bool isDown = e.Key == Key.Down;
+    bool isImmediate = this.Mode == EditableComboBoxMode.Immediate;
+
+    if (!this.IsDropDownOpen)
+      if (isDown || (isImmediate && isUp))
+      {
+        this.IsDropDownOpen = true;
+
+        if (isImmediate)
         {
-            Name = "PART_InnerTextBox",
-            Focusable = true,
-        };
-        this.BindProperty(this.innerTextBox, TextBox.TextProperty, "Value", true);
-        this.BindProperty(this.innerTextBox, TextBox.CaretIndexProperty, twoWay: true);
-        this.BindProperty(this.innerTextBox, TextBox.SelectionStartProperty, twoWay: true);
-        this.BindProperty(this.innerTextBox, TextBox.SelectionEndProperty, twoWay: true);
-        this.BindProperty(this.innerTextBox, TextBox.CaretBlinkIntervalProperty);
-        this.BindProperty(this.innerTextBox, TextBox.SelectionBrushProperty);
-        this.BindProperty(this.innerTextBox, TextBox.SelectionForegroundBrushProperty);
-        this.BindProperty(this.innerTextBox, TextBox.CaretBrushProperty);
+          if (isUp) this.HighlightPreviousItem();
 
-        this.innerTextBox.TextChanged += this.OnTextChanged;
-        this.GetObservable(WatermarkProperty).Subscribe(watermark => this.innerTextBox.Watermark = watermark);
-
-        this.innerComboBox = new InnerComboBox(this, this.innerTextBox)
-        {
-            Name = "PART_InnerComboBox",
-            Focusable = false,
-            IsTabStop = false,
-            AutoScrollToSelectedItem = true,
-
-            ItemsSource = this.filteredItems,
-        };
-
-        this.BindProperty(this.innerComboBox, ComboBox.IsDropDownOpenProperty, twoWay: true);
-        this.BindProperty(this.innerComboBox, InnerComboBox.FocusedBorderThicknessProperty, twoWay: false);
-        this.BindProperty(this.innerComboBox, InnerComboBox.MaxDropDownWidthProperty, twoWay: false);
-        this.BindProperty(this.innerComboBox, InnerComboBox.MaxDropDownHeightProperty, twoWay: false);
-        this.GetObservable(ModeProperty).Subscribe(mode => this.innerComboBox.ValueFilterDropdown = mode == EditableComboBoxMode.Filter);
-        this.innerComboBox.SelectionChanged += this.OnSelectionChanged;
-        this.innerComboBox.GetObservable(ComboBox.IsDropDownOpenProperty).Subscribe(this.OnInnerDropDownOpenChanged);
-
-        this.Template = new FuncControlTemplate((_, namescope) =>
-        {
-            this.innerTextBox.RegisterInNameScope(namescope);
-            this.innerComboBox.RegisterInNameScope(namescope);
-            return new DataValidationErrors
-            {
-                Content = this.innerComboBox,
-                ClipToBounds = false,
-            };
-        });
-
-        this.Items.CollectionChanged += (_, _) => this.FillItems();
-        this.GetObservable(ItemsSourceProperty).Subscribe(_ => this.FillItems());
-        this.GetObservable(ValueProperty).Subscribe(_ => this.FilterItems());
-    }
-
-    public TimeSpan CaretBlinkInterval
-    {
-        get => this.GetValue(CaretBlinkIntervalProperty);
-        set => this.SetValue(CaretBlinkIntervalProperty, value);
-    }
-
-    public IBrush? CaretBrush
-    {
-        get => this.GetValue(CaretBrushProperty);
-        set => this.SetValue(CaretBrushProperty, value);
-    }
-
-    public int CaretIndex
-    {
-        get => this.GetValue(CaretIndexProperty);
-        set => this.SetValue(CaretIndexProperty, value);
-    }
-
-    public bool ClearOnOpen
-    {
-        get => this.GetValue(ClearOnOpenProperty);
-        set => this.SetValue(ClearOnOpenProperty, value);
-    }
-
-    public new bool Focusable
-    {
-        get => this.innerTextBox.Focusable;
-        set => this.innerTextBox.Focusable = value;
-    }
-
-    public Thickness FocusedBorderThickness
-    {
-        get => this.GetValue(FocusedBorderThicknessProperty);
-        set => this.SetValue(FocusedBorderThicknessProperty, value);
-    }
-
-    public IBrush? IconDefaultFill
-    {
-        get => this.GetValue(IconDefaultFillProperty);
-        set => this.SetValue(IconDefaultFillProperty, value);
-    }
-
-    public IEnumerable InnerLeftContent { get; set; } = new AvaloniaList<Control>();
-
-    public IEnumerable InnerRightContent { get; set; } = new AvaloniaList<Control>();
-
-    public bool IsDropDownOpen
-    {
-        get => this.GetValue(IsDropDownOpenProperty);
-        set => this.SetValue(IsDropDownOpenProperty, value);
-    }
-
-    public new bool IsTabStop
-    {
-        get => this.innerTextBox.IsTabStop;
-        set => this.innerTextBox.IsTabStop = value;
-    }
-
-    public double MaxDropDownHeight
-    {
-        get => this.GetValue(MaxDropDownHeightProperty);
-        set => this.SetValue(MaxDropDownHeightProperty, value);
-    }
-
-    public double MaxDropDownWidth
-    {
-        get => this.GetValue(MaxDropDownWidthProperty);
-        set => this.SetValue(MaxDropDownWidthProperty, value);
-    }
-
-    public int MaxLength
-    {
-        get => this.GetValue(MaxLengthProperty);
-        set => this.SetValue(MaxLengthProperty, value);
-    }
-
-    public EditableComboBoxMode Mode
-    {
-        get => this.GetValue(ModeProperty);
-        set => this.SetValue(ModeProperty, value);
-    }
-
-    public IBrush? SelectionBrush
-    {
-        get => this.GetValue(SelectionBrushProperty);
-        set => this.SetValue(SelectionBrushProperty, value);
-    }
-
-    public int SelectionEnd
-    {
-        get => this.GetValue(SelectionEndProperty);
-        set => this.SetValue(SelectionEndProperty, value);
-    }
-
-    public IBrush? SelectionForegroundBrush
-    {
-        get => this.GetValue(SelectionForegroundBrushProperty);
-        set => this.SetValue(SelectionForegroundBrushProperty, value);
-    }
-
-    public int SelectionStart
-    {
-        get => this.GetValue(SelectionStartProperty);
-        set => this.SetValue(SelectionStartProperty, value);
-    }
-
-    public string? Value
-    {
-        get => this.GetValue(ValueProperty);
-        set => this.SetValue(ValueProperty, value);
-    }
-
-    public string? Watermark
-    {
-        get => this.GetValue(WatermarkProperty);
-        set => this.SetValue(WatermarkProperty, value);
-    }
-
-    public new bool Focus(NavigationMethod method = NavigationMethod.Unspecified, KeyModifiers keyModifiers = KeyModifiers.None) =>
-        this.innerTextBox.Focus(method, keyModifiers);
-
-    internal bool UpdateValueFromItemPointerEvent(EditableComboBoxItem source, PointerEventArgs e)
-    {
-        this.Value = source.Value;
-        this.innerTextBox.SelectAll();
-        this.innerTextBox.Watermark = this.Watermark;
-        return true;
-    }
-
-    protected virtual string? CoerceText(string? value) =>
-        value;
-
-    protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
-    {
-        recycleKey = null;
-        return false;
-    }
-
-    protected override void OnGotFocus(GotFocusEventArgs e)
-    {
-        if (e.Handled) return;
-
-        if (e.Source is InnerTextBox) this.innerTextBox.Focus();
-    }
-
-    protected override void OnInitialized()
-    {
-        this.innerTextBox.Watermark = this.Watermark;
-        this.FillItems();
-    }
-
-    protected override void OnKeyDown(KeyEventArgs e)
-    {
-        base.OnKeyDown(e);
-
-        if (e.Handled) return;
-
-        var isUp = e.Key == Key.Up;
-        var isDown = e.Key == Key.Down;
-        var isImmediate = this.Mode == EditableComboBoxMode.Immediate;
-
-        if (!this.IsDropDownOpen)
-            if (isDown || (isImmediate && isUp))
-            {
-                this.IsDropDownOpen = true;
-
-                if (isImmediate)
-                {
-                    if (isUp) this.HighlightPreviousItem();
-
-                    if (isDown) this.HighlightNextItem();
-                }
-                else if (this.innerComboBox.SelectedIndex == -1)
-                {
-                    this.innerComboBox.SelectedIndex = 0;
-                }
-
-                e.Handled = true;
-                return;
-            }
-
-        if (this.IsDropDownOpen)
-        {
-            if (e.Key == Key.Escape)
-            {
-                this.IsDropDownOpen = false;
-                e.Handled = true;
-            }
-            else if (isUp)
-            {
-                this.HighlightPreviousItem();
-                e.Handled = true;
-            }
-            else if (isDown)
-            {
-                this.HighlightNextItem();
-                e.Handled = true;
-            }
-            else if (e.Key == Key.Enter || e.Key == Key.Tab)
-            {
-                if (this.innerComboBox.SelectedIndex >= 0)
-                {
-                    this.Value = this.GetSelectedItemValue();
-                    this.innerTextBox.SelectAll();
-                }
-
-                this.innerTextBox.Watermark = this.Watermark;
-                this.IsDropDownOpen = false;
-
-                if (e.Key == Key.Enter)
-                {
-                    e.Handled = true;
-                }
-                else if (e.Key == Key.Tab)
-                {
-                    var direction = e.Key.ToNavigationDirection(e.KeyModifiers);
-                    if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next))
-                    {
-                        Visual? containerChild = this;
-                        while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
-                               (containerChild = container as Visual) != null)
-                        {
-                            var nextControl = GetNextControl(container, dir, this, false);
-                            if (nextControl is not null)
-                            {
-                                e.Handled = true;
-                                nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                                return;
-                            }
-                        }
-                    }
-                }
-            }
-
-            this.Focus();
+          if (isDown) this.HighlightNextItem();
         }
-    }
-
-    protected override void OnPointerPressed(PointerPressedEventArgs e)
-    {
-        base.OnPointerPressed(e);
-        if (!e.Handled && e.Source is Visual source)
-            if (this.innerComboBox._popup?.IsInsidePopup(source) == true)
-            {
-                e.Handled = true;
-                return;
-            }
-
-        if (this.IsDropDownOpen)
+        else if (this.innerComboBox.SelectedIndex == -1)
         {
-            // When a drop-down is open with OverlayDismissEventPassThrough enabled and the control
-            // is pressed, close the drop-down
-            this.IsDropDownOpen = false;
-            e.Handled = true;
-        }
-        else
-        {
-            this.PseudoClasses.Set(PC_Pressed, true);
-        }
-    }
-
-    protected override void OnPointerReleased(PointerReleasedEventArgs e)
-    {
-        if (!e.Handled && e.Source is Visual source)
-        {
-            if (this.innerComboBox._popup?.IsInsidePopup(source) == true)
-            {
-                this.innerComboBox._popup.Close();
-                e.Handled = true;
-            }
-            else if (this.PseudoClasses.Contains(PC_Pressed))
-            {
-                var newIsOpen = !this.IsDropDownOpen;
-                this.IsDropDownOpen = newIsOpen;
-                e.Handled = true;
-            }
+          this.innerComboBox.SelectedIndex = 0;
         }
 
-        this.PseudoClasses.Set(PC_Pressed, false);
-        base.OnPointerReleased(e);
-    }
+        e.Handled = true;
+        return;
+      }
 
-    private static string? CoerceText(AvaloniaObject sender, string? value) =>
-        ((EditableComboBox)sender).CoerceText(value);
-
-    private void BindProperty(AvaloniaObject target, AvaloniaProperty property, string? path = null, bool twoWay = false)
+    if (this.IsDropDownOpen)
     {
-        target[!property] = this.CreateRelativeBinding(path ?? property.Name, twoWay);
-    }
-
-    private Binding CreateRelativeBinding(string path, bool twoWay = false) =>
-        new(path, twoWay ? BindingMode.TwoWay : BindingMode.OneWay)
-        {
-            RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
-            {
-                AncestorType = typeof(EditableComboBox),
-            },
-        };
-
-    private void FillItems()
-    {
-        if (!this.IsInitialized) return;
-
-        this.realizedItems = new EditableComboBoxItem[this.ItemsView.Count];
-        for (var i = 0; i < this.ItemsView.Count; ++i)
-        {
-            var item = this.ItemsView[i];
-
-            this.realizedItems[i] = item as EditableComboBoxItem
-                                    ?? new EditableComboBoxItem
-                                    {
-                                        Value = item?.ToString() ?? string.Empty,
-                                        DataContext = item,
-                                    };
-        }
-
-        this.filteredItems.Clear();
-
-        // FIXME: Clone is currently required to fix an issue where the InnerComboBox would not re-attach the items
-        //        to it's visual tree when an item that was already added to it is removed and then the same instance is
-        //        re-added (which is what we do when filtering).
-        //
-        //        It would be great if we could find a better way to do this without additional memory allocation.
-        //        - sbergerondrouin 2025-05-09
-        this.filteredItems.AddRange(this.realizedItems.Select(static i => i.Clone()));
-    }
-
-    private void FilterItems()
-    {
-        if (this.Mode != EditableComboBoxMode.Filter) return;
-
-        var trimmedSearch = this.Value?.Trim() ?? string.Empty;
-        this.filteredItems.Clear();
-
-        // See above comment in `FillItems` about cloning
-        this.filteredItems.AddRange(
-            this.realizedItems.Select(item =>
-                string.IsNullOrEmpty(trimmedSearch) || item.Value.Contains(trimmedSearch, StringComparison.OrdinalIgnoreCase)
-                    ? item.Clone()
-                    : null).SkipNulls());
-    }
-
-    private string? GetSelectedItemValue() =>
-        (this.innerComboBox.SelectedItem as EditableComboBoxItem)?.Value ?? this.innerComboBox.SelectedItem?.ToString();
-
-    private void HighlightNextItem()
-    {
-        var isFirst = true;
-        while (this.innerComboBox.SelectedIndex < this.filteredItems.Count - 1)
-        {
-            // NOTE: Setting SelectedIndex to an out-of-bound value will actually result in Avalonia setting the SelectedIndex
-            //       to -1, which would break this logic (we would always be < Count -1).
-            if (isFirst == false && this.innerComboBox.SelectedIndex < 0) return;
-
-            isFirst = false;
-
-            this.innerComboBox.SelectedIndex += 1;
-            var container = this.innerComboBox.ContainerFromIndex(this.innerComboBox.SelectedIndex);
-            if (container?.IsEnabled == true && container.IsVisible) break;
-        }
-
-        if (this.Mode == EditableComboBoxMode.Immediate) this.innerTextBox.SelectAll();
-    }
-
-    private void HighlightPreviousItem()
-    {
-        while (this.innerComboBox.SelectedIndex > 0)
-        {
-            this.innerComboBox.SelectedIndex -= 1;
-            var container = this.innerComboBox.ContainerFromIndex(this.innerComboBox.SelectedIndex);
-            if (container?.IsEnabled == true && container.IsVisible) break;
-        }
-
-        if (this.Mode == EditableComboBoxMode.Immediate) this.innerTextBox.SelectAll();
-    }
-
-    private void OnCloseMenu()
-    {
-        this.innerTextBox.Watermark = this.Watermark;
-    }
-
-    private void OnInnerDropDownOpenChanged(bool value)
-    {
-        if (!this.IsInitialized) return;
-
-        if (value)
-            this.OnOpenMenu();
-        else
-            this.OnCloseMenu();
-    }
-
-    private void OnOpenMenu()
-    {
-        this.FilterItems();
-        if (this.ClearOnOpen)
-            this.innerComboBox.SelectedIndex = -1;
-        else
-            this.SelectItemFromText();
-
-        this.Focus();
-    }
-
-    private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
-    {
+      if (e.Key == Key.Escape)
+      {
+        this.IsDropDownOpen = false;
+        e.Handled = true;
+      }
+      else if (isUp)
+      {
+        this.HighlightPreviousItem();
+        e.Handled = true;
+      }
+      else if (isDown)
+      {
+        this.HighlightNextItem();
+        e.Handled = true;
+      }
+      else if (e.Key == Key.Enter || e.Key == Key.Tab)
+      {
         if (this.innerComboBox.SelectedIndex >= 0)
-            this.innerTextBox.Watermark = this.GetSelectedItemValue();
-        else
-            this.innerTextBox.Watermark = this.Watermark;
-
-        if (this.Mode == EditableComboBoxMode.Immediate && this.innerComboBox.SelectedIndex >= 0)
         {
-            this.Value = this.GetSelectedItemValue();
-            this.innerTextBox.Watermark = this.Watermark;
-        }
-    }
-
-    private void OnTextChanged(object? sender, TextChangedEventArgs e)
-    {
-        this.SelectItemFromText();
-    }
-
-    private void SelectItemFromText()
-    {
-        if (string.IsNullOrEmpty(this.Value))
-        {
-            this.innerComboBox.SelectedIndex = -1;
-            this.innerTextBox.Watermark = this.Watermark;
-            return;
+          this.Value = this.GetSelectedItemValue();
+          this.innerTextBox.SelectAll();
         }
 
-        foreach (var item in this.innerComboBox.ItemsView)
-        {
-            var editableComboBoxItem = item as EditableComboBoxItem;
-            if (editableComboBoxItem?.Value == this.Value || (editableComboBoxItem is null && item?.ToString() == this.Value))
-            {
-                this.innerComboBox.SelectedItem = item;
-                return;
-            }
-        }
-
-        this.innerComboBox.SelectedIndex = -1;
         this.innerTextBox.Watermark = this.Watermark;
+        this.IsDropDownOpen = false;
+
+        if (e.Key == Key.Enter)
+        {
+          e.Handled = true;
+        }
+        else if (e.Key == Key.Tab)
+        {
+          NavigationDirection? direction = e.Key.ToNavigationDirection(e.KeyModifiers);
+          if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next))
+          {
+            Visual? containerChild = this;
+            while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
+                   (containerChild = container as Visual) != null)
+            {
+              IInputElement? nextControl = GetNextControl(container, dir, this, false);
+              if (nextControl is not null)
+              {
+                e.Handled = true;
+                nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
+                return;
+              }
+            }
+          }
+        }
+      }
+
+      this.Focus();
     }
+  }
+
+  protected override void OnPointerPressed(PointerPressedEventArgs e)
+  {
+    base.OnPointerPressed(e);
+    if (!e.Handled && e.Source is Visual source)
+      if (this.innerComboBox._popup?.IsInsidePopup(source) == true)
+      {
+        e.Handled = true;
+        return;
+      }
+
+    if (this.IsDropDownOpen)
+    {
+      // When a drop-down is open with OverlayDismissEventPassThrough enabled and the control
+      // is pressed, close the drop-down
+      this.IsDropDownOpen = false;
+      e.Handled = true;
+    }
+    else
+    {
+      this.PseudoClasses.Set(PC_Pressed, true);
+    }
+  }
+
+  protected override void OnPointerReleased(PointerReleasedEventArgs e)
+  {
+    if (!e.Handled && e.Source is Visual source)
+    {
+      if (this.innerComboBox._popup?.IsInsidePopup(source) == true)
+      {
+        this.innerComboBox._popup.Close();
+        e.Handled = true;
+      }
+      else if (this.PseudoClasses.Contains(PC_Pressed))
+      {
+        bool newIsOpen = !this.IsDropDownOpen;
+        this.IsDropDownOpen = newIsOpen;
+        e.Handled = true;
+      }
+    }
+
+    this.PseudoClasses.Set(PC_Pressed, false);
+    base.OnPointerReleased(e);
+  }
+
+  private static string? CoerceText(AvaloniaObject sender, string? value) =>
+    ((EditableComboBox)sender).CoerceText(value);
+
+  private void BindProperty(AvaloniaObject target, AvaloniaProperty property, string? path = null, bool twoWay = false)
+  {
+    target[!property] = this.CreateRelativeBinding(path ?? property.Name, twoWay);
+  }
+
+  private Binding CreateRelativeBinding(string path, bool twoWay = false) =>
+    new(path, twoWay ? BindingMode.TwoWay : BindingMode.OneWay)
+    {
+      RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+      {
+        AncestorType = typeof(EditableComboBox)
+      }
+    };
+
+  private void FillItems()
+  {
+    if (!this.IsInitialized) return;
+
+    this.realizedItems = new EditableComboBoxItem[this.ItemsView.Count];
+    for (int i = 0; i < this.ItemsView.Count; ++i)
+    {
+      object? item = this.ItemsView[i];
+
+      this.realizedItems[i] = item as EditableComboBoxItem
+                              ?? new EditableComboBoxItem
+                              {
+                                Value = item?.ToString() ?? string.Empty,
+                                DataContext = item
+                              };
+    }
+
+    this.filteredItems.Clear();
+
+    // FIXME: Clone is currently required to fix an issue where the InnerComboBox would not re-attach the items
+    //        to it's visual tree when an item that was already added to it is removed and then the same instance is
+    //        re-added (which is what we do when filtering).
+    //
+    //        It would be great if we could find a better way to do this without additional memory allocation.
+    //        - sbergerondrouin 2025-05-09
+    this.filteredItems.AddRange(this.realizedItems.Select(static i => i.Clone()));
+  }
+
+  private void FilterItems()
+  {
+    if (this.Mode != EditableComboBoxMode.Filter) return;
+
+    string trimmedSearch = this.Value?.Trim() ?? string.Empty;
+    this.filteredItems.Clear();
+
+    // See above comment in `FillItems` about cloning
+    this.filteredItems.AddRange(
+      this.realizedItems.Select(item =>
+        string.IsNullOrEmpty(trimmedSearch) || item.Value.Contains(trimmedSearch, StringComparison.OrdinalIgnoreCase)
+          ? item.Clone()
+          : null).SkipNulls());
+  }
+
+  private string? GetSelectedItemValue() =>
+    (this.innerComboBox.SelectedItem as EditableComboBoxItem)?.Value ?? this.innerComboBox.SelectedItem?.ToString();
+
+  private void HighlightNextItem()
+  {
+    bool isFirst = true;
+    while (this.innerComboBox.SelectedIndex < this.filteredItems.Count - 1)
+    {
+      // NOTE: Setting SelectedIndex to an out-of-bound value will actually result in Avalonia setting the SelectedIndex
+      //       to -1, which would break this logic (we would always be < Count -1).
+      if (isFirst == false && this.innerComboBox.SelectedIndex < 0) return;
+
+      isFirst = false;
+
+      this.innerComboBox.SelectedIndex += 1;
+      Control? container = this.innerComboBox.ContainerFromIndex(this.innerComboBox.SelectedIndex);
+      if (container?.IsEnabled == true && container.IsVisible) break;
+    }
+
+    if (this.Mode == EditableComboBoxMode.Immediate) this.innerTextBox.SelectAll();
+  }
+
+  private void HighlightPreviousItem()
+  {
+    while (this.innerComboBox.SelectedIndex > 0)
+    {
+      this.innerComboBox.SelectedIndex -= 1;
+      Control? container = this.innerComboBox.ContainerFromIndex(this.innerComboBox.SelectedIndex);
+      if (container?.IsEnabled == true && container.IsVisible) break;
+    }
+
+    if (this.Mode == EditableComboBoxMode.Immediate) this.innerTextBox.SelectAll();
+  }
+
+  private void OnCloseMenu()
+  {
+    this.innerTextBox.Watermark = this.Watermark;
+  }
+
+  private void OnInnerDropDownOpenChanged(bool value)
+  {
+    if (!this.IsInitialized) return;
+
+    if (value)
+      this.OnOpenMenu();
+    else
+      this.OnCloseMenu();
+  }
+
+  private void OnOpenMenu()
+  {
+    this.FilterItems();
+    if (this.ClearOnOpen)
+      this.innerComboBox.SelectedIndex = -1;
+    else
+      this.SelectItemFromText();
+
+    this.Focus();
+  }
+
+  private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+  {
+    if (this.innerComboBox.SelectedIndex >= 0)
+      this.innerTextBox.Watermark = this.GetSelectedItemValue();
+    else
+      this.innerTextBox.Watermark = this.Watermark;
+
+    if (this.Mode == EditableComboBoxMode.Immediate && this.innerComboBox.SelectedIndex >= 0)
+    {
+      this.Value = this.GetSelectedItemValue();
+      this.innerTextBox.Watermark = this.Watermark;
+    }
+  }
+
+  private void OnTextChanged(object? sender, TextChangedEventArgs e)
+  {
+    this.SelectItemFromText();
+  }
+
+  private void SelectItemFromText()
+  {
+    if (string.IsNullOrEmpty(this.Value))
+    {
+      this.innerComboBox.SelectedIndex = -1;
+      this.innerTextBox.Watermark = this.Watermark;
+      return;
+    }
+
+    foreach (object? item in this.innerComboBox.ItemsView)
+    {
+      EditableComboBoxItem? editableComboBoxItem = item as EditableComboBoxItem;
+      if (editableComboBoxItem?.Value == this.Value || (editableComboBoxItem is null && item?.ToString() == this.Value))
+      {
+        this.innerComboBox.SelectedItem = item;
+        return;
+      }
+    }
+
+    this.innerComboBox.SelectedIndex = -1;
+    this.innerTextBox.Watermark = this.Watermark;
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
@@ -8,122 +8,124 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Metadata;
+using Avalonia.Platform;
 using Avalonia.VisualTree;
 
 public class EditableComboBoxItem : TemplatedControl, ISelectable
 {
-    public static readonly StyledProperty<string?> FilterHighlightTextProperty =
-        AvaloniaProperty.Register<EditableComboBoxItem, string?>(nameof(FilterHighlightText));
+  public static readonly StyledProperty<string?> FilterHighlightTextProperty =
+    AvaloniaProperty.Register<EditableComboBoxItem, string?>(nameof(FilterHighlightText));
 
-    public static readonly StyledProperty<bool> IsSelectedProperty = SelectingItemsControl.IsSelectedProperty.AddOwner<EditableComboBoxItem>();
+  public static readonly StyledProperty<bool> IsSelectedProperty = SelectingItemsControl.IsSelectedProperty.AddOwner<EditableComboBoxItem>();
 
-    public static readonly StyledProperty<string> ValueProperty =
-        AvaloniaProperty.Register<EditableComboBoxItem, string>(nameof(Value), defaultBindingMode: BindingMode.OneTime);
+  public static readonly StyledProperty<string> ValueProperty =
+    AvaloniaProperty.Register<EditableComboBoxItem, string>(nameof(Value), defaultBindingMode: BindingMode.OneTime);
 
-    private static readonly Point invalidPoint = new(double.NaN, double.NaN);
+  private static readonly Point invalidPoint = new(double.NaN, double.NaN);
 
-    private Point pointerDownPoint = invalidPoint;
+  private Point pointerDownPoint = invalidPoint;
 
-    public EditableComboBoxItem() { }
+  public EditableComboBoxItem() { }
 
-    public EditableComboBoxItem(EditableComboBoxItem toClone)
+  public EditableComboBoxItem(EditableComboBoxItem toClone)
+  {
+    this.Value = toClone.Value;
+  }
+
+  public string? FilterHighlightText
+  {
+    get => this.GetValue(FilterHighlightTextProperty);
+    set => this.SetValue(FilterHighlightTextProperty, value);
+  }
+
+  public bool IsSelected
+  {
+    get => this.GetValue(IsSelectedProperty);
+    set => this.SetValue(IsSelectedProperty, value);
+  }
+
+  [Content]
+  public required string Value
+  {
+    get => this.GetValue(ValueProperty);
+    set => this.SetValue(ValueProperty, value);
+  }
+
+
+  public EditableComboBoxItem Clone() =>
+    new(this)
     {
-        this.Value = toClone.Value;
-    }
+      Value = this.Value
+    };
 
-    public string? FilterHighlightText
+  public override string ToString() =>
+    this.Value;
+
+  protected override void OnPointerPressed(PointerPressedEventArgs e)
+  {
+    base.OnPointerPressed(e);
+
+    this.pointerDownPoint = invalidPoint;
+
+    if (!e.Handled && this.GetOwner() is { } owner)
     {
-        get => this.GetValue(FilterHighlightTextProperty);
-        set => this.SetValue(FilterHighlightTextProperty, value);
-    }
+      PointerPoint p = e.GetCurrentPoint(this);
 
-    public bool IsSelected
+      if (p.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.RightButtonPressed)
+      {
+        if (p.Pointer.Type == PointerType.Mouse)
+          // If the pressed point comes from a mouse, perform the selection immediately.
+          e.Handled = owner.UpdateValueFromItemPointerEvent(this, e);
+        else
+          // Otherwise perform the selection when the pointer is released as to not
+          // interfere with gestures.
+          this.pointerDownPoint = p.Position;
+        // Ideally we'd set handled here, but that would prevent the scroll gesture
+        // recognizer from working.
+        ////e.Handled = true;
+      }
+    }
+  }
+
+  protected override void OnPointerReleased(PointerReleasedEventArgs e)
+  {
+    base.OnPointerReleased(e);
+
+    if (!e.Handled && !double.IsNaN(this.pointerDownPoint.X) && e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right)
     {
-        get => this.GetValue(IsSelectedProperty);
-        set => this.SetValue(IsSelectedProperty, value);
-    }
+      PointerPoint point = e.GetCurrentPoint(this);
+      IPlatformSettings? settings = TopLevel.GetTopLevel(e.Source as Visual)?.PlatformSettings;
+      Size tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
+      Rect tapRect = new Rect(this.pointerDownPoint, new Size()).Inflate(new Thickness(tapSize.Width, tapSize.Height));
 
-    [Content]
-    public required string Value
-    {
-        get => this.GetValue(ValueProperty);
-        set => this.SetValue(ValueProperty, value);
-    }
-
-    public EditableComboBoxItem Clone() =>
-        new(this)
+      if (new Rect(this.Bounds.Size).ContainsExclusive(point.Position) && tapRect.ContainsExclusive(point.Position) &&
+          this.GetOwner() is { } owner)
+        if (owner.UpdateValueFromItemPointerEvent(this, e))
         {
-            Value = this.Value,
-        };
+          // As we only update selection from touch/pen on pointer release, we need to raise
+          // the pointer event on the owner to trigger a commit.
+          if (e.Pointer.Type != PointerType.Mouse)
+          {
+            object? sourceBackup = e.Source;
+            owner.RaiseEvent(e);
+            e.Source = sourceBackup;
+          }
 
-    public override string ToString() =>
-        this.Value;
-
-    protected override void OnPointerPressed(PointerPressedEventArgs e)
-    {
-        base.OnPointerPressed(e);
-
-        this.pointerDownPoint = invalidPoint;
-
-        if (!e.Handled && this.GetOwner() is { } owner)
-        {
-            var p = e.GetCurrentPoint(this);
-
-            if (p.Properties.PointerUpdateKind is PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.RightButtonPressed)
-            {
-                if (p.Pointer.Type == PointerType.Mouse)
-                    // If the pressed point comes from a mouse, perform the selection immediately.
-                    e.Handled = owner.UpdateValueFromItemPointerEvent(this, e);
-                else
-                    // Otherwise perform the selection when the pointer is released as to not
-                    // interfere with gestures.
-                    this.pointerDownPoint = p.Position;
-                // Ideally we'd set handled here, but that would prevent the scroll gesture
-                // recognizer from working.
-                ////e.Handled = true;
-            }
+          e.Handled = true;
         }
     }
 
-    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    this.pointerDownPoint = invalidPoint;
+  }
+
+  private EditableComboBox? GetOwner()
+  {
+    object? container = ItemsControl.ItemsControlFromItemContainer(this);
+    return container switch
     {
-        base.OnPointerReleased(e);
-
-        if (!e.Handled && !double.IsNaN(this.pointerDownPoint.X) && e.InitialPressMouseButton is MouseButton.Left or MouseButton.Right)
-        {
-            var point = e.GetCurrentPoint(this);
-            var settings = TopLevel.GetTopLevel(e.Source as Visual)?.PlatformSettings;
-            var tapSize = settings?.GetTapSize(point.Pointer.Type) ?? new Size(4, 4);
-            var tapRect = new Rect(this.pointerDownPoint, new Size()).Inflate(new Thickness(tapSize.Width, tapSize.Height));
-
-            if (new Rect(this.Bounds.Size).ContainsExclusive(point.Position) && tapRect.ContainsExclusive(point.Position) &&
-                this.GetOwner() is { } owner)
-                if (owner.UpdateValueFromItemPointerEvent(this, e))
-                {
-                    // As we only update selection from touch/pen on pointer release, we need to raise
-                    // the pointer event on the owner to trigger a commit.
-                    if (e.Pointer.Type != PointerType.Mouse)
-                    {
-                        var sourceBackup = e.Source;
-                        owner.RaiseEvent(e);
-                        e.Source = sourceBackup;
-                    }
-
-                    e.Handled = true;
-                }
-        }
-
-        this.pointerDownPoint = invalidPoint;
-    }
-
-    private EditableComboBox? GetOwner()
-    {
-        object? container = ItemsControl.ItemsControlFromItemContainer(this);
-        return container switch
-        {
-            EditableComboBox c => c,
-            ComboBox innerComboBox => innerComboBox.FindAncestorOfType<EditableComboBox>(),
-            _ => this.Parent as EditableComboBox,
-        };
-    }
+      EditableComboBox c => c,
+      ComboBox innerComboBox => innerComboBox.FindAncestorOfType<EditableComboBox>(),
+      _ => this.Parent as EditableComboBox
+    };
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxMode.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxMode.cs
@@ -2,9 +2,9 @@ namespace Devolutions.AvaloniaControls.Controls;
 
 public enum EditableComboBoxMode
 {
-    Normal = 0,
+  Normal = 0,
 
-    Immediate = 1,
+  Immediate = 1,
 
-    Filter = 2,
+  Filter = 2
 }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
@@ -8,456 +8,457 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Platform;
 using Avalonia.VisualTree;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
 public partial class EditableComboBox
 {
-    [TemplatePart("PART_TextBoxPresenter", typeof(ContentPresenter), IsRequired = true)]
-    [TemplatePart("PART_Popup", typeof(Popup), IsRequired = true)]
-    [TemplatePart("PART_InnerLeftContent", typeof(ItemsControl), IsRequired = true)]
-    [TemplatePart("PART_InnerRightContent", typeof(ItemsControl), IsRequired = true)]
-    [PseudoClasses(":dropdown-open-from-top", ":dropdown-overflow-left", ":dropdown-overflow-right", ":is-split-between-screens")]
-    public sealed class InnerComboBox : ComboBox, INavigableContainer
+  [TemplatePart("PART_TextBoxPresenter", typeof(ContentPresenter), IsRequired = true)]
+  [TemplatePart("PART_Popup", typeof(Popup), IsRequired = true)]
+  [TemplatePart("PART_InnerLeftContent", typeof(ItemsControl), IsRequired = true)]
+  [TemplatePart("PART_InnerRightContent", typeof(ItemsControl), IsRequired = true)]
+  [PseudoClasses(":dropdown-open-from-top", ":dropdown-overflow-left", ":dropdown-overflow-right", ":is-split-between-screens")]
+  public sealed class InnerComboBox : ComboBox, INavigableContainer
+  {
+    public static readonly StyledProperty<Thickness> FocusedBorderThicknessProperty = AvaloniaProperty.Register<InnerComboBox, Thickness>(
+      nameof(FocusedBorderThickness),
+      Application.Current?.FindResource("TextControlBorderThemeThicknessFocused") as Thickness? ?? new Thickness(2));
+
+    public static readonly DirectProperty<InnerComboBox, IEnumerable> InnerLeftContentProperty =
+      AvaloniaProperty.RegisterDirect<InnerComboBox, IEnumerable>(
+        nameof(InnerLeftContent),
+        static o => o.InnerLeftContent,
+        static (o, v) => o.InnerLeftContent = v);
+
+    public static readonly DirectProperty<InnerComboBox, IEnumerable> InnerRightContentProperty =
+      AvaloniaProperty.RegisterDirect<InnerComboBox, IEnumerable>(
+        nameof(InnerRightContent),
+        static o => o.InnerRightContent,
+        static (o, v) => o.InnerRightContent = v);
+
+    public static readonly StyledProperty<double> MaxDropDownWidthProperty =
+      AvaloniaProperty.Register<InnerComboBox, double>(nameof(MaxDropDownWidth));
+
+    public static readonly StyledProperty<Thickness> PopupBorderMaskMarginProperty =
+      AvaloniaProperty.Register<InnerComboBox, Thickness>(nameof(PopupBorderMaskMargin));
+
+    public static readonly StyledProperty<double> PopupBorderMaskWidthProperty =
+      AvaloniaProperty.Register<InnerComboBox, double>(nameof(PopupBorderMaskWidth));
+
+    public static readonly StyledProperty<bool> ValueFilterDropdownProperty =
+      AvaloniaProperty.Register<InnerComboBox, bool>(nameof(ValueFilterDropdown));
+
+    private readonly EditableComboBox parent;
+
+    private ItemsControl? innerLeftContentControl;
+
+    private ItemsControl? innerRightContentControl;
+
+    private IDisposable? popupChildBoundSubscription;
+
+    private IDisposable? popupChildSubscription;
+
+    private ContentPresenter? textboxContentPresenter;
+
+    public InnerComboBox(EditableComboBox parent, InnerTextBox innerTextBox)
     {
-        public static readonly StyledProperty<Thickness> FocusedBorderThicknessProperty = AvaloniaProperty.Register<InnerComboBox, Thickness>(
-            nameof(FocusedBorderThickness),
-            Application.Current?.FindResource("TextControlBorderThemeThicknessFocused") as Thickness? ?? new Thickness(2));
+      this.parent = parent;
+      this._innerTextBox = innerTextBox;
 
-        public static readonly DirectProperty<InnerComboBox, IEnumerable> InnerLeftContentProperty =
-            AvaloniaProperty.RegisterDirect<InnerComboBox, IEnumerable>(
-                nameof(InnerLeftContent),
-                static o => o.InnerLeftContent,
-                static (o, v) => o.InnerLeftContent = v);
-
-        public static readonly DirectProperty<InnerComboBox, IEnumerable> InnerRightContentProperty =
-            AvaloniaProperty.RegisterDirect<InnerComboBox, IEnumerable>(
-                nameof(InnerRightContent),
-                static o => o.InnerRightContent,
-                static (o, v) => o.InnerRightContent = v);
-
-        public static readonly StyledProperty<double> MaxDropDownWidthProperty =
-            AvaloniaProperty.Register<InnerComboBox, double>(nameof(MaxDropDownWidth));
-
-        public static readonly StyledProperty<Thickness> PopupBorderMaskMarginProperty =
-            AvaloniaProperty.Register<InnerComboBox, Thickness>(nameof(PopupBorderMaskMargin));
-
-        public static readonly StyledProperty<double> PopupBorderMaskWidthProperty =
-            AvaloniaProperty.Register<InnerComboBox, double>(nameof(PopupBorderMaskWidth));
-
-        public static readonly StyledProperty<bool> ValueFilterDropdownProperty =
-            AvaloniaProperty.Register<InnerComboBox, bool>(nameof(ValueFilterDropdown));
-
-        private readonly EditableComboBox parent;
-
-        private ItemsControl? innerLeftContentControl;
-
-        private ItemsControl? innerRightContentControl;
-
-        private IDisposable? popupChildBoundSubscription;
-
-        private IDisposable? popupChildSubscription;
-
-        private ContentPresenter? textboxContentPresenter;
-
-        public InnerComboBox(EditableComboBox parent, InnerTextBox innerTextBox)
+      this.GetObservable(FocusedBorderThicknessProperty).Subscribe(v => this.CalculatePopupBorderMask(v, null));
+      this.GetObservable(BoundsProperty)
+        .Subscribe(v =>
         {
-            this.parent = parent;
-            this._innerTextBox = innerTextBox;
-
-            this.GetObservable(FocusedBorderThicknessProperty).Subscribe(v => this.CalculatePopupBorderMask(v, null));
-            this.GetObservable(BoundsProperty)
-                .Subscribe(v =>
-                {
-                    this.CalculatePopupBorderMask(null, v);
-                    this.UpdateDropdownOverflowPseudoClass(v, null);
-                });
-        }
-
-        public InnerTextBox _innerTextBox { get; init; }
-
-        public Popup? _popup { get; private set; }
-
-        public Thickness FocusedBorderThickness
-        {
-            get => this.GetValue(FocusedBorderThicknessProperty);
-            set => this.SetValue(FocusedBorderThicknessProperty, value);
-        }
-
-        public IEnumerable InnerLeftContent { get; set; } = new AvaloniaList<Control>();
-
-        public IEnumerable InnerRightContent { get; set; } = new AvaloniaList<Control>();
-
-        public double MaxDropDownWidth
-        {
-            get => this.GetValue(MaxDropDownWidthProperty);
-            set => this.SetValue(MaxDropDownWidthProperty, value);
-        }
-
-        public Thickness PopupBorderMaskMargin
-        {
-            get => this.GetValue(PopupBorderMaskMarginProperty);
-            private set => this.SetValue(PopupBorderMaskMarginProperty, value);
-        }
-
-        public double PopupBorderMaskWidth
-        {
-            get => this.GetValue(PopupBorderMaskWidthProperty);
-            private set => this.SetValue(PopupBorderMaskWidthProperty, value);
-        }
-
-        public bool ValueFilterDropdown
-        {
-            get => this.GetValue(ValueFilterDropdownProperty);
-            set => this.SetValue(ValueFilterDropdownProperty, value);
-        }
-
-        public IInputElement? GetControl(NavigationDirection direction, IInputElement? from, bool wrap)
-        {
-            return direction switch
-            {
-                NavigationDirection.Previous => this.GetPreviousControl(from),
-                NavigationDirection.Next => this.GetNextControl(from),
-                _ => null,
-            };
-        }
-
-        protected override void ClearContainerForItemOverride(Control element)
-        {
-            base.ClearContainerForItemOverride(element);
-            if (element is EditableComboBoxItem editableComboBoxItem) editableComboBoxItem.Value = string.Empty;
-        }
-
-        protected override void ContainerForItemPreparedOverride(Control container, object? item, int index)
-        {
-            base.ContainerForItemPreparedOverride(container, item, index);
-            if (container is EditableComboBoxItem editableComboBoxItem)
-            {
-                if (this.ValueFilterDropdown)
-                {
-                    editableComboBoxItem.Bind(EditableComboBoxItem.FilterHighlightTextProperty,
-                        AvaloniaObjectExtensions.GetObservable(this.parent, (AvaloniaProperty)ValueProperty).ToBinding());
-                }
-                else
-                {
-                    editableComboBoxItem.ClearValue(EditableComboBoxItem.FilterHighlightTextProperty);
-                    editableComboBoxItem.FilterHighlightText = null;
-                }
-            }
-        }
-
-        protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey) =>
-            new EditableComboBoxItem
-            {
-                Value = item?.ToString() ?? string.Empty,
-            };
-
-        protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey) =>
-            this.NeedsContainer<EditableComboBoxItem>(item, out recycleKey);
-
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-        {
-            this.innerLeftContentControl = e.NameScope.Get<ItemsControl>("PART_InnerLeftContent");
-            this.innerRightContentControl = e.NameScope.Get<ItemsControl>("PART_InnerRightContent");
-
-            this.textboxContentPresenter = e.NameScope.Get<ContentPresenter>("PART_TextBoxPresenter");
-            this.textboxContentPresenter.Content = this._innerTextBox;
-
-            if (this._popup != null)
-            {
-                this._popup.Opened -= this._popup_OnOpened;
-                this._popup.Closed -= this._popup_OnClosed;
-
-                if (this.popupChildBoundSubscription != null)
-                {
-                    this.popupChildBoundSubscription.Dispose();
-                    this.popupChildBoundSubscription = null;
-                }
-
-                if (this.popupChildSubscription != null)
-                {
-                    this.popupChildSubscription.Dispose();
-                    this.popupChildSubscription = null;
-                }
-            }
-
-            this._popup = e.NameScope.Get<Popup>("PART_Popup");
-            this._popup.Focusable = false;
-            this._popup.IsTabStop = false;
-            this._popup.PlacementTarget = this.parent;
-            this._popup.Opened += this._popup_OnOpened;
-            this._popup.Closed += this._popup_OnClosed;
-
-            this.popupChildSubscription = this._popup.GetObservable(Popup.ChildProperty)
-                .Subscribe(child =>
-                {
-                    if (this.popupChildBoundSubscription != null)
-                    {
-                        this.popupChildBoundSubscription.Dispose();
-                        this.popupChildBoundSubscription = null;
-                    }
-
-                    this.popupChildBoundSubscription = child?.GetObservable(BoundsProperty).Subscribe(b =>
-                    {
-                        this.UpdateDropdownOverflowPseudoClass(null, b);
-                    });
-                });
-        }
-
-        protected override void OnInitialized()
-        {
-            base.OnInitialized();
-            this.CalculatePopupBorderMask(null, null);
-        }
-
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            if (this.IsDropDownOpen) return;
-
-            // TODO: Respect/implement all `KeyboardNavigation.TabNavigation` variants;
-            //       for now, we only specifically handle `Continue`, otherwise we don't handle the event and bubble up.
-            //       - sbergerondrouin 2025-05-21
-            var direction = e.Key.ToNavigationDirection(e.KeyModifiers);
-            if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next))
-            {
-                var topLevel = TopLevel.GetTopLevel(this)!;
-                var focus = topLevel.FocusManager;
-                var focused = focus?.GetFocusedElement();
-
-                var nextControl = GetNextControl(this, dir, focused, false);
-                if (nextControl is not null)
-                {
-                    e.Handled = true;
-                    nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                    return;
-                }
-
-                Visual? containerChild = this.parent;
-                while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
-                       (containerChild = container as Visual) != null)
-                {
-                    nextControl = GetNextControl(container, dir, this.parent, false);
-                    if (nextControl is not null)
-                    {
-                        e.Handled = true;
-                        nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                        return;
-                    }
-                }
-
-                while (containerChild?.FindAncestorOfType<Grid>() is { } grid)
-                {
-                    var index = -1;
-                    if (containerChild is Control control) index = grid.Children.IndexOf(control);
-
-                    var increment = dir == NavigationDirection.Previous ? -1 : 1;
-                    index += increment;
-                    for (; 0 <= index && index < grid.Children.Count; index += increment)
-                    {
-                        nextControl = grid.Children[index];
-                        if (nextControl is { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true })
-                        {
-                            e.Handled = true;
-                            nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                            return;
-                        }
-                    }
-
-                    containerChild = grid;
-                }
-            }
-
-            // Passthrough the rest instead of base, to handle on EditableComboBox instead
-        }
-
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
-        {
-            // Pointer interactions handled by EditableComboBox
-        }
-
-        protected override void OnPointerReleased(PointerReleasedEventArgs e)
-        {
-            // Pointer interactions handled by EditableComboBox
-        }
-
-        protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
-        {
-            base.PrepareContainerForItemOverride(container, item, index);
-            if (container != item)
-                if (container is EditableComboBoxItem editableComboBoxItem)
-                    // FIXME: Verify if we shouldn't maybe bind instead ?
-                    editableComboBoxItem.Value = (item as EditableComboBoxItem)?.Value ?? item?.ToString() ?? string.Empty;
-        }
-
-        private static bool IsSplitBetweenScreen(Visual visual)
-        {
-            if (TopLevel.GetTopLevel(visual) is not { } topLevel) return false;
-
-            var topLeftPoint = visual.PointToScreen(new Point(0, 0));
-            var bottomRightPoint = visual.PointToScreen(new Point(visual.Bounds.Width, visual.Bounds.Height));
-            var screen1 = topLevel.Screens?.ScreenFromPoint(topLeftPoint);
-            var screen2 = topLevel.Screens?.ScreenFromPoint(bottomRightPoint);
-            return screen1 is not null && screen2 is not null && screen1 != screen2;
-        }
-
-        private void _popup_OnClosed(object? sender, EventArgs e)
-        {
-            this.PseudoClasses.Remove(":dropdown-open-from-top");
-            this.PseudoClasses.Remove(":dropdown-overflow");
-
-            if (this._popup?.Child?.GetVisualRoot() is PopupRoot popupRoot) popupRoot.PositionChanged -= this.PopupRoot_OnPositionChanged;
-        }
-
-        private void _popup_OnOpened(object? sender, EventArgs e)
-        {
-            if (this._popup?.Child == null) return;
-
-            this.UpdatePseudoClasses();
-
-            if (this._popup.Child?.GetVisualRoot() is PopupRoot popupRoot) popupRoot.PositionChanged += this.PopupRoot_OnPositionChanged;
-        }
-
-        private int? CalculateOffsetLeft()
-        {
-            if (this._popup?.Child == null) return null;
-
-            return this.PointToScreen(new Point(0, 0)).X - this._popup.Child.PointToScreen(new Point(0, 0)).X;
-        }
-
-        private void CalculatePopupBorderMask(Thickness? newFocusBorderThickness, Rect? newBounds, int? offsetLeft = null)
-        {
-            var focusBorderThickness = newFocusBorderThickness ?? this.FocusedBorderThickness;
-            var bounds = newBounds ?? this.Bounds;
-
-            this.PopupBorderMaskMargin = new Thickness(focusBorderThickness.Left, 0, 0, 0);
-            this.PopupBorderMaskWidth = bounds.Width - focusBorderThickness.Left - focusBorderThickness.Right;
-
-            if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
-
-            var isSplitBetweenScreens = IsSplitBetweenScreen(this);
-            this.PseudoClasses.Set(":is-split-between-screens", isSplitBetweenScreens);
-
-            if (isSplitBetweenScreens)
-            {
-                this.PopupBorderMaskWidth = 0;
-            }
-            else
-            {
-                offsetLeft ??= this.CalculateOffsetLeft();
-                this.PopupBorderMaskMargin = new Thickness(
-                    this.PopupBorderMaskMargin.Left + (int)offsetLeft!,
-                    this.PopupBorderMaskMargin.Top,
-                    this.PopupBorderMaskMargin.Right,
-                    this.PopupBorderMaskMargin.Bottom);
-            }
-        }
-
-        private IInputElement? GetNextControl(IInputElement? from)
-        {
-            var foundCurrent = Equals(from, this._innerTextBox);
-
-            if (this.innerLeftContentControl != null)
-                foreach (var item in this.innerLeftContentControl.Items)
-                {
-                    if (!foundCurrent)
-                    {
-                        foundCurrent = Equals(from, item);
-                        continue;
-                    }
-
-                    var itemControl = item != null ? this.innerLeftContentControl.ContainerFromItem(item) : null;
-                    if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
-                }
-
-            if (this.innerRightContentControl != null)
-                foreach (var item in this.innerRightContentControl.Items)
-                {
-                    if (!foundCurrent)
-                    {
-                        foundCurrent = Equals(from, item);
-                        continue;
-                    }
-
-                    var itemControl = item != null ? this.innerRightContentControl.ContainerFromItem(item) : null;
-                    if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
-                }
-
-            return null;
-        }
-
-        private IInputElement? GetPreviousControl(IInputElement? from)
-        {
-            if (Equals(from, this._innerTextBox) || Equals(from, this) || Equals(from, this.parent)) return null;
-
-            var foundCurrent = false;
-
-            if (this.innerRightContentControl != null)
-                foreach (var item in this.innerRightContentControl.Items.Reverse())
-                {
-                    if (!foundCurrent)
-                    {
-                        foundCurrent = Equals(from, item);
-                        continue;
-                    }
-
-                    var itemControl = item != null ? this.innerRightContentControl.ContainerFromItem(item) : null;
-                    if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
-                }
-
-            if (this.innerLeftContentControl != null)
-                foreach (var item in this.innerLeftContentControl.Items.Reverse())
-                {
-                    if (!foundCurrent)
-                    {
-                        foundCurrent = Equals(from, item);
-                        continue;
-                    }
-
-                    var itemControl = item != null ? this.innerLeftContentControl.ContainerFromItem(item) : null;
-                    if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
-                }
-
-            if (foundCurrent) return this._innerTextBox;
-
-            return null;
-        }
-
-        private void PopupRoot_OnPositionChanged(object? sender, PixelPointEventArgs e)
-        {
-            this.UpdatePseudoClasses();
-        }
-
-        private void UpdateDropdownOpenFromTop()
-        {
-            if (Design.IsDesignMode || this._popup?.Child == null) return;
-
-            this.PseudoClasses.Set(":dropdown-open-from-top",
-                this.PointToScreen(new Point(0, 0)).Y > this._popup.Child.PointToScreen(new Point(0, 0)).Y);
-        }
-
-        private void UpdateDropdownOverflowPseudoClass(Rect? newDropdownBounds, Rect? newPopupBounds, int? offsetLeft = null)
-        {
-            if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
-
-            offsetLeft ??= this.CalculateOffsetLeft();
-
-            var dropdownWidth = (newDropdownBounds ?? this.Bounds).Width;
-            var popupWidth = (newPopupBounds ?? this._popup.Child.Bounds).Width;
-
-            this.PseudoClasses.Set(":dropdown-overflow-right", popupWidth - offsetLeft > dropdownWidth);
-            this.PseudoClasses.Set(":dropdown-overflow-left", offsetLeft > 0);
-        }
-
-        private void UpdatePseudoClasses()
-        {
-            if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
-
-            var offsetLeft = (int)this.CalculateOffsetLeft()!;
-            this.UpdateDropdownOpenFromTop();
-            this.CalculatePopupBorderMask(null, null, offsetLeft);
-            this.UpdateDropdownOverflowPseudoClass(null, null, offsetLeft);
-        }
+          this.CalculatePopupBorderMask(null, v);
+          this.UpdateDropdownOverflowPseudoClass(v, null);
+        });
     }
+
+    public InnerTextBox _innerTextBox { get; init; }
+
+    public Popup? _popup { get; private set; }
+
+    public Thickness FocusedBorderThickness
+    {
+      get => this.GetValue(FocusedBorderThicknessProperty);
+      set => this.SetValue(FocusedBorderThicknessProperty, value);
+    }
+
+    public IEnumerable InnerLeftContent { get; set; } = new AvaloniaList<Control>();
+
+    public IEnumerable InnerRightContent { get; set; } = new AvaloniaList<Control>();
+
+    public double MaxDropDownWidth
+    {
+      get => this.GetValue(MaxDropDownWidthProperty);
+      set => this.SetValue(MaxDropDownWidthProperty, value);
+    }
+
+    public Thickness PopupBorderMaskMargin
+    {
+      get => this.GetValue(PopupBorderMaskMarginProperty);
+      private set => this.SetValue(PopupBorderMaskMarginProperty, value);
+    }
+
+    public double PopupBorderMaskWidth
+    {
+      get => this.GetValue(PopupBorderMaskWidthProperty);
+      private set => this.SetValue(PopupBorderMaskWidthProperty, value);
+    }
+
+    public bool ValueFilterDropdown
+    {
+      get => this.GetValue(ValueFilterDropdownProperty);
+      set => this.SetValue(ValueFilterDropdownProperty, value);
+    }
+
+    public IInputElement? GetControl(NavigationDirection direction, IInputElement? from, bool wrap)
+    {
+      return direction switch
+      {
+        NavigationDirection.Previous => this.GetPreviousControl(from),
+        NavigationDirection.Next => this.GetNextControl(from),
+        _ => null
+      };
+    }
+
+    protected override void ClearContainerForItemOverride(Control element)
+    {
+      base.ClearContainerForItemOverride(element);
+      if (element is EditableComboBoxItem editableComboBoxItem) editableComboBoxItem.Value = string.Empty;
+    }
+
+    protected override void ContainerForItemPreparedOverride(Control container, object? item, int index)
+    {
+      base.ContainerForItemPreparedOverride(container, item, index);
+      if (container is EditableComboBoxItem editableComboBoxItem)
+      {
+        if (this.ValueFilterDropdown)
+        {
+          editableComboBoxItem.Bind(EditableComboBoxItem.FilterHighlightTextProperty,
+            AvaloniaObjectExtensions.GetObservable(this.parent, (AvaloniaProperty)ValueProperty).ToBinding());
+        }
+        else
+        {
+          editableComboBoxItem.ClearValue(EditableComboBoxItem.FilterHighlightTextProperty);
+          editableComboBoxItem.FilterHighlightText = null;
+        }
+      }
+    }
+
+    protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey) =>
+      new EditableComboBoxItem
+      {
+        Value = item?.ToString() ?? string.Empty
+      };
+
+    protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey) =>
+      this.NeedsContainer<EditableComboBoxItem>(item, out recycleKey);
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+      this.innerLeftContentControl = e.NameScope.Get<ItemsControl>("PART_InnerLeftContent");
+      this.innerRightContentControl = e.NameScope.Get<ItemsControl>("PART_InnerRightContent");
+
+      this.textboxContentPresenter = e.NameScope.Get<ContentPresenter>("PART_TextBoxPresenter");
+      this.textboxContentPresenter.Content = this._innerTextBox;
+
+      if (this._popup != null)
+      {
+        this._popup.Opened -= this._popup_OnOpened;
+        this._popup.Closed -= this._popup_OnClosed;
+
+        if (this.popupChildBoundSubscription != null)
+        {
+          this.popupChildBoundSubscription.Dispose();
+          this.popupChildBoundSubscription = null;
+        }
+
+        if (this.popupChildSubscription != null)
+        {
+          this.popupChildSubscription.Dispose();
+          this.popupChildSubscription = null;
+        }
+      }
+
+      this._popup = e.NameScope.Get<Popup>("PART_Popup");
+      this._popup.Focusable = false;
+      this._popup.IsTabStop = false;
+      this._popup.PlacementTarget = this.parent;
+      this._popup.Opened += this._popup_OnOpened;
+      this._popup.Closed += this._popup_OnClosed;
+
+      this.popupChildSubscription = this._popup.GetObservable(Popup.ChildProperty)
+        .Subscribe(child =>
+        {
+          if (this.popupChildBoundSubscription != null)
+          {
+            this.popupChildBoundSubscription.Dispose();
+            this.popupChildBoundSubscription = null;
+          }
+
+          this.popupChildBoundSubscription = child?.GetObservable(BoundsProperty).Subscribe(b =>
+          {
+            this.UpdateDropdownOverflowPseudoClass(null, b);
+          });
+        });
+    }
+
+    protected override void OnInitialized()
+    {
+      base.OnInitialized();
+      this.CalculatePopupBorderMask(null, null);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+      if (this.IsDropDownOpen) return;
+
+      // TODO: Respect/implement all `KeyboardNavigation.TabNavigation` variants;
+      //       for now, we only specifically handle `Continue`, otherwise we don't handle the event and bubble up.
+      //       - sbergerondrouin 2025-05-21
+      NavigationDirection? direction = e.Key.ToNavigationDirection(e.KeyModifiers);
+      if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next))
+      {
+        TopLevel topLevel = TopLevel.GetTopLevel(this)!;
+        IFocusManager? focus = topLevel.FocusManager;
+        IInputElement? focused = focus?.GetFocusedElement();
+
+        IInputElement? nextControl = GetNextControl(this, dir, focused, false);
+        if (nextControl is not null)
+        {
+          e.Handled = true;
+          nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
+          return;
+        }
+
+        Visual? containerChild = this.parent;
+        while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
+               (containerChild = container as Visual) != null)
+        {
+          nextControl = GetNextControl(container, dir, this.parent, false);
+          if (nextControl is not null)
+          {
+            e.Handled = true;
+            nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
+            return;
+          }
+        }
+
+        while (containerChild?.FindAncestorOfType<Grid>() is { } grid)
+        {
+          int index = -1;
+          if (containerChild is Control control) index = grid.Children.IndexOf(control);
+
+          int increment = dir == NavigationDirection.Previous ? -1 : 1;
+          index += increment;
+          for (; 0 <= index && index < grid.Children.Count; index += increment)
+          {
+            nextControl = grid.Children[index];
+            if (nextControl is { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true })
+            {
+              e.Handled = true;
+              nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
+              return;
+            }
+          }
+
+          containerChild = grid;
+        }
+      }
+
+      // Passthrough the rest instead of base, to handle on EditableComboBox instead
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+      // Pointer interactions handled by EditableComboBox
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+      // Pointer interactions handled by EditableComboBox
+    }
+
+    protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
+    {
+      base.PrepareContainerForItemOverride(container, item, index);
+      if (container != item)
+        if (container is EditableComboBoxItem editableComboBoxItem)
+          // FIXME: Verify if we shouldn't maybe bind instead ?
+          editableComboBoxItem.Value = (item as EditableComboBoxItem)?.Value ?? item?.ToString() ?? string.Empty;
+    }
+
+    private static bool IsSplitBetweenScreen(Visual visual)
+    {
+      if (TopLevel.GetTopLevel(visual) is not { } topLevel) return false;
+
+      PixelPoint topLeftPoint = visual.PointToScreen(new Point(0, 0));
+      PixelPoint bottomRightPoint = visual.PointToScreen(new Point(visual.Bounds.Width, visual.Bounds.Height));
+      Screen? screen1 = topLevel.Screens?.ScreenFromPoint(topLeftPoint);
+      Screen? screen2 = topLevel.Screens?.ScreenFromPoint(bottomRightPoint);
+      return screen1 is not null && screen2 is not null && screen1 != screen2;
+    }
+
+    private void _popup_OnClosed(object? sender, EventArgs e)
+    {
+      this.PseudoClasses.Remove(":dropdown-open-from-top");
+      this.PseudoClasses.Remove(":dropdown-overflow");
+
+      if (this._popup?.Child?.GetVisualRoot() is PopupRoot popupRoot) popupRoot.PositionChanged -= this.PopupRoot_OnPositionChanged;
+    }
+
+    private void _popup_OnOpened(object? sender, EventArgs e)
+    {
+      if (this._popup?.Child == null) return;
+
+      this.UpdatePseudoClasses();
+
+      if (this._popup.Child?.GetVisualRoot() is PopupRoot popupRoot) popupRoot.PositionChanged += this.PopupRoot_OnPositionChanged;
+    }
+
+    private int? CalculateOffsetLeft()
+    {
+      if (this._popup?.Child == null) return null;
+
+      return this.PointToScreen(new Point(0, 0)).X - this._popup.Child.PointToScreen(new Point(0, 0)).X;
+    }
+
+    private void CalculatePopupBorderMask(Thickness? newFocusBorderThickness, Rect? newBounds, int? offsetLeft = null)
+    {
+      Thickness focusBorderThickness = newFocusBorderThickness ?? this.FocusedBorderThickness;
+      Rect bounds = newBounds ?? this.Bounds;
+
+      this.PopupBorderMaskMargin = new Thickness(focusBorderThickness.Left, 0, 0, 0);
+      this.PopupBorderMaskWidth = bounds.Width - focusBorderThickness.Left - focusBorderThickness.Right;
+
+      if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
+
+      bool isSplitBetweenScreens = IsSplitBetweenScreen(this);
+      this.PseudoClasses.Set(":is-split-between-screens", isSplitBetweenScreens);
+
+      if (isSplitBetweenScreens)
+      {
+        this.PopupBorderMaskWidth = 0;
+      }
+      else
+      {
+        offsetLeft ??= this.CalculateOffsetLeft();
+        this.PopupBorderMaskMargin = new Thickness(
+          this.PopupBorderMaskMargin.Left + (int)offsetLeft!,
+          this.PopupBorderMaskMargin.Top,
+          this.PopupBorderMaskMargin.Right,
+          this.PopupBorderMaskMargin.Bottom);
+      }
+    }
+
+    private IInputElement? GetNextControl(IInputElement? from)
+    {
+      bool foundCurrent = Equals(from, this._innerTextBox);
+
+      if (this.innerLeftContentControl != null)
+        foreach (object? item in this.innerLeftContentControl.Items)
+        {
+          if (!foundCurrent)
+          {
+            foundCurrent = Equals(from, item);
+            continue;
+          }
+
+          Control? itemControl = item != null ? this.innerLeftContentControl.ContainerFromItem(item) : null;
+          if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
+        }
+
+      if (this.innerRightContentControl != null)
+        foreach (object? item in this.innerRightContentControl.Items)
+        {
+          if (!foundCurrent)
+          {
+            foundCurrent = Equals(from, item);
+            continue;
+          }
+
+          Control? itemControl = item != null ? this.innerRightContentControl.ContainerFromItem(item) : null;
+          if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
+        }
+
+      return null;
+    }
+
+    private IInputElement? GetPreviousControl(IInputElement? from)
+    {
+      if (Equals(from, this._innerTextBox) || Equals(from, this) || Equals(from, this.parent)) return null;
+
+      bool foundCurrent = false;
+
+      if (this.innerRightContentControl != null)
+        foreach (object? item in this.innerRightContentControl.Items.Reverse())
+        {
+          if (!foundCurrent)
+          {
+            foundCurrent = Equals(from, item);
+            continue;
+          }
+
+          Control? itemControl = item != null ? this.innerRightContentControl.ContainerFromItem(item) : null;
+          if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
+        }
+
+      if (this.innerLeftContentControl != null)
+        foreach (object? item in this.innerLeftContentControl.Items.Reverse())
+        {
+          if (!foundCurrent)
+          {
+            foundCurrent = Equals(from, item);
+            continue;
+          }
+
+          Control? itemControl = item != null ? this.innerLeftContentControl.ContainerFromItem(item) : null;
+          if (itemControl?.Focusable == true && itemControl.IsEnabled) return itemControl;
+        }
+
+      if (foundCurrent) return this._innerTextBox;
+
+      return null;
+    }
+
+    private void PopupRoot_OnPositionChanged(object? sender, PixelPointEventArgs e)
+    {
+      this.UpdatePseudoClasses();
+    }
+
+    private void UpdateDropdownOpenFromTop()
+    {
+      if (Design.IsDesignMode || this._popup?.Child == null) return;
+
+      this.PseudoClasses.Set(":dropdown-open-from-top",
+        this.PointToScreen(new Point(0, 0)).Y > this._popup.Child.PointToScreen(new Point(0, 0)).Y);
+    }
+
+    private void UpdateDropdownOverflowPseudoClass(Rect? newDropdownBounds, Rect? newPopupBounds, int? offsetLeft = null)
+    {
+      if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
+
+      offsetLeft ??= this.CalculateOffsetLeft();
+
+      double dropdownWidth = (newDropdownBounds ?? this.Bounds).Width;
+      double popupWidth = (newPopupBounds ?? this._popup.Child.Bounds).Width;
+
+      this.PseudoClasses.Set(":dropdown-overflow-right", popupWidth - offsetLeft > dropdownWidth);
+      this.PseudoClasses.Set(":dropdown-overflow-left", offsetLeft > 0);
+    }
+
+    private void UpdatePseudoClasses()
+    {
+      if (this._popup?.Child?.IsAttachedToVisualTree() != true) return;
+
+      int offsetLeft = (int)this.CalculateOffsetLeft()!;
+      this.UpdateDropdownOpenFromTop();
+      this.CalculatePopupBorderMask(null, null, offsetLeft);
+      this.UpdateDropdownOverflowPseudoClass(null, null, offsetLeft);
+    }
+  }
 }
 
 // ReSharper enable MemberHidesStaticFromOuterClass

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerTextBox.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerTextBox.cs
@@ -5,26 +5,26 @@ using Avalonia.Input;
 
 public partial class EditableComboBox
 {
-    public sealed class InnerTextBox : TextBox
+  public sealed class InnerTextBox : TextBox
+  {
+    protected override void OnGotFocus(GotFocusEventArgs e)
     {
-        protected override void OnGotFocus(GotFocusEventArgs e)
-        {
-            base.OnGotFocus(e);
-            this.SelectAll();
-        }
-
-        public void TriggerOnKeyDown(KeyEventArgs e)
-        {
-            this.OnKeyDown(e);
-        }
-
-        protected override void OnKeyDown(KeyEventArgs e)
-        {
-            if (e.Handled) return;
-
-            base.OnKeyDown(e);
-
-            if (e.Key == Key.Up || e.Key == Key.Down) e.Handled = false;
-        }
+      base.OnGotFocus(e);
+      this.SelectAll();
     }
+
+    public void TriggerOnKeyDown(KeyEventArgs e)
+    {
+      this.OnKeyDown(e);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+      if (e.Handled) return;
+
+      base.OnKeyDown(e);
+
+      if (e.Key == Key.Up || e.Key == Key.Down) e.Handled = false;
+    }
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml
@@ -1,27 +1,27 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:controls="clr-namespace:Devolutions.AvaloniaControls.Controls">
-   <Design.PreviewWith>
-      <controls:SearchHighlightTextBlock
-         Search="t wi"
-         Content="Test with some stuff" />
-   </Design.PreviewWith>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:controls="clr-namespace:Devolutions.AvaloniaControls.Controls">
+  <Design.PreviewWith>
+    <controls:SearchHighlightTextBlock
+      Search="t wi"
+      Content="Test with some stuff" />
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type controls:SearchHighlightTextBlock}" TargetType="controls:SearchHighlightTextBlock">
-      <Setter Property="HighlightBackground" Value="#66FFFF00" />
-      <Setter Property="HighlightForeground" Value="{DynamicResource TextControlButtonForeground}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <StackPanel Orientation="Horizontal">
-               <TextBlock Text="{TemplateBinding LeftText}" />
-               <TextBlock
-                  Text="{TemplateBinding HighlightedText}"
-                  Background="{TemplateBinding HighlightBackground}"
-                  Foreground="{TemplateBinding HighlightForeground}" />
-               <TextBlock Text="{TemplateBinding RightText}" />
-            </StackPanel>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+  <ControlTheme x:Key="{x:Type controls:SearchHighlightTextBlock}" TargetType="controls:SearchHighlightTextBlock">
+    <Setter Property="HighlightBackground" Value="#66FFFF00" />
+    <Setter Property="HighlightForeground" Value="{DynamicResource TextControlButtonForeground}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <StackPanel Orientation="Horizontal">
+          <TextBlock Text="{TemplateBinding LeftText}" />
+          <TextBlock
+            Text="{TemplateBinding HighlightedText}"
+            Background="{TemplateBinding HighlightBackground}"
+            Foreground="{TemplateBinding HighlightForeground}" />
+          <TextBlock Text="{TemplateBinding RightText}" />
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml.cs
@@ -7,88 +7,88 @@ using System;
 
 public class SearchHighlightTextBlock : ContentControl
 {
-    public static readonly DirectProperty<SearchHighlightTextBlock, string> LeftTextProperty =
-        AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(LeftText), static o => o.leftText);
+  public static readonly DirectProperty<SearchHighlightTextBlock, string> LeftTextProperty =
+    AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(LeftText), static o => o.leftText);
 
-    public static readonly DirectProperty<SearchHighlightTextBlock, string> HighlightedTextProperty =
-        AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(HighlightedText), static o => o.highlightedText);
+  public static readonly DirectProperty<SearchHighlightTextBlock, string> HighlightedTextProperty =
+    AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(HighlightedText), static o => o.highlightedText);
 
-    public static readonly DirectProperty<SearchHighlightTextBlock, string> RightTextProperty =
-        AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(RightText), static o => o.rightText);
+  public static readonly DirectProperty<SearchHighlightTextBlock, string> RightTextProperty =
+    AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string>(nameof(RightText), static o => o.rightText);
 
-    public static readonly DirectProperty<SearchHighlightTextBlock, string?> SearchProperty =
-        AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string?>(nameof(Search), static o => o.Search, static (o, v) => o.Search = v);
+  public static readonly DirectProperty<SearchHighlightTextBlock, string?> SearchProperty =
+    AvaloniaProperty.RegisterDirect<SearchHighlightTextBlock, string?>(nameof(Search), static o => o.Search, static (o, v) => o.Search = v);
 
-    public static readonly StyledProperty<IBrush?> HighlightBackgroundProperty =
-        AvaloniaProperty.Register<SearchHighlightTextBlock, IBrush?>(nameof(HighlightBackground));
+  public static readonly StyledProperty<IBrush?> HighlightBackgroundProperty =
+    AvaloniaProperty.Register<SearchHighlightTextBlock, IBrush?>(nameof(HighlightBackground));
 
-    public static readonly StyledProperty<IBrush?> HighlightForegroundProperty =
-        AvaloniaProperty.Register<SearchHighlightTextBlock, IBrush?>(nameof(HighlightForeground));
+  public static readonly StyledProperty<IBrush?> HighlightForegroundProperty =
+    AvaloniaProperty.Register<SearchHighlightTextBlock, IBrush?>(nameof(HighlightForeground));
 
-    private string highlightedText = string.Empty;
+  private string highlightedText = string.Empty;
 
-    private string leftText = string.Empty;
+  private string leftText = string.Empty;
 
-    private string rightText = string.Empty;
+  private string rightText = string.Empty;
 
-    private string? search;
+  private string? search;
 
-    public SearchHighlightTextBlock()
+  public SearchHighlightTextBlock()
+  {
+    this.GetObservable(ContentProperty).Subscribe(_ => this.ProcessHighlight());
+    this.GetObservable(SearchProperty).Subscribe(_ => this.ProcessHighlight());
+    this.ProcessHighlight();
+  }
+
+  public string LeftText => this.leftText;
+
+  public string HighlightedText => this.highlightedText;
+
+  public string RightText => this.rightText;
+
+  public string? Search
+  {
+    get => this.search;
+    set => this.SetAndRaise(SearchProperty, ref this.search, value);
+  }
+
+  public IBrush? HighlightBackground
+  {
+    get => this.GetValue(HighlightBackgroundProperty);
+    set => this.SetValue(HighlightBackgroundProperty, value);
+  }
+
+  public IBrush? HighlightForeground
+  {
+    get => this.GetValue(HighlightForegroundProperty);
+    set => this.SetValue(HighlightForegroundProperty, value);
+  }
+
+  private void ProcessHighlight()
+  {
+    string currentSearch = this.Search ?? string.Empty;
+    string content = this.Content?.ToString() ?? string.Empty;
+
+    var oldLeftText = this.leftText;
+    var oldHighlightedText = this.highlightedText;
+    var oldRightText = this.rightText;
+
+    int highlightIndex = content.IndexOf(currentSearch, StringComparison.OrdinalIgnoreCase);
+    if (highlightIndex >= 0)
     {
-        this.GetObservable(ContentProperty).Subscribe(_ => this.ProcessHighlight());
-        this.GetObservable(SearchProperty).Subscribe(_ => this.ProcessHighlight());
-        this.ProcessHighlight();
+      this.leftText = content[..highlightIndex];
+      this.highlightedText = content.Substring(highlightIndex, currentSearch.Length);
+      this.rightText = content[(highlightIndex + currentSearch.Length)..];
+    }
+    else
+    {
+      this.leftText = content;
+      this.highlightedText = string.Empty;
+      this.rightText = string.Empty;
     }
 
-    public string LeftText => this.leftText;
-
-    public string HighlightedText => this.highlightedText;
-
-    public string RightText => this.rightText;
-
-    public string? Search
-    {
-        get => this.search;
-        set => this.SetAndRaise(SearchProperty, ref this.search, value);
-    }
-
-    public IBrush? HighlightBackground
-    {
-        get => this.GetValue(HighlightBackgroundProperty);
-        set => this.SetValue(HighlightBackgroundProperty, value);
-    }
-
-    public IBrush? HighlightForeground
-    {
-        get => this.GetValue(HighlightForegroundProperty);
-        set => this.SetValue(HighlightForegroundProperty, value);
-    }
-
-    private void ProcessHighlight()
-    {
-        var currentSearch = this.Search ?? string.Empty;
-        var content = this.Content?.ToString() ?? string.Empty;
-
-        var oldLeftText = this.leftText;
-        var oldHighlightedText = this.highlightedText;
-        var oldRightText = this.rightText;
-
-        var highlightIndex = content.IndexOf(currentSearch, StringComparison.OrdinalIgnoreCase);
-        if (highlightIndex >= 0)
-        {
-            this.leftText = content[..highlightIndex];
-            this.highlightedText = content.Substring(highlightIndex, currentSearch.Length);
-            this.rightText = content[(highlightIndex + currentSearch.Length)..];
-        }
-        else
-        {
-            this.leftText = content;
-            this.highlightedText = string.Empty;
-            this.rightText = string.Empty;
-        }
-
-        this.RaisePropertyChanged(LeftTextProperty, oldLeftText, this.leftText);
-        this.RaisePropertyChanged(HighlightedTextProperty, oldHighlightedText, this.highlightedText);
-        this.RaisePropertyChanged(RightTextProperty, oldRightText, this.rightText);
-    }
+    this.RaisePropertyChanged(LeftTextProperty, oldLeftText, this.leftText);
+    this.RaisePropertyChanged(HighlightedTextProperty, oldHighlightedText, this.highlightedText);
+    this.RaisePropertyChanged(RightTextProperty, oldRightText, this.rightText);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Converters/BooleanToChoiceConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/BooleanToChoiceConverter.cs
@@ -6,12 +6,12 @@ using Avalonia.Data.Converters;
 
 public class BooleanToChoiceConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        var selectedChoice = values[0] is true ? values[1] : values[2];
-        return selectedChoice ?? AvaloniaProperty.UnsetValue;
-    }
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    object? selectedChoice = values[0] is true ? values[1] : values[2];
+    return selectedChoice ?? AvaloniaProperty.UnsetValue;
+  }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/ClassToChoiceConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/ClassToChoiceConverter.cs
@@ -7,17 +7,17 @@ using Avalonia.Data.Converters;
 
 public class ClassToChoiceConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        var secondOption = values.Count >= 3 ? values[2] : AvaloniaProperty.UnsetValue;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    object? secondOption = values.Count >= 3 ? values[2] : AvaloniaProperty.UnsetValue;
 
-        var selectedChoice =
-            values[0] is Classes classes && parameter is string className && classes.Contains(className)
-                ? values[1]
-                : secondOption;
-        return selectedChoice ?? AvaloniaProperty.UnsetValue;
-    }
+    object? selectedChoice =
+      values[0] is Classes classes && parameter is string className && classes.Contains(className)
+        ? values[1]
+        : secondOption;
+    return selectedChoice ?? AvaloniaProperty.UnsetValue;
+  }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/ColorToCssFillConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/ColorToCssFillConverter.cs
@@ -16,22 +16,22 @@ using Avalonia.Media;
 /// </remarks>
 public class ColorToCssFillConverter : IValueConverter
 {
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (value is not SolidColorBrush brush) return ".st0 {fill : #000000; }";
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (value is not SolidColorBrush brush) return ".st0 {fill : #000000; }";
 
-        var classes = parameter as string ?? ".st0, .st1, .st2, .st3";
+    string classes = parameter as string ?? ".st0, .st1, .st2, .st3";
 
-        return $"{classes} {{fill : {RemoveAlphaChannel(brush.Color)}; }}";
-    }
+    return $"{classes} {{fill : {RemoveAlphaChannel(brush.Color)}; }}";
+  }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 
-    private string RemoveAlphaChannel(Color argbColor)
-    {
-        var hexString = argbColor.ToString();
-        if (hexString.Length != 9) return hexString;
-        return "#" + hexString.Substring(3);
-    }
+  private static string RemoveAlphaChannel(Color argbColor)
+  {
+    string hexString = argbColor.ToString();
+    if (hexString.Length != 9) return hexString;
+    return "#" + hexString.Substring(3);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Converters/CornerRadiusExtractor.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/CornerRadiusExtractor.cs
@@ -6,18 +6,18 @@ using Avalonia.Data.Converters;
 
 public static partial class DevoConverters
 {
-    public static FuncValueConverter<CornerRadius, CornerRadiusSubset, CornerRadius> CornerRadiusExtractor { get; } =
-        new(static (cornerRadius, subset) => new CornerRadius(
-            subset.HasFlag(CornerRadiusSubset.TopLeft) ? cornerRadius.TopLeft : 0,
-            subset.HasFlag(CornerRadiusSubset.TopRight) ? cornerRadius.TopRight : 0,
-            subset.HasFlag(CornerRadiusSubset.BottomRight) ? cornerRadius.BottomRight : 0,
-            subset.HasFlag(CornerRadiusSubset.BottomLeft) ? cornerRadius.BottomLeft : 0));
+  public static FuncValueConverter<CornerRadius, CornerRadiusSubset, CornerRadius> CornerRadiusExtractor { get; } =
+    new(static (cornerRadius, subset) => new CornerRadius(
+      subset.HasFlag(CornerRadiusSubset.TopLeft) ? cornerRadius.TopLeft : 0,
+      subset.HasFlag(CornerRadiusSubset.TopRight) ? cornerRadius.TopRight : 0,
+      subset.HasFlag(CornerRadiusSubset.BottomRight) ? cornerRadius.BottomRight : 0,
+      subset.HasFlag(CornerRadiusSubset.BottomLeft) ? cornerRadius.BottomLeft : 0));
 }
 
 [Flags]
 [SuppressMessage("StyleCop.CSharp.SpacingRules",
-    "SA1025:Code should not contain multiple whitespace in a row",
-    Justification = "Clearer for bitflags")]
+  "SA1025:Code should not contain multiple whitespace in a row",
+  Justification = "Clearer for bitflags")]
 public enum CornerRadiusSubset
 {
     // @formatter:off
@@ -35,7 +35,7 @@ public enum CornerRadiusSubset
     AllButTopLeft = 0b_1110,
     AllButBottomLeft = 0b_0111,
     AllButTopRight = 0b_1101,
-    AllButBottomRight = 0b_1011,
-    
-    // @formatter:on
+    AllButBottomRight = 0b_1011
+
+  // @formatter:on
 }

--- a/src/Devolutions.AvaloniaControls/Converters/DevoConverters.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/DevoConverters.cs
@@ -2,6 +2,6 @@ namespace Devolutions.AvaloniaControls.Converters;
 
 public static partial class DevoConverters
 {
-    public static readonly ColorToCssFillConverter ColorToCssFillConverter = new();
-    public static readonly ThicknessToSelectiveThicknessConverter ThicknessToSelectiveThicknessConverter = new();
+  public static readonly ColorToCssFillConverter ColorToCssFillConverter = new();
+  public static readonly ThicknessToSelectiveThicknessConverter ThicknessToSelectiveThicknessConverter = new();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/DevoDoubleConverters.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/DevoDoubleConverters.cs
@@ -4,9 +4,9 @@ using Avalonia.Data.Converters;
 
 public static partial class DevoDoubleConverters
 {
-    public static readonly IMultiValueConverter Multiply =
-        new FuncMultiValueConverter<double, double>(static e => e.Aggregate(1.0, static (x, y) => x * y));
+  public static readonly IMultiValueConverter Multiply =
+    new FuncMultiValueConverter<double, double>(static e => e.Aggregate(1.0, static (x, y) => x * y));
 
-    public static readonly IMultiValueConverter Add =
-        new FuncMultiValueConverter<double, double>(static e => e.Aggregate(0.0, static (x, y) => x + y));
+  public static readonly IMultiValueConverter Add =
+    new FuncMultiValueConverter<double, double>(static e => e.Aggregate(0.0, static (x, y) => x + y));
 }

--- a/src/Devolutions.AvaloniaControls/Converters/DevoMultiConverters.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/DevoMultiConverters.cs
@@ -2,13 +2,13 @@ namespace Devolutions.AvaloniaControls.Converters;
 
 public static class DevoMultiConverters
 {
-    public static readonly BooleanToChoiceConverter BooleanToChoiceConverter = new();
-    public static readonly ClassToChoiceConverter ClassToChoiceConverter = new();
-    public static readonly IsExplicitlyTrueConverter IsExplicitlyTrueConverter = new();
-    public static readonly IsUnsetConverter IsUnsetConverter = new();
-    public static readonly RevealPasswordToFontSizeConverter RevealPasswordToFontSizeConverter = new();
-    public static readonly SelectedIndexToPopupOffsetConverter SelectedIndexToPopupOffsetConverter = new();
-    public static readonly TotalWidthConverter TotalWidthConverter = new();
-    public static readonly TabBorderVisibilityConverter TabBorderVisibilityConverter = new();
-    public static readonly FirstNonNullValueMultiConverter FirstNonNullValueMultiConverter = new();
+  public static readonly BooleanToChoiceConverter BooleanToChoiceConverter = new();
+  public static readonly ClassToChoiceConverter ClassToChoiceConverter = new();
+  public static readonly IsExplicitlyTrueConverter IsExplicitlyTrueConverter = new();
+  public static readonly IsUnsetConverter IsUnsetConverter = new();
+  public static readonly RevealPasswordToFontSizeConverter RevealPasswordToFontSizeConverter = new();
+  public static readonly SelectedIndexToPopupOffsetConverter SelectedIndexToPopupOffsetConverter = new();
+  public static readonly TotalWidthConverter TotalWidthConverter = new();
+  public static readonly TabBorderVisibilityConverter TabBorderVisibilityConverter = new();
+  public static readonly FirstNonNullValueMultiConverter FirstNonNullValueMultiConverter = new();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/FirstNonNullValueMultiConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/FirstNonNullValueMultiConverter.cs
@@ -5,12 +5,12 @@ using Avalonia;
 using Avalonia.Data.Converters;
 
 /// <summary>
-///     Returns the first non-null value in the multi-value binding, ignores the rest.
+///   Returns the first non-null value in the multi-value binding, ignores the rest.
 /// </summary>
 public class FirstNonNullValueMultiConverter : IMultiValueConverter
 {
-    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        return values.FirstOrDefault(static value => value is not null && value is not UnsetValueType, null);
-    }
+  public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    return values.FirstOrDefault(static value => value is not null && value is not UnsetValueType, null);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Converters/HasClassConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/HasClassConverter.cs
@@ -5,6 +5,6 @@ using Avalonia.Data.Converters;
 
 public static partial class DevoConverters
 {
-    public static FuncValueConverter<Classes, string, bool> HasClass { get; } =
-        new(static (classes, classToCheck) => classToCheck is not null && classes?.Contains(classToCheck) == true);
+  public static FuncValueConverter<Classes, string, bool> HasClass { get; } =
+    new(static (classes, classToCheck) => classToCheck is not null && classes?.Contains(classToCheck) == true);
 }

--- a/src/Devolutions.AvaloniaControls/Converters/IsExplicitlyTrueConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/IsExplicitlyTrueConverter.cs
@@ -17,9 +17,9 @@ using Avalonia.Data.Converters;
 /// </remarks>
 public class IsExplicitlyTrueConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        values[0] is true;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+    values[0] is true;
 
-    public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/IsUnsetConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/IsUnsetConverter.cs
@@ -17,9 +17,9 @@ using Avalonia.Data.Converters;
 /// </remarks>
 public class IsUnsetConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        values[0] == AvaloniaProperty.UnsetValue;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+    values[0] == AvaloniaProperty.UnsetValue;
 
-    public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/RevealPasswordToFontSizeConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/RevealPasswordToFontSizeConverter.cs
@@ -5,17 +5,17 @@ using Avalonia.Data.Converters;
 
 public class RevealPasswordToFontSizeConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (values is not
-            [char passwordChar, bool revealPassword, double defaultFontSize, double hiddenPasswordBulletFontSize])
-            return double.NaN;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (values is not
+        [char passwordChar, bool revealPassword, double defaultFontSize, double hiddenPasswordBulletFontSize])
+      return double.NaN;
 
-        var isPasswordInput = passwordChar != '\0';
+    bool isPasswordInput = passwordChar != '\0';
 
-        return !isPasswordInput || revealPassword ? defaultFontSize : hiddenPasswordBulletFontSize;
-    }
+    return !isPasswordInput || revealPassword ? defaultFontSize : hiddenPasswordBulletFontSize;
+  }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/SelectedIndexToPopupOffsetConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/SelectedIndexToPopupOffsetConverter.cs
@@ -5,17 +5,17 @@ using Avalonia.Data.Converters;
 
 public class SelectedIndexToPopupOffsetConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (values is not
-                [int index, int rowHeight, int initialFirstItemDistance, double maxDropDownHeight, int popupTrimHeight]
-            || index < 0) return 0d;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (values is not
+          [int index, int rowHeight, int initialFirstItemDistance, double maxDropDownHeight, int popupTrimHeight]
+        || index < 0) return 0d;
 
-        var effectivePopupHeight = maxDropDownHeight - popupTrimHeight;
-        double offset = (index + 1) * -rowHeight - initialFirstItemDistance;
-        return -effectivePopupHeight < offset ? offset : -effectivePopupHeight;
-    }
+    double effectivePopupHeight = maxDropDownHeight - popupTrimHeight;
+    double offset = (index + 1) * -rowHeight - initialFirstItemDistance;
+    return -effectivePopupHeight < offset ? offset : -effectivePopupHeight;
+  }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/TabBorderVisibilityConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/TabBorderVisibilityConverter.cs
@@ -18,46 +18,46 @@ using Avalonia.Data.Converters;
 /// </remarks>
 public class TabBorderVisibilityConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (values[0] is not TabItem tabItem ||
+        values[1] is not TabControl tabControl ||
+        values[2] is not int selectedTabIndex)
+      return true;
+
+    int currentTabIndex = GetTabIndex(tabControl, tabItem);
+
+    bool isFirstTab = currentTabIndex == 0;
+    bool isLastTab = currentTabIndex == tabControl.Items.Count - 1;
+    bool isSelected = selectedTabIndex == currentTabIndex;
+    bool previousTabIsSelected = selectedTabIndex == currentTabIndex - 1;
+    bool nextTabIsSelected = selectedTabIndex == currentTabIndex + 1;
+    bool isLeftOfSelectedTab = currentTabIndex < selectedTabIndex;
+    bool isRightOfSelectedTab = currentTabIndex > selectedTabIndex;
+
+    switch (parameter)
     {
-        if (values[0] is not TabItem tabItem ||
-            values[1] is not TabControl tabControl ||
-            values[2] is not int selectedTabIndex)
-            return true;
-
-        var currentTabIndex = GetTabIndex(tabControl, tabItem);
-
-        var isFirstTab = currentTabIndex == 0;
-        var isLastTab = currentTabIndex == tabControl.Items.Count - 1;
-        var isSelected = selectedTabIndex == currentTabIndex;
-        var previousTabIsSelected = selectedTabIndex == currentTabIndex - 1;
-        var nextTabIsSelected = selectedTabIndex == currentTabIndex + 1;
-        var isLeftOfSelectedTab = currentTabIndex < selectedTabIndex;
-        var isRightOfSelectedTab = currentTabIndex > selectedTabIndex;
-
-        switch (parameter)
-        {
-            case "LeftBorder":
-                return !isFirstTab && (isLeftOfSelectedTab || isSelected);
-            case "BottomLeftCorner":
-                return !isFirstTab && (isLeftOfSelectedTab || isSelected);
-            case "RightBorder":
-                return isLastTab || isRightOfSelectedTab || isSelected;
-            case "BottomRightCorner":
-                return isLastTab || isRightOfSelectedTab || isSelected;
-            case "BottomLeftBorder":
-                return !(previousTabIsSelected || isSelected);
-            case "BottomRightBorder":
-                return !(nextTabIsSelected || isSelected);
-        }
-
-        return true;
+      case "LeftBorder":
+        return !isFirstTab && (isLeftOfSelectedTab || isSelected);
+      case "BottomLeftCorner":
+        return !isFirstTab && (isLeftOfSelectedTab || isSelected);
+      case "RightBorder":
+        return isLastTab || isRightOfSelectedTab || isSelected;
+      case "BottomRightCorner":
+        return isLastTab || isRightOfSelectedTab || isSelected;
+      case "BottomLeftBorder":
+        return !(previousTabIsSelected || isSelected);
+      case "BottomRightBorder":
+        return !(nextTabIsSelected || isSelected);
     }
 
+    return true;
+  }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
 
-    private static int GetTabIndex(TabControl tabControl, TabItem tabItem) =>
-        tabControl.Items.Cast<object>().ToList().IndexOf(tabItem);
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
+
+  private static int GetTabIndex(TabControl tabControl, TabItem tabItem) =>
+    tabControl.Items.Cast<object>().ToList().IndexOf(tabItem);
 }

--- a/src/Devolutions.AvaloniaControls/Converters/ThicknessExtractor.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/ThicknessExtractor.cs
@@ -1,33 +1,34 @@
 ﻿namespace Devolutions.AvaloniaControls.Converters;
 
 using System.Diagnostics.CodeAnalysis;
+using Avalonia;
 using Avalonia.Data.Converters;
 
 public static partial class DevoConverters
 {
-    public static FuncValueConverter<Avalonia.Thickness, ThicknessSubset, Avalonia.Thickness> ThicknessExtractor { get; } =
-        new(static (thickness, subset) => new Avalonia.Thickness(
-            subset.HasFlag(ThicknessSubset.Left) ? thickness.Left : 0,
-            subset.HasFlag(ThicknessSubset.Top) ? thickness.Top : 0,
-            subset.HasFlag(ThicknessSubset.Right) ? thickness.Right : 0,
-            subset.HasFlag(ThicknessSubset.Bottom) ? thickness.Bottom : 0));
+  public static FuncValueConverter<Thickness, ThicknessSubset, Thickness> ThicknessExtractor { get; } =
+    new(static (thickness, subset) => new Thickness(
+      subset.HasFlag(ThicknessSubset.Left) ? thickness.Left : 0,
+      subset.HasFlag(ThicknessSubset.Top) ? thickness.Top : 0,
+      subset.HasFlag(ThicknessSubset.Right) ? thickness.Right : 0,
+      subset.HasFlag(ThicknessSubset.Bottom) ? thickness.Bottom : 0));
 }
 
 [Flags]
 [SuppressMessage("StyleCop.CSharp.SpacingRules",
-    "SA1025:Code should not contain multiple whitespace in a row",
-    Justification = "Clearer for bitflags")]
+  "SA1025:Code should not contain multiple whitespace in a row",
+  Justification = "Clearer for bitflags")]
 public enum ThicknessSubset
 {
-    Left = 0b_0001,
-    Top = 0b_0010,
-    Right = 0b_0100,
-    Bottom = 0b_1000,
+  Left = 0b_0001,
+  Top = 0b_0010,
+  Right = 0b_0100,
+  Bottom = 0b_1000,
 
-    AllButLeft = 0b_1110,
-    AllButTop = 0b_1101,
-    AllButRight = 0b_1011,
-    AllButBottom = 0b_0111,
+  AllButLeft = 0b_1110,
+  AllButTop = 0b_1101,
+  AllButRight = 0b_1011,
+  AllButBottom = 0b_0111,
 
-    All = 0b_1111,
+  All = 0b_1111
 }

--- a/src/Devolutions.AvaloniaControls/Converters/ThicknessToSelectiveThicknessConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/ThicknessToSelectiveThicknessConverter.cs
@@ -6,19 +6,19 @@ using Avalonia.Data.Converters;
 
 public class ThicknessToSelectiveThicknessConverter : IValueConverter
 {
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (value is not Thickness thickness || parameter is not Thickness thicknessFactors)
-            return AvaloniaProperty.UnsetValue;
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (value is not Thickness thickness || parameter is not Thickness thicknessFactors)
+      return AvaloniaProperty.UnsetValue;
 
-        return new Thickness(
-            thickness.Left * thicknessFactors.Left,
-            thickness.Top * thicknessFactors.Top,
-            thickness.Right * thicknessFactors.Right,
-            thickness.Bottom * thicknessFactors.Bottom
-        );
-    }
+    return new Thickness(
+      thickness.Left * thicknessFactors.Left,
+      thickness.Top * thicknessFactors.Top,
+      thickness.Right * thicknessFactors.Right,
+      thickness.Bottom * thicknessFactors.Bottom
+    );
+  }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/Converters/TotalWidthConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/TotalWidthConverter.cs
@@ -5,13 +5,13 @@ using Avalonia.Data.Converters;
 
 public class TotalWidthConverter : IMultiValueConverter
 {
-    public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
-    {
-        if (values[0] is not double width || values[1] is not int sideMargin) return 200d;
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (values[0] is not double width || values[1] is not int sideMargin) return 200d;
 
-        return width + 2 * sideMargin;
-    }
+    return width + 2 * sideMargin;
+  }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
+++ b/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
@@ -1,12 +1,12 @@
 <Styles
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-   <Styles.Resources>
-      <ResourceDictionary>
-         <ResourceDictionary.MergedDictionaries>
-            <MergeResourceInclude Source="Controls/SearchHighlightTextBlock.axaml" />
-            <MergeResourceInclude Source="Controls/EditableComboBox/EditableComboBox.axaml" />
-         </ResourceDictionary.MergedDictionaries>
-      </ResourceDictionary>
-   </Styles.Resources>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="Controls/SearchHighlightTextBlock.axaml" />
+        <MergeResourceInclude Source="Controls/EditableComboBox/EditableComboBox.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
 </Styles>

--- a/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
+++ b/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
@@ -9,8 +9,8 @@
     <RootNamespace>Devolutions.AvaloniaControls</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="*" />
-    <PackageReference Include="System.Reactive" Version="*" />
+    <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="*"/>
+    <PackageReference Include="System.Reactive" Version="*"/>
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaControls/EnumerableExtensions.cs
+++ b/src/Devolutions.AvaloniaControls/EnumerableExtensions.cs
@@ -2,17 +2,17 @@ namespace Devolutions.AvaloniaControls;
 
 internal static class EnumerableExtensions
 {
-    internal static IEnumerable<T> Add<T>(this IEnumerable<T> enumerable, T addedValue)
-    {
-        foreach (var value in enumerable) yield return value;
+  internal static IEnumerable<T> Add<T>(this IEnumerable<T> enumerable, T addedValue)
+  {
+    foreach (var value in enumerable) yield return value;
 
-        yield return addedValue;
-    }
+    yield return addedValue;
+  }
 
-    internal static IEnumerable<T> SkipNulls<T>(this IEnumerable<T?> enumerable)
-    {
-        foreach (var value in enumerable)
-            if (value != null)
-                yield return value;
-    }
+  internal static IEnumerable<T> SkipNulls<T>(this IEnumerable<T?> enumerable)
+  {
+    foreach (var value in enumerable)
+      if (value != null)
+        yield return value;
+  }
 }

--- a/src/Devolutions.AvaloniaControls/Enums/SortDirection.cs
+++ b/src/Devolutions.AvaloniaControls/Enums/SortDirection.cs
@@ -2,9 +2,9 @@ namespace Devolutions.AvaloniaControls.Enums;
 
 public enum SortDirection
 {
-    None = 0,
+  None = 0,
 
-    Ascending = 1,
+  Ascending = 1,
 
-    Descending = 2,
+  Descending = 2,
 }

--- a/src/Devolutions.AvaloniaControls/Helpers/MarkupExtensionHelpers.cs
+++ b/src/Devolutions.AvaloniaControls/Helpers/MarkupExtensionHelpers.cs
@@ -6,62 +6,62 @@ using Avalonia.Data;
 
 public static class MarkupExtensionHelpers
 {
-    // Dynamic approach is slightly faster than using reflection, see: https://stackoverflow.com/a/78582306
-    public static IBinding? GetBinding<TIn>(object? v)
+  // Dynamic approach is slightly faster than using reflection, see: https://stackoverflow.com/a/78582306
+  public static IBinding? GetBinding<TIn>(object? v)
+  {
+    switch (v)
     {
-        switch (v)
+      case null:
+        return null;
+      case IBinding binding:
+        return binding;
+      case string str:
+      {
+        var isParsable = typeof(TIn).GetInterfaces()
+          .Any(static c => c.IsGenericType && c.GetGenericTypeDefinition() == typeof(IParsable<>));
+        if (isParsable)
         {
-            case null:
-                return null;
-            case IBinding binding:
-                return binding;
-            case string str:
-            {
-                var isParsable = typeof(TIn).GetInterfaces()
-                    .Any(static c => c.IsGenericType && c.GetGenericTypeDefinition() == typeof(IParsable<>));
-                if (isParsable)
-                {
-                    TIn value = Parse(str, (dynamic)default(TIn)!);
-                    return SingleValueObservable(value).ToBinding();
-                }
-
-                break;
-            }
+          TIn value = Parse(str, (dynamic)default(TIn)!);
+          return SingleValueObservable(value).ToBinding();
         }
 
-        if (typeof(TIn) == typeof(object)) return SingleValueObservable(v).ToBinding();
-
-        return typeof(TIn) == typeof(object)
-            ? SingleValueObservable(v).ToBinding()
-            : SingleValueObservable(TypeDescriptor.GetConverter(v.GetType()).ConvertTo(v, typeof(TIn))).ToBinding();
+        break;
+      }
     }
 
-    public static IBinding? GetBinding(object? v, Type type)
-    {
-        switch (v)
-        {
-            case null:
-                return null;
-            case IBinding binding:
-                return binding;
-            case string str:
-            {
-                var isParsable = type.GetInterfaces().Any(static c => c.IsGenericType && c.GetGenericTypeDefinition() == typeof(IParsable<>));
-                if (isParsable)
-                {
-                    var parseMethod = type.GetMethod("Parse", [typeof(string)]);
-                    return SingleValueObservable(parseMethod?.Invoke(type, [str])).ToBinding();
-                }
+    if (typeof(TIn) == typeof(object)) return SingleValueObservable(v).ToBinding();
 
-                break;
-            }
+    return typeof(TIn) == typeof(object)
+      ? SingleValueObservable(v).ToBinding()
+      : SingleValueObservable(TypeDescriptor.GetConverter(v.GetType()).ConvertTo(v, typeof(TIn))).ToBinding();
+  }
+
+  public static IBinding? GetBinding(object? v, Type type)
+  {
+    switch (v)
+    {
+      case null:
+        return null;
+      case IBinding binding:
+        return binding;
+      case string str:
+      {
+        var isParsable = type.GetInterfaces().Any(static c => c.IsGenericType && c.GetGenericTypeDefinition() == typeof(IParsable<>));
+        if (isParsable)
+        {
+          var parseMethod = type.GetMethod("Parse", [typeof(string)]);
+          return SingleValueObservable(parseMethod?.Invoke(type, [str])).ToBinding();
         }
 
-        return SingleValueObservable(TypeDescriptor.GetConverter(v.GetType()).ConvertTo(v, type)).ToBinding();
+        break;
+      }
     }
 
-    private static T Parse<T>(string stringValue, T _) where T : IParsable<T> =>
-        T.Parse(stringValue, null);
+    return SingleValueObservable(TypeDescriptor.GetConverter(v.GetType()).ConvertTo(v, type)).ToBinding();
+  }
 
-    private static SingleValueObservable<T> SingleValueObservable<T>(T v) => new(v);
+  private static T Parse<T>(string stringValue, T _) where T : IParsable<T> =>
+    T.Parse(stringValue, null);
+
+  private static SingleValueObservable<T> SingleValueObservable<T>(T v) => new(v);
 }

--- a/src/Devolutions.AvaloniaControls/Helpers/ObservableHelpers.cs
+++ b/src/Devolutions.AvaloniaControls/Helpers/ObservableHelpers.cs
@@ -2,28 +2,28 @@ namespace Devolutions.AvaloniaControls.Helpers;
 
 public static class ObservableHelpers
 {
-    public static SingleValueObservable<T> SingleValue<T>(T v) => new(v);
+  public static SingleValueObservable<T> SingleValue<T>(T v) => new(v);
 
-    public static SingleValueObservable<T?> EmptyTyped<T>() where T : class? => new(null);
+  public static SingleValueObservable<T?> EmptyTyped<T>() where T : class? => new(null);
 
-    public static readonly SingleValueObservable<object?> Empty = new(null);
+  public static readonly SingleValueObservable<object?> Empty = new(null);
 }
 
 public class SingleValueObservable<T>(T value) : IObservable<T>
 {
-    public IDisposable Subscribe(IObserver<T> observer)
-    {
-        observer.OnNext(value);
-        observer.OnCompleted();
-        return EmptyDisposable.Instance;
-    }
+  public IDisposable Subscribe(IObserver<T> observer)
+  {
+    observer.OnNext(value);
+    observer.OnCompleted();
+    return EmptyDisposable.Instance;
+  }
 
-    private sealed class EmptyDisposable : IDisposable
-    {
-        public static readonly EmptyDisposable Instance = new();
+  private sealed class EmptyDisposable : IDisposable
+  {
+    public static readonly EmptyDisposable Instance = new();
 
-        private EmptyDisposable() { }
+    private EmptyDisposable() { }
 
-        public void Dispose() { }
-    }
+    public void Dispose() { }
+  }
 }

--- a/src/Devolutions.AvaloniaControls/INativeWindowAvaloniaHost.cs
+++ b/src/Devolutions.AvaloniaControls/INativeWindowAvaloniaHost.cs
@@ -4,9 +4,9 @@ using Avalonia;
 
 public interface INativeWindowAvaloniaHost<out TAvaloniaObjectHost> where TAvaloniaObjectHost : AvaloniaObject
 {
-    public static readonly StyledProperty<bool> IsActiveProperty = AvaloniaProperty.Register<TAvaloniaObjectHost, bool>(nameof(IsActive), true);
+  public static readonly StyledProperty<bool> IsActiveProperty = AvaloniaProperty.Register<TAvaloniaObjectHost, bool>(nameof(IsActive), true);
 
-    public TAvaloniaObjectHost Host { get; }
+  public TAvaloniaObjectHost Host { get; }
 
-    public bool IsActive { get; set; }
+  public bool IsActive { get; set; }
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/AbstractMultipleValueBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/AbstractMultipleValueBinding.cs
@@ -7,36 +7,36 @@ using Helpers;
 
 public abstract class AbstractMultipleValueBinding<TIn> : MarkupExtension
 {
-    protected readonly IBinding a;
+  protected readonly IBinding a;
 
-    protected readonly IBinding b;
+  protected readonly IBinding b;
 
-    protected readonly IBinding[] extraBindings = [];
+  protected readonly IBinding[] extraBindings = [];
 
-    private MultiBinding? multiBindingInstance;
+  private MultiBinding? multiBindingInstance;
 
-    protected AbstractMultipleValueBinding(object a, object b)
+  protected AbstractMultipleValueBinding(object a, object b)
+  {
+    this.a = GetBinding(a)!;
+    this.b = GetBinding(b)!;
+  }
+
+  protected AbstractMultipleValueBinding(object a, object b, params object[] bindings) : this(a, b)
+  {
+    this.extraBindings = bindings.Select(GetBinding).SkipNulls().ToArray();
+  }
+
+  protected abstract IMultiValueConverter MultiValueConverter { get; }
+
+  public override object ProvideValue(IServiceProvider serviceProvider)
+  {
+    this.multiBindingInstance ??= new MultiBinding
     {
-        this.a = GetBinding(a)!;
-        this.b = GetBinding(b)!;
-    }
+      Bindings = [this.a, this.b, ..this.extraBindings],
+      Converter = this.MultiValueConverter,
+    };
+    return this.multiBindingInstance;
+  }
 
-    protected AbstractMultipleValueBinding(object a, object b, params object[] bindings) : this(a, b)
-    {
-        this.extraBindings = bindings.Select(GetBinding).SkipNulls().ToArray();
-    }
-
-    protected abstract IMultiValueConverter MultiValueConverter { get; }
-
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        this.multiBindingInstance ??= new MultiBinding
-        {
-            Bindings = [this.a, this.b, ..this.extraBindings],
-            Converter = this.MultiValueConverter,
-        };
-        return this.multiBindingInstance;
-    }
-
-    private static IBinding? GetBinding(object? v) => MarkupExtensionHelpers.GetBinding<TIn>(v);
+  private static IBinding? GetBinding(object? v) => MarkupExtensionHelpers.GetBinding<TIn>(v);
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/AddBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/AddBinding.cs
@@ -5,9 +5,9 @@ using Converters;
 
 public class AddBinding : AbstractMultipleValueBinding<double>
 {
-    public AddBinding(object a, object b) : base(a, b) { }
+  public AddBinding(object a, object b) : base(a, b) { }
 
-    public AddBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
+  public AddBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
 
-    protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Add;
+  protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Add;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/AndBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/AndBinding.cs
@@ -4,9 +4,9 @@ using Avalonia.Data.Converters;
 
 public class AndBinding : AbstractMultipleValueBinding<bool>
 {
-    public AndBinding(object a, object b) : base(a, b) { }
+  public AndBinding(object a, object b) : base(a, b) { }
 
-    public AndBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
+  public AndBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
 
-    protected override IMultiValueConverter MultiValueConverter => BoolConverters.And;
+  protected override IMultiValueConverter MultiValueConverter => BoolConverters.And;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/BindingToggler.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/BindingToggler.cs
@@ -10,54 +10,54 @@ using Microsoft.Extensions.DependencyInjection;
 
 public class BindingTogglerExtension : MarkupExtension
 {
-    private IBinding? resolvedWhenTrueBinding;
+  private IBinding? resolvedWhenTrueBinding;
 
-    private IBinding? resolvedWhenFalseBinding;
+  private IBinding? resolvedWhenFalseBinding;
 
-    public BindingTogglerExtension(IBinding conditionBinding, object whenTrueBinding, object whenFalseBinding)
+  public BindingTogglerExtension(IBinding conditionBinding, object whenTrueBinding, object whenFalseBinding)
+  {
+    this.ConditionBinding = conditionBinding;
+    this.WhenTrueBinding = whenTrueBinding;
+    this.WhenFalseBinding = whenFalseBinding;
+  }
+
+  [ConstructorArgument("conditionBinding")]
+  public IBinding ConditionBinding { get; init; }
+
+  [ConstructorArgument("whenTrueBinding")]
+  public object WhenTrueBinding { get; init; }
+
+  [ConstructorArgument("whenFalseBinding")]
+  public object WhenFalseBinding { get; init; }
+
+  public override object ProvideValue(IServiceProvider serviceProvider)
+  {
+    var provideTarget = serviceProvider.GetService<IProvideValueTarget>();
+    var setter = provideTarget?.TargetObject as Setter;
+    var targetType = setter?.Property?.PropertyType;
+
+    if (targetType is not null)
     {
-        this.ConditionBinding = conditionBinding;
-        this.WhenTrueBinding = whenTrueBinding;
-        this.WhenFalseBinding = whenFalseBinding;
+      this.resolvedWhenTrueBinding ??=
+        MarkupExtensionHelpers.GetBinding(this.WhenTrueBinding, targetType) ?? ObservableHelpers.Empty.ToBinding();
+      this.resolvedWhenFalseBinding ??=
+        MarkupExtensionHelpers.GetBinding(this.WhenFalseBinding, targetType) ?? ObservableHelpers.Empty.ToBinding();
+    }
+    else
+    {
+      this.resolvedWhenTrueBinding ??=
+        MarkupExtensionHelpers.GetBinding<object?>(this.WhenTrueBinding) ?? ObservableHelpers.Empty.ToBinding();
+      this.resolvedWhenFalseBinding ??=
+        MarkupExtensionHelpers.GetBinding<object?>(this.WhenFalseBinding) ?? ObservableHelpers.Empty.ToBinding();
     }
 
-    [ConstructorArgument("conditionBinding")]
-    public IBinding ConditionBinding { get; init; }
-
-    [ConstructorArgument("whenTrueBinding")]
-    public object WhenTrueBinding { get; init; }
-
-    [ConstructorArgument("whenFalseBinding")]
-    public object WhenFalseBinding { get; init; }
-
-    public override object ProvideValue(IServiceProvider serviceProvider)
+    return new MultiBinding
     {
-        var provideTarget = serviceProvider.GetService<IProvideValueTarget>();
-        var setter = provideTarget?.TargetObject as Setter;
-        var targetType = setter?.Property?.PropertyType;
-
-        if (targetType is not null)
-        {
-            this.resolvedWhenTrueBinding ??=
-                MarkupExtensionHelpers.GetBinding(this.WhenTrueBinding, targetType) ?? ObservableHelpers.Empty.ToBinding();
-            this.resolvedWhenFalseBinding ??=
-                MarkupExtensionHelpers.GetBinding(this.WhenFalseBinding, targetType) ?? ObservableHelpers.Empty.ToBinding();
-        }
-        else
-        {
-            this.resolvedWhenTrueBinding ??=
-                MarkupExtensionHelpers.GetBinding<object?>(this.WhenTrueBinding) ?? ObservableHelpers.Empty.ToBinding();
-            this.resolvedWhenFalseBinding ??=
-                MarkupExtensionHelpers.GetBinding<object?>(this.WhenFalseBinding) ?? ObservableHelpers.Empty.ToBinding();
-        }
-
-        return new MultiBinding
-        {
-            Converter = DevoMultiConverters.BooleanToChoiceConverter,
-            Bindings =
-            [
-                this.ConditionBinding, this.resolvedWhenTrueBinding, this.resolvedWhenFalseBinding,
-            ],
-        };
-    }
+      Converter = DevoMultiConverters.BooleanToChoiceConverter,
+      Bindings =
+      [
+        this.ConditionBinding, this.resolvedWhenTrueBinding, this.resolvedWhenFalseBinding,
+      ],
+    };
+  }
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/ChangeColorOpacity.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/ChangeColorOpacity.cs
@@ -8,28 +8,28 @@ using Helpers;
 
 public class ChangeColorOpacity(object color, object opacity) : MarkupExtension
 {
-    private static readonly FuncMultiValueConverter<object, Color> Converter = new(static e =>
+  private static readonly FuncMultiValueConverter<object, Color> Converter = new(static e =>
+  {
+    using var enumerator = e.GetEnumerator();
+    enumerator.MoveNext();
+    var color = (Color)enumerator.Current!;
+    enumerator.MoveNext();
+    var opacity = (double)enumerator.Current;
+
+    return DoChangeColorOpacity(color, opacity);
+  });
+
+  protected readonly IBinding color = MarkupExtensionHelpers.GetBinding<Color>(color)!;
+
+  protected readonly IBinding opacity = MarkupExtensionHelpers.GetBinding<double>(opacity)!;
+
+  public override object ProvideValue(IServiceProvider serviceProvider) =>
+    new MultiBinding
     {
-        using var enumerator = e.GetEnumerator();
-        enumerator.MoveNext();
-        var color = (Color)enumerator.Current!;
-        enumerator.MoveNext();
-        var opacity = (double)enumerator.Current;
+      Bindings = [this.color, this.opacity],
+      Converter = Converter,
+    };
 
-        return DoChangeColorOpacity(color, opacity);
-    });
-
-    protected readonly IBinding color = MarkupExtensionHelpers.GetBinding<Color>(color)!;
-
-    protected readonly IBinding opacity = MarkupExtensionHelpers.GetBinding<double>(opacity)!;
-
-    public override object ProvideValue(IServiceProvider serviceProvider) =>
-        new MultiBinding
-        {
-            Bindings = [this.color, this.opacity],
-            Converter = Converter,
-        };
-
-    private static Color DoChangeColorOpacity(Color color, double opacity) =>
-        new(Math.Clamp((byte)(opacity * 255.0), (byte)0, (byte)255), color.R, color.G, color.B);
+  private static Color DoChangeColorOpacity(Color color, double opacity) =>
+    new(Math.Clamp((byte)(opacity * 255.0), (byte)0, (byte)255), color.R, color.G, color.B);
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/DynamicResourceToggler.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/DynamicResourceToggler.cs
@@ -8,32 +8,32 @@ using Helpers;
 
 public class DynamicResourceTogglerExtension : MarkupExtension
 {
-    private BindingTogglerExtension? toggler;
+  private BindingTogglerExtension? toggler;
 
-    public DynamicResourceTogglerExtension(object conditionBinding, object whenTrueResourceKey, object whenFalseResourceKey)
-    {
-        this.ConditionBinding = conditionBinding as IBinding ?? MarkupExtensionHelpers.GetBinding<bool>(conditionBinding)!;
-        this.WhenTrueResourceKey = whenTrueResourceKey;
-        this.WhenFalseResourceKey = whenFalseResourceKey;
-    }
+  public DynamicResourceTogglerExtension(object conditionBinding, object whenTrueResourceKey, object whenFalseResourceKey)
+  {
+    this.ConditionBinding = conditionBinding as IBinding ?? MarkupExtensionHelpers.GetBinding<bool>(conditionBinding)!;
+    this.WhenTrueResourceKey = whenTrueResourceKey;
+    this.WhenFalseResourceKey = whenFalseResourceKey;
+  }
 
-    [ConstructorArgument("conditionBinding")]
-    public IBinding ConditionBinding { get; init; }
+  [ConstructorArgument("conditionBinding")]
+  public IBinding ConditionBinding { get; init; }
 
-    [ConstructorArgument("whenTrueResourceKey")]
-    public object WhenTrueResourceKey { get; init; }
+  [ConstructorArgument("whenTrueResourceKey")]
+  public object WhenTrueResourceKey { get; init; }
 
-    [ConstructorArgument("whenFalseResourceKey")]
-    public object WhenFalseResourceKey { get; init; }
+  [ConstructorArgument("whenFalseResourceKey")]
+  public object WhenFalseResourceKey { get; init; }
 
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        this.toggler ??= new BindingTogglerExtension(
-            this.ConditionBinding,
-            Application.Current?.GetResourceObservable(this.WhenTrueResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding(),
-            Application.Current?.GetResourceObservable(this.WhenFalseResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding()
-        );
+  public override object ProvideValue(IServiceProvider serviceProvider)
+  {
+    this.toggler ??= new BindingTogglerExtension(
+      this.ConditionBinding,
+      Application.Current?.GetResourceObservable(this.WhenTrueResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding(),
+      Application.Current?.GetResourceObservable(this.WhenFalseResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding()
+    );
 
-        return this.toggler.ProvideValue(serviceProvider);
-    }
+    return this.toggler.ProvideValue(serviceProvider);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/MultiplyBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/MultiplyBinding.cs
@@ -5,9 +5,9 @@ using Converters;
 
 public class MultiplyBinding : AbstractMultipleValueBinding<double>
 {
-    public MultiplyBinding(object a, object b) : base(a, b) { }
+  public MultiplyBinding(object a, object b) : base(a, b) { }
 
-    public MultiplyBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
+  public MultiplyBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
 
-    protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Multiply;
+  protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Multiply;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/OrBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/OrBinding.cs
@@ -4,9 +4,9 @@ using Avalonia.Data.Converters;
 
 public class OrBinding : AbstractMultipleValueBinding<bool>
 {
-    public OrBinding(object a, object b) : base(a, b) { }
+  public OrBinding(object a, object b) : base(a, b) { }
 
-    public OrBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
+  public OrBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
 
-    protected override IMultiValueConverter MultiValueConverter => BoolConverters.Or;
+  protected override IMultiValueConverter MultiValueConverter => BoolConverters.Or;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowActiveBindingToggler.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowActiveBindingToggler.cs
@@ -4,28 +4,28 @@ using Avalonia.Markup.Xaml;
 
 public class WindowActiveBindingTogglerExtension : MarkupExtension
 {
-    private BindingTogglerExtension? toggleBindingExtension;
+  private BindingTogglerExtension? toggleBindingExtension;
 
-    public WindowActiveBindingTogglerExtension(object whenActiveBinding, object whenInactiveBinding)
-    {
-        this.WhenActiveBinding = whenActiveBinding;
-        this.WhenInactiveBinding = whenInactiveBinding;
-    }
+  public WindowActiveBindingTogglerExtension(object whenActiveBinding, object whenInactiveBinding)
+  {
+    this.WhenActiveBinding = whenActiveBinding;
+    this.WhenInactiveBinding = whenInactiveBinding;
+  }
 
-    [ConstructorArgument("whenActiveBinding")]
-    public object WhenActiveBinding { get; init; }
+  [ConstructorArgument("whenActiveBinding")]
+  public object WhenActiveBinding { get; init; }
 
-    [ConstructorArgument("whenInactiveBinding")]
-    public object WhenInactiveBinding { get; init; }
+  [ConstructorArgument("whenInactiveBinding")]
+  public object WhenInactiveBinding { get; init; }
 
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        this.toggleBindingExtension ??= new BindingTogglerExtension(
-            WindowIsActiveBindingExtension.CreateIsActiveBinding(),
-            this.WhenActiveBinding,
-            this.WhenInactiveBinding
-        );
+  public override object ProvideValue(IServiceProvider serviceProvider)
+  {
+    this.toggleBindingExtension ??= new BindingTogglerExtension(
+      WindowIsActiveBindingExtension.CreateIsActiveBinding(),
+      this.WhenActiveBinding,
+      this.WhenInactiveBinding
+    );
 
-        return this.toggleBindingExtension.ProvideValue(serviceProvider);
-    }
+    return this.toggleBindingExtension.ProvideValue(serviceProvider);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowActiveResourceToggler.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowActiveResourceToggler.cs
@@ -7,27 +7,27 @@ using Helpers;
 
 public class WindowActiveResourceTogglerExtension : MarkupExtension
 {
-    private WindowActiveBindingTogglerExtension? toggler;
+  private WindowActiveBindingTogglerExtension? toggler;
 
-    public WindowActiveResourceTogglerExtension(object activeResourceKey, object inactiveResourceKey)
-    {
-        this.ActiveResourceKey = activeResourceKey;
-        this.InactiveResourceKey = inactiveResourceKey;
-    }
+  public WindowActiveResourceTogglerExtension(object activeResourceKey, object inactiveResourceKey)
+  {
+    this.ActiveResourceKey = activeResourceKey;
+    this.InactiveResourceKey = inactiveResourceKey;
+  }
 
-    [ConstructorArgument("activeResourceKey")]
-    public object ActiveResourceKey { get; init; }
+  [ConstructorArgument("activeResourceKey")]
+  public object ActiveResourceKey { get; init; }
 
-    [ConstructorArgument("inactiveResourceKey")]
-    public object InactiveResourceKey { get; init; }
+  [ConstructorArgument("inactiveResourceKey")]
+  public object InactiveResourceKey { get; init; }
 
-    public override object ProvideValue(IServiceProvider serviceProvider)
-    {
-        this.toggler ??= new WindowActiveBindingTogglerExtension(
-            Application.Current?.GetResourceObservable(this.ActiveResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding(),
-            Application.Current?.GetResourceObservable(this.InactiveResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding()
-        );
+  public override object ProvideValue(IServiceProvider serviceProvider)
+  {
+    this.toggler ??= new WindowActiveBindingTogglerExtension(
+      Application.Current?.GetResourceObservable(this.ActiveResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding(),
+      Application.Current?.GetResourceObservable(this.InactiveResourceKey).ToBinding() ?? ObservableHelpers.Empty.ToBinding()
+    );
 
-        return this.toggler.ProvideValue(serviceProvider);
-    }
+    return this.toggler.ProvideValue(serviceProvider);
+  }
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowIsActiveBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/WindowIsActiveBinding.cs
@@ -9,66 +9,66 @@ using Converters;
 
 public class WindowIsActiveBindingExtension : MarkupExtension
 {
-    public static IBinding CreateIsActiveBinding() =>
-        new MultiBinding
+  public static IBinding CreateIsActiveBinding() =>
+    new MultiBinding
+    {
+      Converter = DevoMultiConverters.FirstNonNullValueMultiConverter,
+      Bindings =
+      [
+        new Binding
         {
-            Converter = DevoMultiConverters.FirstNonNullValueMultiConverter,
-            Bindings =
-            [
-                new Binding
-                {
-                    Path = "IsActive",
-                    RelativeSource = new RelativeSource
-                    {
-                        Mode = RelativeSourceMode.FindAncestor,
-                        AncestorType = typeof(INativeWindowAvaloniaHost<AvaloniaObject>),
-                    },
-                    Source = new Binding
-                    {
-                        RelativeSource = new RelativeSource
-                        {
-                            Mode = RelativeSourceMode.TemplatedParent,
-                        },
-                    },
-                },
-                new Binding
-                {
-                    Path = "IsActive",
-                    RelativeSource = new RelativeSource
-                    {
-                        Mode = RelativeSourceMode.FindAncestor,
-                        AncestorType = typeof(INativeWindowAvaloniaHost<AvaloniaObject>),
-                    },
-                },
-                new Binding
-                {
-                    Path = "IsActive",
-                    RelativeSource = new RelativeSource
-                    {
-                        Mode = RelativeSourceMode.FindAncestor,
-                        AncestorType = typeof(Window),
-                    },
-                    Source = new Binding
-                    {
-                        RelativeSource = new RelativeSource
-                        {
-                            Mode = RelativeSourceMode.TemplatedParent,
-                        },
-                    },
-                },
-                new Binding
-                {
-                    Path = "IsActive",
-                    RelativeSource = new RelativeSource
-                    {
-                        Mode = RelativeSourceMode.FindAncestor,
-                        AncestorType = typeof(Window),
-                    },
-                },
+          Path = "IsActive",
+          RelativeSource = new RelativeSource
+          {
+            Mode = RelativeSourceMode.FindAncestor,
+            AncestorType = typeof(INativeWindowAvaloniaHost<AvaloniaObject>),
+          },
+          Source = new Binding
+          {
+            RelativeSource = new RelativeSource
+            {
+              Mode = RelativeSourceMode.TemplatedParent,
+            },
+          },
+        },
+        new Binding
+        {
+          Path = "IsActive",
+          RelativeSource = new RelativeSource
+          {
+            Mode = RelativeSourceMode.FindAncestor,
+            AncestorType = typeof(INativeWindowAvaloniaHost<AvaloniaObject>),
+          },
+        },
+        new Binding
+        {
+          Path = "IsActive",
+          RelativeSource = new RelativeSource
+          {
+            Mode = RelativeSourceMode.FindAncestor,
+            AncestorType = typeof(Window),
+          },
+          Source = new Binding
+          {
+            RelativeSource = new RelativeSource
+            {
+              Mode = RelativeSourceMode.TemplatedParent,
+            },
+          },
+        },
+        new Binding
+        {
+          Path = "IsActive",
+          RelativeSource = new RelativeSource
+          {
+            Mode = RelativeSourceMode.FindAncestor,
+            AncestorType = typeof(Window),
+          },
+        },
 
-                new Binding { Source = true },
-            ],
-        };
+        new Binding { Source = true },
+      ],
+    };
 
-    public override object ProvideValue(IServiceProvider serviceProvider) => CreateIsActiveBinding();
+  public override object ProvideValue(IServiceProvider serviceProvider) => CreateIsActiveBinding();
 }

--- a/src/Devolutions.AvaloniaControls/README.md
+++ b/src/Devolutions.AvaloniaControls/README.md
@@ -9,16 +9,15 @@ Custom Avalonia Controls developed by [Devolutions](https://devolutions.net/)
 
 ## Custom Controls [Work in Progress]
 
-In this package we publish various custom controls as well as converters, markup extensions and other helper 
-utilities used in our [themes](https://github.com/Devolutions/avalonia-extensions) and  [Devolutions Remote 
-Desktop Manager](https://devolutions.net/remote-desktop-manager/). The more generically useful ones are listed here 
+In this package we publish various custom controls as well as converters, markup extensions and other helper
+utilities used in our [themes](https://github.com/Devolutions/avalonia-extensions) and  [Devolutions Remote
+Desktop Manager](https://devolutions.net/remote-desktop-manager/). The more generically useful ones are listed here
 (full documentation tba ...).
 
 - [Installation](#installation)
 - [Controls](#controls)
 - [Converters](#converters)
 - [MarkupExtensions](#markupextensions)
-
 
 ## Installation
 
@@ -34,7 +33,6 @@ or .NET
 ```bash
 dotnet add package Devolutions.AvaloniaControls
 ```
-
 
 ### Controls
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -1,185 +1,184 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Light">
+      <Color x:Key="BackgroundColor">#ffffff</Color>
+      <Color x:Key="BorderColor">#dadada</Color>
+      <Color x:Key="SystemRegionColor">#f0f0f0</Color>
+      <Color x:Key="ForegroundColor">#000000</Color>
 
-   <ResourceDictionary.ThemeDictionaries>
-      <ResourceDictionary x:Key="Light">
-         <Color x:Key="BackgroundColor">#ffffff</Color>
-         <Color x:Key="BorderColor">#dadada</Color>
-         <Color x:Key="SystemRegionColor">#f0f0f0</Color>
-         <Color x:Key="ForegroundColor">#000000</Color>
+      <Color x:Key="AccentForegroundColor">#ffffff</Color>
+      <Color x:Key="ErrorTextColor">#C50500</Color>
 
-         <Color x:Key="AccentForegroundColor">#ffffff</Color>
-         <Color x:Key="ErrorTextColor">#C50500</Color>
+      <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
+      <Color x:Key="ControlBackgroundMidColor">#eaeaea</Color>
 
-         <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
-         <Color x:Key="ControlBackgroundMidColor">#eaeaea</Color>
+      <Color x:Key="ControlBorderLowColorSolid">#e7e7e7</Color>
+      <Color x:Key="ControlBorderMidColorSolid">#dbdbdb</Color>
 
-         <Color x:Key="ControlBorderLowColorSolid">#e7e7e7</Color>
-         <Color x:Key="ControlBorderMidColorSolid">#dbdbdb</Color>
+      <Color x:Key="ButtonForegroundDisabledColorSolid">#bdbdbd</Color>
 
-         <Color x:Key="ButtonForegroundDisabledColorSolid">#bdbdbd</Color>
+      <Color x:Key="TextSelectionColorSolid">#A3C7EB</Color>
 
-         <Color x:Key="TextSelectionColorSolid">#A3C7EB</Color>
+      <Color x:Key='DataGridForegroundColor'>#000</Color>
+      <Color x:Key='DataGridSelectedRowColor'>#cde8ff</Color>
 
-         <Color x:Key='DataGridForegroundColor'>#000</Color>
-         <Color x:Key='DataGridSelectedRowColor'>#cde8ff</Color>
+      <Color x:Key='TextBoxBackgroundColor'>#fff</Color>
+      <Color x:Key='TextBoxBorderBottomColor'>#9f9f9f</Color>
 
-         <Color x:Key='TextBoxBackgroundColor'>#fff</Color>
-         <Color x:Key='TextBoxBorderBottomColor'>#9f9f9f</Color>
+      <Color x:Key='ScrollBarThumbColor'>#9f9f9f</Color>
 
-         <Color x:Key='ScrollBarThumbColor'>#9f9f9f</Color>
+      <SolidColorBrush x:Key="ControlBackgroundSelectedBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.07" />
+      <SolidColorBrush x:Key="TreeViewItemBackgroundSelectedBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
 
-         <SolidColorBrush x:Key="ControlBackgroundSelectedBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.07" />
-         <SolidColorBrush x:Key="TreeViewItemBackgroundSelectedBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
+      <Color x:Key="EditableComboBoxItemHoverForegroundColor">#0067c0</Color>
+      <Color x:Key="EditableComboBoxItemIconColor">#0088f2</Color>
+      <SolidColorBrush x:Key="EditableComboBoxGlyphHoverBrush" Color="{ChangeColorOpacity {DynamicResource SystemAccentColorLight2}, 0.25}" />
+      <SolidColorBrush x:Key="EditableComboBoxGlyphPressedBrush" Color="{ChangeColorOpacity {DynamicResource SystemAccentColorLight3}, 0.2}" />
+      <BoxShadows x:Key='EditableComboBoxBoxShadow'>0 0 5 0 #88666666</BoxShadows>
+    </ResourceDictionary>
 
-         <Color x:Key="EditableComboBoxItemHoverForegroundColor">#0067c0</Color>
-         <Color x:Key="EditableComboBoxItemIconColor">#0088f2</Color>
-         <SolidColorBrush x:Key="EditableComboBoxGlyphHoverBrush" Color="{ChangeColorOpacity {DynamicResource SystemAccentColorLight2}, 0.25}" />
-         <SolidColorBrush x:Key="EditableComboBoxGlyphPressedBrush" Color="{ChangeColorOpacity {DynamicResource SystemAccentColorLight3}, 0.2}" />
-         <BoxShadows x:Key='EditableComboBoxBoxShadow'>0 0 5 0 #88666666</BoxShadows>
-      </ResourceDictionary>
+    <!-- TODO: Darkmode colours just roughly -->
+    <ResourceDictionary x:Key="Dark">
+      <Color x:Key="BackgroundColor">#202020</Color>
+      <Color x:Key="BorderColor">#404040</Color>
+      <Color x:Key="SystemRegionColor">#202020</Color>
+      <Color x:Key="ForegroundColor">#f5f5f5</Color>
 
-      <!-- TODO: Darkmode colours just roughly -->
-      <ResourceDictionary x:Key="Dark">
-         <Color x:Key="BackgroundColor">#202020</Color>
-         <Color x:Key="BorderColor">#404040</Color>
-         <Color x:Key="SystemRegionColor">#202020</Color>
-         <Color x:Key="ForegroundColor">#f5f5f5</Color>
+      <Color x:Key="AccentForegroundColor">#deecf9</Color>
+      <Color x:Key="ErrorTextColor">#ed7083</Color>
 
-         <Color x:Key="AccentForegroundColor">#deecf9</Color>
-         <Color x:Key="ErrorTextColor">#ed7083</Color>
+      <Color x:Key="ControlBackgroundHighColor">#595959</Color>
 
-         <Color x:Key="ControlBackgroundHighColor">#595959</Color>
+      <Color x:Key="ControlBorderLowColorSolid">#343434</Color>
+      <Color x:Key="ControlBorderMidColorSolid">#454545</Color>
 
-         <Color x:Key="ControlBorderLowColorSolid">#343434</Color>
-         <Color x:Key="ControlBorderMidColorSolid">#454545</Color>
+      <Color x:Key="ButtonForegroundDisabledColorSolid">#656565</Color>
 
-         <Color x:Key="ButtonForegroundDisabledColorSolid">#656565</Color>
+      <Color x:Key="TextSelectionColorSolid">#A3C7EB</Color>
 
-         <Color x:Key="TextSelectionColorSolid">#A3C7EB</Color>
+      <Color x:Key='DataGridForegroundColor'>#f5f5f5</Color>
+      <Color x:Key='DataGridSelectedRowColor'>#3c3c3c</Color>
 
-         <Color x:Key='DataGridForegroundColor'>#f5f5f5</Color>
-         <Color x:Key='DataGridSelectedRowColor'>#3c3c3c</Color>
+      <Color x:Key='TextBoxBackgroundColor'>#202020</Color>
+      <Color x:Key='TextBoxBorderBottomColor'>#666666</Color>
 
-         <Color x:Key='TextBoxBackgroundColor'>#202020</Color>
-         <Color x:Key='TextBoxBorderBottomColor'>#666666</Color>
+      <Color x:Key='ScrollBarThumbColor'>#808080</Color>
 
-         <Color x:Key='ScrollBarThumbColor'>#808080</Color>
+      <Color x:Key='ControlBackgroundSelectedColor'>#21ffffff</Color>
+      <SolidColorBrush x:Key="ControlBackgroundSelectedBrush" Color="{DynamicResource ControlBackgroundSelectedColor}" />
+      <SolidColorBrush x:Key="TreeViewItemBackgroundSelectedBrush" Color="{DynamicResource ForegroundColor}"
+                       Opacity="0.13" />
+      <Color x:Key="EditableComboBoxItemHoverForegroundColor">#387ec4</Color>
+      <Color x:Key="EditableComboBoxItemIconColor">#0088f2</Color>
+      <SolidColorBrush x:Key="EditableComboBoxGlyphHoverBrush">#3c3c3c</SolidColorBrush>
+      <SolidColorBrush x:Key="EditableComboBoxGlyphPressedBrush" Color="#363636" />
+      <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="#404040" />
+      <BoxShadows x:Key='EditableComboBoxBoxShadow'>0 0 4 0 #88010101</BoxShadows>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
 
-         <Color x:Key='ControlBackgroundSelectedColor'>#21ffffff</Color>
-         <SolidColorBrush x:Key="ControlBackgroundSelectedBrush" Color="{DynamicResource ControlBackgroundSelectedColor}" />
-         <SolidColorBrush x:Key="TreeViewItemBackgroundSelectedBrush" Color="{DynamicResource ForegroundColor}"
-                          Opacity="0.13" />
-         <Color x:Key="EditableComboBoxItemHoverForegroundColor">#387ec4</Color>
-         <Color x:Key="EditableComboBoxItemIconColor">#0088f2</Color>
-         <SolidColorBrush x:Key="EditableComboBoxGlyphHoverBrush">#3c3c3c</SolidColorBrush>
-         <SolidColorBrush x:Key="EditableComboBoxGlyphPressedBrush" Color="#363636" />
-         <SolidColorBrush x:Key="ComboBoxDropDownBorderBrush" Color="#404040" />
-         <BoxShadows x:Key='EditableComboBoxBoxShadow'>0 0 4 0 #88010101</BoxShadows>
-      </ResourceDictionary>
-   </ResourceDictionary.ThemeDictionaries>
+  <CornerRadius x:Key="ControlCornerRadius">3</CornerRadius>
 
-   <CornerRadius x:Key="ControlCornerRadius">3</CornerRadius>
+  <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
+  <SolidColorBrush x:Key="SystemRegionBrush" Color="{DynamicResource SystemRegionColor}" />
 
-   <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
-   <SolidColorBrush x:Key="SystemRegionBrush" Color="{DynamicResource SystemRegionColor}" />
+  <FontFamily x:Key="DevExpressThemeFontFamily">Segoe UI, Helvetica Neue, Arial, sans-serif</FontFamily>
+  <x:Double x:Key="DefaultFontSize">12</x:Double>
+  <x:Double x:Key="ControlFontSize">12</x:Double>
+  <x:Double x:Key="PasswordHiddenFontSize">10</x:Double>
 
-   <FontFamily x:Key="DevExpressThemeFontFamily">Segoe UI, Helvetica Neue, Arial, sans-serif</FontFamily>
-   <x:Double x:Key="DefaultFontSize">12</x:Double>
-   <x:Double x:Key="ControlFontSize">12</x:Double>
-   <x:Double x:Key="PasswordHiddenFontSize">10</x:Double>
+  <SolidColorBrush x:Key="Foreground" Color="{DynamicResource ForegroundColor}" />
+  <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
+  <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
 
-   <SolidColorBrush x:Key="Foreground" Color="{DynamicResource ForegroundColor}" />
-   <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
-   <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
+  <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.90" />
+  <SolidColorBrush x:Key="ForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
 
-   <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.90" />
-   <SolidColorBrush x:Key="ForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
+  <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
 
-   <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
+  <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.06" />
 
-   <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.06" />
+  <SolidColorBrush x:Key="ControlForegroundAccentHighBrush" Color="{DynamicResource AccentForegroundColor}" />
+  <SolidColorBrush x:Key="ControlBackgroundHighBrush" Color="{DynamicResource ControlBackgroundHighColor}" />
+  <SolidColorBrush x:Key="ControlBackgroundMidBrush" Color="{DynamicResource ControlBackgroundMidColor}" />
+  <SolidColorBrush x:Key="ControlBackgroundAccentBrush" Color="{DynamicResource SystemAccentColor}" />
 
-   <SolidColorBrush x:Key="ControlForegroundAccentHighBrush" Color="{DynamicResource AccentForegroundColor}" />
-   <SolidColorBrush x:Key="ControlBackgroundHighBrush" Color="{DynamicResource ControlBackgroundHighColor}" />
-   <SolidColorBrush x:Key="ControlBackgroundMidBrush" Color="{DynamicResource ControlBackgroundMidColor}" />
-   <SolidColorBrush x:Key="ControlBackgroundAccentBrush" Color="{DynamicResource SystemAccentColor}" />
+  <SolidColorBrush x:Key="ControlBorderMidBrush" Color="{DynamicResource ControlBorderMidColorSolid}" />
+  <SolidColorBrush x:Key="ControlBorderBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.11" />
+  <LinearGradientBrush x:Key="ControlBorderRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColorSolid}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlBorderMidColorSolid}" />
+  </LinearGradientBrush>
+  <SolidColorBrush x:Key="ControlBorderSelectedBrush" Color="{DynamicResource SystemAccentColor}" />
 
-   <SolidColorBrush x:Key="ControlBorderMidBrush" Color="{DynamicResource ControlBorderMidColorSolid}" />
-   <SolidColorBrush x:Key="ControlBorderBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.11" />
-   <LinearGradientBrush x:Key="ControlBorderRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColorSolid}" />
-      <GradientStop Offset="1" Color="{DynamicResource ControlBorderMidColorSolid}" />
-   </LinearGradientBrush>
-   <SolidColorBrush x:Key="ControlBorderSelectedBrush" Color="{DynamicResource SystemAccentColor}" />
+  <SolidColorBrush x:Key="ButtonForegroundDisabledBrush" Color="{DynamicResource ButtonForegroundDisabledColorSolid}" />
+  <SolidColorBrush x:Key="ButtonPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.06" />
+  <SolidColorBrush x:Key="ButtonAccentPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
 
-   <SolidColorBrush x:Key="ButtonForegroundDisabledBrush" Color="{DynamicResource ButtonForegroundDisabledColorSolid}" />
-   <SolidColorBrush x:Key="ButtonPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.06" />
-   <SolidColorBrush x:Key="ButtonAccentPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
+  <SolidColorBrush x:Key="SplitButtonBackground" Color="{DynamicResource ControlBackgroundHighColor}" />
+  <StaticResource x:Key="SplitButtonForeground" ResourceKey="ForegroundHighBrush" />
+  <StaticResource x:Key="SplitButtonBorderBrush" ResourceKey="ControlBorderRaisedBrush" />
+  <Thickness x:Key="SplitButtonBorderThemeThickness">1</Thickness>
+  <Thickness x:Key="ButtonPadding">5, 0</Thickness>
 
-   <SolidColorBrush x:Key="SplitButtonBackground" Color="{DynamicResource ControlBackgroundHighColor}" />
-   <StaticResource x:Key="SplitButtonForeground" ResourceKey="ForegroundHighBrush" />
-   <StaticResource x:Key="SplitButtonBorderBrush" ResourceKey="ControlBorderRaisedBrush" />
-   <Thickness x:Key="SplitButtonBorderThemeThickness">1</Thickness>
-   <Thickness x:Key="ButtonPadding">5, 0</Thickness>
+  <StaticResource x:Key="SplitButtonBackgroundPointerOver" ResourceKey="ButtonPointerOverBrushTransparent" />
+  <StaticResource x:Key="SplitButtonBorderBrushPointerOver" ResourceKey="SplitButtonBorderBrush" />
+  <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="SplitButtonForeground" />
 
-   <StaticResource x:Key="SplitButtonBackgroundPointerOver" ResourceKey="ButtonPointerOverBrushTransparent" />
-   <StaticResource x:Key="SplitButtonBorderBrushPointerOver" ResourceKey="SplitButtonBorderBrush" />
-   <StaticResource x:Key="SplitButtonForegroundPointerOver" ResourceKey="SplitButtonForeground" />
+  <SolidColorBrush x:Key="TabItemPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.02" />
 
-   <SolidColorBrush x:Key="TabItemPointerOverBrushTransparent" Color="{DynamicResource ForegroundColor}" Opacity="0.02" />
+  <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="{DynamicResource TextBoxBackgroundColor}" />
+  <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ControlBorderLowColorSolid}" />
+  <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource TextBoxBorderBottomColor}" />
+  <SolidColorBrush x:Key="TextBoxDisabledBorderSelectedBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
+  <Thickness x:Key="TextBoxPrefixPaddingFactors">1 1 0 1</Thickness>
+  <Thickness x:Key="TextBoxSufixPaddingFactors">0 1 1 1</Thickness>
 
-   <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="{DynamicResource TextBoxBackgroundColor}" />
-   <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ControlBorderLowColorSolid}" />
-   <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource TextBoxBorderBottomColor}" />
-   <SolidColorBrush x:Key="TextBoxDisabledBorderSelectedBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
-   <Thickness x:Key="TextBoxPrefixPaddingFactors">1 1 0 1</Thickness>
-   <Thickness x:Key="TextBoxSufixPaddingFactors">0 1 1 1</Thickness>
+  <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
+  <SolidColorBrush x:Key="ComboBoxDropDownBorderBrushTransparent" Color="{DynamicResource ForegroundColor}"
+                   Opacity="0.28" />
+  <Thickness x:Key="ComboBoxPadding">10,0,10,0</Thickness>
+  <x:Double x:Key="TextBasedInputMinHeight">23</x:Double>
+  <BoxShadows x:Key="ComboBoxDropDownShadow"> 0 3 7 0 #30000000</BoxShadows>
 
-   <SolidColorBrush x:Key="ComboBoxItemBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
-   <SolidColorBrush x:Key="ComboBoxDropDownBorderBrushTransparent" Color="{DynamicResource ForegroundColor}"
-                    Opacity="0.28" />
-   <Thickness x:Key="ComboBoxPadding">10,0,10,0</Thickness>
-   <x:Double x:Key="TextBasedInputMinHeight">23</x:Double>
-   <BoxShadows x:Key="ComboBoxDropDownShadow"> 0 3 7 0 #30000000</BoxShadows>
+  <SolidColorBrush x:Key="CheckBoxBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
+  <SolidColorBrush x:Key="CheckBoxForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.56" />
+  <SolidColorBrush x:Key="CheckBoxCheckedBackgroundDisabledBrush" Color="{DynamicResource ForegroundColor}"
+                   Opacity="0.2" />
 
-   <SolidColorBrush x:Key="CheckBoxBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
-   <SolidColorBrush x:Key="CheckBoxForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.56" />
-   <SolidColorBrush x:Key="CheckBoxCheckedBackgroundDisabledBrush" Color="{DynamicResource ForegroundColor}"
-                    Opacity="0.2" />
+  <Thickness x:Key="TabItemHeaderPadding">4 0</Thickness>
+  <Thickness x:Key="FirstTabItemHeaderPadding">6 0 4 0</Thickness>
 
-   <Thickness x:Key="TabItemHeaderPadding">4 0</Thickness>
-   <Thickness x:Key="FirstTabItemHeaderPadding">6 0 4 0</Thickness>
+  <SolidColorBrush x:Key="DataGridForeground" Color="{DynamicResource DataGridForegroundColor}" />
+  <SolidColorBrush x:Key="DataGridSelectedRowFill" Color="{DynamicResource DataGridSelectedRowColor}" />
 
-   <SolidColorBrush x:Key="DataGridForeground" Color="{DynamicResource DataGridForegroundColor}" />
-   <SolidColorBrush x:Key="DataGridSelectedRowFill" Color="{DynamicResource DataGridSelectedRowColor}" />
+  <CornerRadius x:Key="OverlayCornerRadius">0</CornerRadius>
 
-   <CornerRadius x:Key="OverlayCornerRadius">0</CornerRadius>
+  <x:Double x:Key="OpacityVisible">1</x:Double>
+  <x:Double x:Key="OpacityHidden">0</x:Double>
 
-   <x:Double x:Key="OpacityVisible">1</x:Double>
-   <x:Double x:Key="OpacityHidden">0</x:Double>
+  <x:Double x:Key="ScrollBarSize">17.4</x:Double>
+  <SolidColorBrush x:Key="ScrollBarBackgroundBrush" Color="{DynamicResource SystemRegionColor}" />
+  <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ScrollBarThumbColor}" />
+  <CornerRadius x:Key="ScrollBarThumbCornerRadius">2</CornerRadius>
+  <CornerRadius x:Key="ScrollBarThumbExpandedCornerRadius">4</CornerRadius>
+  <TransformOperations x:Key="VerticalScrollThumbShrinkTransform">scaleX(0.4)</TransformOperations>
+  <TransformOperations x:Key="HorizontalScrollThumbShrinkTransform">scaleY(0.4)</TransformOperations>
+  <TransformOperations x:Key="NoTransform">none</TransformOperations>
 
-   <x:Double x:Key="ScrollBarSize">17.4</x:Double>
-   <SolidColorBrush x:Key="ScrollBarBackgroundBrush" Color="{DynamicResource SystemRegionColor}" />
-   <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ScrollBarThumbColor}" />
-   <CornerRadius x:Key="ScrollBarThumbCornerRadius">2</CornerRadius>
-   <CornerRadius x:Key="ScrollBarThumbExpandedCornerRadius">4</CornerRadius>
-   <TransformOperations x:Key="VerticalScrollThumbShrinkTransform">scaleX(0.4)</TransformOperations>
-   <TransformOperations x:Key="HorizontalScrollThumbShrinkTransform">scaleY(0.4)</TransformOperations>
-   <TransformOperations x:Key="NoTransform">none</TransformOperations>
+  <x:Double x:Key="TreeViewItemMinHeight">22</x:Double>
+  <x:Double x:Key="TreeViewItemExpandCollapseChevronSize">12</x:Double>
+  <Thickness x:Key="TreeViewItemExpandCollapseChevronMargin">4 0 4 0</Thickness>
+  <Thickness x:Key="TreeViewItemTreeViewItemPaddingn">0 0 5 0</Thickness>
 
-   <x:Double x:Key="TreeViewItemMinHeight">22</x:Double>
-   <x:Double x:Key="TreeViewItemExpandCollapseChevronSize">12</x:Double>
-   <Thickness x:Key="TreeViewItemExpandCollapseChevronMargin">4 0 4 0</Thickness>
-   <Thickness x:Key="TreeViewItemTreeViewItemPaddingn">0 0 5 0</Thickness>
+  <!-- DEVELOPMENT ONLY -->
+  <!-- <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.13" /> -->
 
-   <!-- DEVELOPMENT ONLY -->
-   <!-- <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.13" /> -->
-
-   <SolidColorBrush x:Key="TestGreen" Color="Green" Opacity="0.84" />
-   <SolidColorBrush x:Key="TestRed" Color="Red" />
-   <SolidColorBrush x:Key="TestBlue" Color="Blue" />
-   <SolidColorBrush x:Key="TestYellow" Color="Yellow" />
+  <SolidColorBrush x:Key="TestGreen" Color="Green" Opacity="0.84" />
+  <SolidColorBrush x:Key="TestRed" Color="Red" />
+  <SolidColorBrush x:Key="TestBlue" Color="Blue" />
+  <SolidColorBrush x:Key="TestYellow" Color="Yellow" />
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
@@ -1,93 +1,93 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <StackPanel Spacing="20">
-         <Border Padding="20" Background="#f0f0f0">
-            <Grid ColumnDefinitions="91, 2, 75" RowDefinitions="Auto, 10, Auto">
-               <Button Grid.Row="0" Grid.Column="0" Classes="accent" Content="test" />
-               <Button Grid.Row="0" Grid.Column="2" Content="Cancel" />
-               <Button Grid.Row="2" Grid.Column="0" Classes="accent" Content="Disabled" IsEnabled="False" />
-               <Button Grid.Row="2" Grid.Column="2" Content="Disabled" IsEnabled="False" />
-            </Grid>
-         </Border>
-         <CheckBox IsEnabled="False">Birthday focussed</CheckBox>
-      </StackPanel>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <StackPanel Spacing="20">
+      <Border Padding="20" Background="#f0f0f0">
+        <Grid ColumnDefinitions="91, 2, 75" RowDefinitions="Auto, 10, Auto">
+          <Button Grid.Row="0" Grid.Column="0" Classes="accent" Content="test" />
+          <Button Grid.Row="0" Grid.Column="2" Content="Cancel" />
+          <Button Grid.Row="2" Grid.Column="0" Classes="accent" Content="Disabled" IsEnabled="False" />
+          <Button Grid.Row="2" Grid.Column="2" Content="Disabled" IsEnabled="False" />
+        </Grid>
+      </Border>
+      <CheckBox IsEnabled="False">Birthday focussed</CheckBox>
+    </StackPanel>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type Button}" TargetType="Button">
-      <Setter Property="MinHeight" Value="26" />
+  <ControlTheme x:Key="{x:Type Button}" TargetType="Button">
+    <Setter Property="MinHeight" Value="26" />
+    <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontWeight" Value="SemiLight" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border
+            Name="BackgroundElement"
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            CornerRadius="{TemplateBinding CornerRadius}" />
+          <Border
+            Name="ButtonActiveElement"
+            Background="Transparent"
+            BorderBrush="{DynamicResource TransparentBrush}"
+            BorderThickness="2"
+            CornerRadius="{TemplateBinding CornerRadius}" />
+          <ContentPresenter
+            Name="PART_ContentPresenter"
+            Content="{TemplateBinding Content}"
+            Foreground="{TemplateBinding Foreground}"
+            Padding="{TemplateBinding Padding}"
+            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+            FontSize="{TemplateBinding FontSize}"
+            FontWeight="{TemplateBinding FontWeight}" />
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:pointerover /template/ Border#ButtonActiveElement">
+      <Setter Property="Background" Value="{DynamicResource ButtonPointerOverBrushTransparent}" />
+    </Style>
+    <Style Selector="^:pressed">
       <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
-      <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-      <Setter Property="HorizontalContentAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="FontWeight" Value="SemiLight" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Panel>
-               <Border
-                  Name="BackgroundElement"
-                  Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="{TemplateBinding CornerRadius}" />
-               <Border
-                  Name="ButtonActiveElement"
-                  Background="Transparent"
-                  BorderBrush="{DynamicResource TransparentBrush}"
-                  BorderThickness="2"
-                  CornerRadius="{TemplateBinding CornerRadius}" />
-               <ContentPresenter
-                  Name="PART_ContentPresenter"
-                  Content="{TemplateBinding Content}"
-                  Foreground="{TemplateBinding Foreground}"
-                  Padding="{TemplateBinding Padding}"
-                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                  FontSize="{TemplateBinding FontSize}"
-                  FontWeight="{TemplateBinding FontWeight}" />
-            </Panel>
-         </ControlTemplate>
-      </Setter>
+      <Style Selector="^:pointerover /template/ Border#ButtonActiveElement">
+        <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
+      </Style>
+    </Style>
+    <Style Selector="^:focus, ^:focus-visible">
+      <Style Selector="^ /template/ Border#ButtonActiveElement">
+        <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBorderRaisedBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBackgroundHighBrush}" />
+      <Setter Property="Foreground" Value="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ForegroundHighBrush}" />
+      <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBorderRaisedBrush}" />
 
       <Style Selector="^:pointerover /template/ Border#ButtonActiveElement">
-         <Setter Property="Background" Value="{DynamicResource ButtonPointerOverBrushTransparent}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonAccentPointerOverBrushTransparent}" />
       </Style>
-      <Style Selector="^:pressed">
-         <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
-         <Style Selector="^:pointerover /template/ Border#ButtonActiveElement">
-            <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
-         </Style>
-      </Style>
-      <Style Selector="^:focus, ^:focus-visible">
-         <Style Selector="^ /template/ Border#ButtonActiveElement">
-            <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBorderRaisedBrush}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^.accent">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBackgroundHighBrush}" />
-         <Setter Property="Foreground" Value="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ForegroundHighBrush}" />
-         <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBackgroundAccentBrush, ControlBorderRaisedBrush}" />
-
-         <Style Selector="^:pointerover /template/ Border#ButtonActiveElement">
-            <Setter Property="Background" Value="{DynamicResource ButtonAccentPointerOverBrushTransparent}" />
-         </Style>
-      </Style>
-      <Style Selector="^:disabled">
-         <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabledBrush}" />
-         <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderMidBrush}" />
-      </Style>
-   </ControlTheme>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabledBrush}" />
+      <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderMidBrush}" />
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
@@ -1,105 +1,105 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <Border Padding="20" Height="300">
-         <StackPanel Spacing="10" Width="200">
-            <ComboBox PlaceholderText="Select an option" SelectedIndex="1">
-               <ComboBoxItem>External</ComboBoxItem>
-               <ComboBoxItem>Embedded (tabbed)</ComboBoxItem>
-               <ComboBoxItem>Undocked</ComboBoxItem>
-            </ComboBox>
-            <ComboBox
-               IsEnabled="False"
-               Width="200"
-               SelectedIndex="1"
-               HorizontalContentAlignment="Center">
-               <ComboBoxItem>Item 1</ComboBoxItem>
-               <ComboBoxItem>Item 2</ComboBoxItem>
-            </ComboBox>
-         </StackPanel>
-      </Border>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Padding="20" Height="300">
+      <StackPanel Spacing="10" Width="200">
+        <ComboBox PlaceholderText="Select an option" SelectedIndex="1">
+          <ComboBoxItem>External</ComboBoxItem>
+          <ComboBoxItem>Embedded (tabbed)</ComboBoxItem>
+          <ComboBoxItem>Undocked</ComboBoxItem>
+        </ComboBox>
+        <ComboBox
+          IsEnabled="False"
+          Width="200"
+          SelectedIndex="1"
+          HorizontalContentAlignment="Center">
+          <ComboBoxItem>Item 1</ComboBoxItem>
+          <ComboBoxItem>Item 2</ComboBoxItem>
+        </ComboBox>
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
-      <Setter Property="Padding" Value="10 3 " />
-      <Setter Property="CornerRadius" Value="3" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="Template">
-         <ControlTemplate>
+  <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
+    <Setter Property="Padding" Value="10 3 " />
+    <Setter Property="CornerRadius" Value="3" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Name="LayoutRoot"
+          Background="Transparent"
+          MinHeight="24"
+          CornerRadius="{TemplateBinding CornerRadius}"
+          Padding="0 7 0 5">
+          <StackPanel Orientation="Horizontal">
             <Border
-               Name="LayoutRoot"
-               Background="Transparent"
-               MinHeight="24"
-               CornerRadius="{TemplateBinding CornerRadius}"
-               Padding="0 7 0 5">
-               <StackPanel Orientation="Horizontal">
-                  <Border
-                     Name="SelectionHighlight"
-                     Width="2"
-                     VerticalAlignment="Stretch"
-                     Background="Transparent"
-                     CornerRadius="2" />
-                  <ContentPresenter
-                     Name="PART_ContentPresenter"
-                     FontSize="{TemplateBinding FontSize}"
-                     Foreground="{TemplateBinding Foreground}"
-                     ContentTemplate="{TemplateBinding ContentTemplate}"
-                     Content="{TemplateBinding Content}"
-                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                     Padding="{TemplateBinding Padding}" />
-               </StackPanel>
-            </Border>
-         </ControlTemplate>
-      </Setter>
+              Name="SelectionHighlight"
+              Width="2"
+              VerticalAlignment="Stretch"
+              Background="Transparent"
+              CornerRadius="2" />
+            <ContentPresenter
+              Name="PART_ContentPresenter"
+              FontSize="{TemplateBinding FontSize}"
+              Foreground="{TemplateBinding Foreground}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              Content="{TemplateBinding Content}"
+              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+              Padding="{TemplateBinding Padding}" />
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
 
-      <!--  Selected state  -->
-      <Style Selector="^:selected">
-         <Style Selector="^ /template/ Border#LayoutRoot">
-            <Setter
-               Property="Background"
-               Value="{BindingToggler
+    <!--  Selected state  -->
+    <Style Selector="^:selected">
+      <Style Selector="^ /template/ Border#LayoutRoot">
+        <Setter
+          Property="Background"
+          Value="{BindingToggler
                   {Binding IsPointerOver, RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
                   {DynamicResource ComboBoxItemBackgroundBrush},
                   {DynamicResource ControlBackgroundSelectedBrush}
                }" />
-         </Style>
-         <Style Selector="^ /template/ Border#SelectionHighlight">
-            <Setter
-               Property="Background"
-               Value="{BindingToggler
+      </Style>
+      <Style Selector="^ /template/ Border#SelectionHighlight">
+        <Setter
+          Property="Background"
+          Value="{BindingToggler
                   {Binding IsPointerOver, RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
                   {DynamicResource TransparentBrush},
                   {DynamicResource ControlBorderSelectedBrush}
                }" />
-         </Style>
       </Style>
+    </Style>
 
-      <!--  PointerOver state  -->
-      <Style Selector="^:pointerover">
-         <Style Selector="^ /template/ Border#LayoutRoot">
-            <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
-         </Style>
-         <Style Selector="^ /template/ Border#SelectionHighlight">
-            <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
-         </Style>
+    <!--  PointerOver state  -->
+    <Style Selector="^:pointerover">
+      <Style Selector="^ /template/ Border#LayoutRoot">
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
       </Style>
-
-      <!--  Disabled state  -->
-      <Style Selector="^:disabled /template/ ContentPresenter">
-         <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushDisabled}" />
-         <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
+      <Style Selector="^ /template/ Border#SelectionHighlight">
+        <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
       </Style>
+    </Style>
 
-   </ControlTheme>
+    <!--  Disabled state  -->
+    <Style Selector="^:disabled /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushDisabled}" />
+      <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
+    </Style>
+
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ContextMenu.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ContextMenu.axaml
@@ -5,81 +5,82 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
-    <Design.PreviewWith>
-        <Border Background="{DynamicResource SystemAccentColor}"
-                Margin="16"
-                Padding="48"
-                Width="400"
-                Height="200">
-            <Border.ContextMenu>
-                <ContextMenu>
-                    <MenuItem Header="Standard _Menu Item" />
-                    <MenuItem Header="Disabled" IsEnabled="False" />
-                    <Separator />
-                    <MenuItem Header="Menu with _Submenu">
-                        <MenuItem Header="Submenu _1" />
-                        <MenuItem Header="Submenu _2" />
-                    </MenuItem>
-                    <MenuItem Header="Menu Item with _Icon" />
-                    <MenuItem Header="Menu Item with _Checkbox">
-                        <MenuItem.Icon>
-                            <CheckBox BorderThickness="0"
-                                      IsHitTestVisible="False"
-                                      IsChecked="True" />
-                        </MenuItem.Icon>
-                    </MenuItem>
-                </ContextMenu>
-            </Border.ContextMenu>
-            <TextBlock Text="Defined in XAML" />
+
+  <Design.PreviewWith>
+    <Border Background="{DynamicResource SystemAccentColor}"
+            Margin="16"
+            Padding="48"
+            Width="400"
+            Height="200">
+      <Border.ContextMenu>
+        <ContextMenu>
+          <MenuItem Header="Standard _Menu Item" />
+          <MenuItem Header="Disabled" IsEnabled="False" />
+          <Separator />
+          <MenuItem Header="Menu with _Submenu">
+            <MenuItem Header="Submenu _1" />
+            <MenuItem Header="Submenu _2" />
+          </MenuItem>
+          <MenuItem Header="Menu Item with _Icon" />
+          <MenuItem Header="Menu Item with _Checkbox">
+            <MenuItem.Icon>
+              <CheckBox BorderThickness="0"
+                        IsHitTestVisible="False"
+                        IsChecked="True" />
+            </MenuItem.Icon>
+          </MenuItem>
+        </ContextMenu>
+      </Border.ContextMenu>
+      <TextBlock Text="Defined in XAML" />
+    </Border>
+  </Design.PreviewWith>
+
+  <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
+  <Thickness x:Key="MenuIconPresenterMargin">4 0 10 0</Thickness>
+
+  <ControlTheme x:Key="{x:Type Separator}" TargetType="Separator" BasedOn="{StaticResource {x:Type Separator}}">
+    <Setter Property="Margin" Value="40,0,-4,0" />
+    <Setter Property="Background" Value="{DynamicResource Border}" />
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type MenuItem}" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
+    <Setter Property="Padding" Value="4" />
+    <Setter Property="Margin" Value="4" />
+    <Setter Property="CornerRadius" Value="4" />
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type ContextMenu}" TargetType="ContextMenu">
+    <Setter Property="Background" Value="{DynamicResource BackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="MaxWidth" Value="{DynamicResource FlyoutThemeMaxWidth}" />
+    <Setter Property="MinHeight" Value="{DynamicResource MenuFlyoutThemeMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource MenuFlyoutPresenterThemePadding}" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="WindowManagerAddShadowHint" Value="False" />
+    <Setter Property="FontSize" Value="12" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Padding="{TemplateBinding Padding}"
+                MaxWidth="{TemplateBinding MaxWidth}"
+                MinHeight="{TemplateBinding MinHeight}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <ScrollViewer>
+            <ItemsPresenter Name="PART_ItemsPresenter"
+                            ItemsPanel="{TemplateBinding ItemsPanel}"
+                            Margin="0"
+                            KeyboardNavigation.TabNavigation="Continue"
+                            Grid.IsSharedSizeScope="True" />
+          </ScrollViewer>
         </Border>
-    </Design.PreviewWith>
-
-    <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
-    <Thickness x:Key="MenuIconPresenterMargin">4 0 10 0</Thickness>
-    
-    <ControlTheme x:Key="{x:Type Separator}" TargetType="Separator" BasedOn="{StaticResource {x:Type Separator}}">
-        <Setter Property="Margin" Value="40,0,-4,0" />
-        <Setter Property="Background" Value="{DynamicResource Border}" />
-    </ControlTheme>
-    
-    <ControlTheme x:Key="{x:Type MenuItem}" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
-        <Setter Property="Padding" Value="4" />
-        <Setter Property="Margin" Value="4" />
-        <Setter Property="CornerRadius" Value="4" />
-    </ControlTheme>
-
-    <ControlTheme x:Key="{x:Type ContextMenu}" TargetType="ContextMenu">
-        <Setter Property="Background" Value="{DynamicResource BackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
-        <Setter Property="BorderThickness" Value="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}" />
-        <Setter Property="CornerRadius" Value="{DynamicResource OverlayCornerRadius}" />
-        <Setter Property="Focusable" Value="True" />
-        <Setter Property="MaxWidth" Value="{DynamicResource FlyoutThemeMaxWidth}" />
-        <Setter Property="MinHeight" Value="{DynamicResource MenuFlyoutThemeMinHeight}" />
-        <Setter Property="Padding" Value="{DynamicResource MenuFlyoutPresenterThemePadding}" />
-        <Setter Property="HorizontalAlignment" Value="Stretch" />
-        <Setter Property="WindowManagerAddShadowHint" Value="False" />
-        <Setter Property="FontSize" Value="12" />
-        
-        <Setter Property="Template">
-            <ControlTemplate>
-                <Border Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        Padding="{TemplateBinding Padding}"
-                        MaxWidth="{TemplateBinding MaxWidth}"
-                        MinHeight="{TemplateBinding MinHeight}"
-                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                        CornerRadius="{TemplateBinding CornerRadius}">
-                    <ScrollViewer>
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}"
-                                        Margin="0"
-                                        KeyboardNavigation.TabNavigation="Continue"
-                                        Grid.IsSharedSizeScope="True" />
-                    </ScrollViewer>
-                </Border>
-            </ControlTemplate>
-        </Setter>
-    </ControlTheme>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
@@ -1,355 +1,356 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   x:ClassModifier="internal">
-   <Design.PreviewWith>
-      <StackPanel Width="400" Height="400" Spacing="20">
-         <EditableComboBox
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Watermark="test2">
-            <EditableComboBoxItem Value="test1" />
-            <EditableComboBoxItem Value="test2" />
-            <EditableComboBoxItem Value="test3" />
-         </EditableComboBox>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:ClassModifier="internal">
 
-         <EditableComboBox
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Watermark="test">
-            <EditableComboBox.InnerLeftContent>
-               <Label Content="A" />
-            </EditableComboBox.InnerLeftContent>
-            <EditableComboBox.InnerRightContent>
-               <Label Content="B" />
-            </EditableComboBox.InnerRightContent>
+  <Design.PreviewWith>
+    <StackPanel Width="400" Height="400" Spacing="20">
+      <EditableComboBox
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Watermark="test2">
+        <EditableComboBoxItem Value="test1" />
+        <EditableComboBoxItem Value="test2" />
+        <EditableComboBoxItem Value="test3" />
+      </EditableComboBox>
 
-            <EditableComboBoxItem Value="test1" />
-            <EditableComboBoxItem Value="test2" />
-            <EditableComboBoxItem Value="test3" />
-         </EditableComboBox>
-      </StackPanel>
-   </Design.PreviewWith>
+      <EditableComboBox
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Watermark="test">
+        <EditableComboBox.InnerLeftContent>
+          <Label Content="A" />
+        </EditableComboBox.InnerLeftContent>
+        <EditableComboBox.InnerRightContent>
+          <Label Content="B" />
+        </EditableComboBox.InnerRightContent>
 
-   <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
-   <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
-   <Thickness x:Key="EditableComboBoxItemPadding">10,3</Thickness>
-   <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
-   <x:Double x:Key="EditableComboBoxHeight">22</x:Double>
-   <x:Double x:Key="EditableComboBoxItemsHeight">28</x:Double>
-   <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushFocused" Color="{DynamicResource SystemAccentColor}" />
+        <EditableComboBoxItem Value="test1" />
+        <EditableComboBoxItem Value="test2" />
+        <EditableComboBoxItem Value="test3" />
+      </EditableComboBox>
+    </StackPanel>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" BasedOn="{StaticResource {x:Type EditableComboBoxItem}}">
-      <Setter Property="IsHitTestVisible" Value="True" />
-      <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
+  <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
+  <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
+  <Thickness x:Key="EditableComboBoxItemPadding">10,3</Thickness>
+  <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
+  <x:Double x:Key="EditableComboBoxHeight">22</x:Double>
+  <x:Double x:Key="EditableComboBoxItemsHeight">28</x:Double>
+  <SolidColorBrush x:Key="ComboBoxBackgroundBorderBrushFocused" Color="{DynamicResource SystemAccentColor}" />
+
+  <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" BasedOn="{StaticResource {x:Type EditableComboBoxItem}}">
+    <Setter Property="IsHitTestVisible" Value="True" />
+    <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Padding" Value="{DynamicResource EditableComboBoxItemPadding}" />
+
+    <Style
+      Selector="^:pointerover /template/ Border#PART_Background, ^[IsSelected=True] /template/ Border#PART_Background">
       <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Padding" Value="{DynamicResource EditableComboBoxItemPadding}" />
+    </Style>
 
-      <Style
-         Selector="^:pointerover /template/ Border#PART_Background, ^[IsSelected=True] /template/ Border#PART_Background">
-         <Setter Property="Background" Value="Transparent" />
-      </Style>
+    <Style Selector="^:pointerover /template/ SearchHighlightTextBlock#PART_Text">
+      <Setter Property="Foreground" Value="{DynamicResource EditableComboBoxItemHoverForegroundColor}" />
+    </Style>
 
-      <Style Selector="^:pointerover /template/ SearchHighlightTextBlock#PART_Text">
-         <Setter Property="Foreground" Value="{DynamicResource EditableComboBoxItemHoverForegroundColor}" />
-      </Style>
+    <Style Selector="^[IsSelected=True] /template/ SearchHighlightTextBlock#PART_Text">
+      <Setter Property="Foreground" Value="{DynamicResource EditableComboBoxItemHoverForegroundColor}" />
+    </Style>
 
-      <Style Selector="^[IsSelected=True] /template/ SearchHighlightTextBlock#PART_Text">
-         <Setter Property="Foreground" Value="{DynamicResource EditableComboBoxItemHoverForegroundColor}" />
-      </Style>
+    <Style Selector="^:disabled /template/ SearchHighlightTextBlock#PART_Text">
+      <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
+    </Style>
 
-      <Style Selector="^:disabled /template/ SearchHighlightTextBlock#PART_Text">
-         <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
-      </Style>
+    <Style Selector="^:pressed /template/ SearchHighlightTextBlock#PART_Text">
+      <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPressed}" />
+    </Style>
+  </ControlTheme>
 
-      <Style Selector="^:pressed /template/ SearchHighlightTextBlock#PART_Text">
-         <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPressed}" />
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}" TargetType="EditableComboBox+InnerTextBox">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="BorderBrush" Value="Transparent" />
-      <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="CornerRadius" Value="0" />
-      <Setter Property="MinHeight" Value="0" />
-      <Setter Property="Margin"
-              Value="{Binding 
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}" TargetType="EditableComboBox+InnerTextBox">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderBrush" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="Margin"
+            Value="{Binding 
             Padding, 
             RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox},
             Converter={x:Static DevoConverters.ThicknessExtractor}, 
             ConverterParameter={x:Static ThicknessSubset.AllButRight}
         }" />
-      <Setter Property="Padding" Value="0" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ContextFlyout"
-              Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Grid ColumnDefinitions="Auto,*,Auto">
-               <DockPanel x:Name="PART_InnerDockPanel" Grid.Column="1" Margin="{TemplateBinding Padding}">
-                  <TextBlock
-                     Name="PART_FloatingWatermark"
-                     Foreground="{DynamicResource SystemAccentColor}"
-                     IsVisible="False"
-                     Text="{TemplateBinding Watermark}"
-                     DockPanel.Dock="Top" />
-                  <ScrollViewer
-                     Name="PART_ScrollViewer"
-                     HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                     VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                     IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                     AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                     BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                     <Panel>
-                        <TextBlock
-                           Name="PART_Watermark"
-                           Opacity="0.5"
-                           Text="{TemplateBinding Watermark}"
-                           TextAlignment="{TemplateBinding TextAlignment}"
-                           TextWrapping="{TemplateBinding TextWrapping}"
-                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                           <TextBlock.IsVisible>
-                              <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                 <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                          Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                                 <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                          Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                              </MultiBinding>
-                           </TextBlock.IsVisible>
-                        </TextBlock>
-                        <TextPresenter
-                           Name="PART_TextPresenter"
-                           Text="{TemplateBinding Text, Mode=TwoWay}"
-                           CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                           CaretIndex="{TemplateBinding CaretIndex}"
-                           SelectionStart="{TemplateBinding SelectionStart}"
-                           SelectionEnd="{TemplateBinding SelectionEnd}"
-                           TextAlignment="{TemplateBinding TextAlignment}"
-                           TextWrapping="{TemplateBinding TextWrapping}"
-                           LineHeight="{TemplateBinding LineHeight}"
-                           LetterSpacing="{TemplateBinding LetterSpacing}"
-                           PasswordChar="{TemplateBinding PasswordChar}"
-                           RevealPassword="{TemplateBinding RevealPassword}"
-                           SelectionBrush="{TemplateBinding SelectionBrush}"
-                           SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                           CaretBrush="{TemplateBinding CaretBrush}"
-                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                     </Panel>
-                  </ScrollViewer>
-               </DockPanel>
-            </Grid>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ContextFlyout"
+            Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid ColumnDefinitions="Auto,*,Auto">
+          <DockPanel x:Name="PART_InnerDockPanel" Grid.Column="1" Margin="{TemplateBinding Padding}">
+            <TextBlock
+              Name="PART_FloatingWatermark"
+              Foreground="{DynamicResource SystemAccentColor}"
+              IsVisible="False"
+              Text="{TemplateBinding Watermark}"
+              DockPanel.Dock="Top" />
+            <ScrollViewer
+              Name="PART_ScrollViewer"
+              HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+              IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+              AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+              BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+              <Panel>
+                <TextBlock
+                  Name="PART_Watermark"
+                  Opacity="0.5"
+                  Text="{TemplateBinding Watermark}"
+                  TextAlignment="{TemplateBinding TextAlignment}"
+                  TextWrapping="{TemplateBinding TextWrapping}"
+                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                  <TextBlock.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                      <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                               Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                      <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                               Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                    </MultiBinding>
+                  </TextBlock.IsVisible>
+                </TextBlock>
+                <TextPresenter
+                  Name="PART_TextPresenter"
+                  Text="{TemplateBinding Text, Mode=TwoWay}"
+                  CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                  CaretIndex="{TemplateBinding CaretIndex}"
+                  SelectionStart="{TemplateBinding SelectionStart}"
+                  SelectionEnd="{TemplateBinding SelectionEnd}"
+                  TextAlignment="{TemplateBinding TextAlignment}"
+                  TextWrapping="{TemplateBinding TextWrapping}"
+                  LineHeight="{TemplateBinding LineHeight}"
+                  LetterSpacing="{TemplateBinding LetterSpacing}"
+                  PasswordChar="{TemplateBinding PasswordChar}"
+                  RevealPassword="{TemplateBinding RevealPassword}"
+                  SelectionBrush="{TemplateBinding SelectionBrush}"
+                  SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                  CaretBrush="{TemplateBinding CaretBrush}"
+                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+              </Panel>
+            </ScrollViewer>
+          </DockPanel>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}"
-                 TargetType="EditableComboBox+InnerComboBox">
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="MaxDropDownHeight" Value="504" />
-      <Setter Property="Foreground"
-              Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Background"
-              Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderBrush"
-              Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderThickness"
-              Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="CornerRadius"
-              Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Padding"
-              Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="MinHeight"
-              Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerLeftContent"
-              Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerRightContent"
-              Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors>
-               <Grid ColumnDefinitions="Auto,*,24,Auto" HorizontalAlignment="Stretch">
-                  <Border
-                     Name="BorderElement"
-                     Grid.Column="0"
-                     Grid.ColumnSpan="4"
-                     Background="{TemplateBinding Background}"
-                     BorderBrush="{DynamicResource TextBoxBorderBrush}"
-                     BorderThickness="1 1 1 0"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}" />
-                  <Border
-                     Name="BottomBorderElement"
-                     Grid.Column="0"
-                     Grid.ColumnSpan="4"
-                     Background="Transparent"
-                     Margin="1 0"
-                     BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
-                     BorderThickness="0 0 0 1"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}" />
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}"
+                TargetType="EditableComboBox+InnerComboBox">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="MaxDropDownHeight" Value="504" />
+    <Setter Property="Foreground"
+            Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Background"
+            Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderBrush"
+            Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderThickness"
+            Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="CornerRadius"
+            Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Padding"
+            Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="MinHeight"
+            Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerLeftContent"
+            Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerRightContent"
+            Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors>
+          <Grid ColumnDefinitions="Auto,*,24,Auto" HorizontalAlignment="Stretch">
+            <Border
+              Name="BorderElement"
+              Grid.Column="0"
+              Grid.ColumnSpan="4"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{DynamicResource TextBoxBorderBrush}"
+              BorderThickness="1 1 1 0"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}" />
+            <Border
+              Name="BottomBorderElement"
+              Grid.Column="0"
+              Grid.ColumnSpan="4"
+              Background="Transparent"
+              Margin="1 0"
+              BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
+              BorderThickness="0 0 0 1"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}" />
 
-                  <ItemsControl
-                     Grid.Column="0"
-                     Name="PART_InnerLeftContent"
-                     ItemsSource="{TemplateBinding InnerLeftContent}">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <StackPanel Orientation="Horizontal" Margin="2 2 0 2" />
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                  </ItemsControl>
+            <ItemsControl
+              Grid.Column="0"
+              Name="PART_InnerLeftContent"
+              ItemsSource="{TemplateBinding InnerLeftContent}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Orientation="Horizontal" Margin="2 2 0 2" />
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+            </ItemsControl>
 
-                  <ContentPresenter x:Name="PART_TextBoxPresenter" Grid.Column="1" />
+            <ContentPresenter x:Name="PART_TextBoxPresenter" Grid.Column="1" />
 
-                  <Panel Grid.Column="2" Margin="0 0 1 0" HorizontalAlignment="Right" VerticalAlignment="Center"
-                         Width="17" Height="16">
-                     <Border
-                        Name="DropDownGlyphBackground"
-                        Background="Transparent"
-                        CornerRadius="{DynamicResource ControlCornerRadius}" />
-                     <PathIcon
-                        Name="DropDownGlyph"
-                        UseLayoutRounding="False"
-                        IsHitTestVisible="False"
-                        Height="8"
-                        Width="8"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Foreground="{DynamicResource ForegroundHighBrush}"
-                        Data="{StaticResource ChevronPath}" />
-                  </Panel>
+            <Panel Grid.Column="2" Margin="0 0 1 0" HorizontalAlignment="Right" VerticalAlignment="Center"
+                   Width="17" Height="16">
+              <Border
+                Name="DropDownGlyphBackground"
+                Background="Transparent"
+                CornerRadius="{DynamicResource ControlCornerRadius}" />
+              <PathIcon
+                Name="DropDownGlyph"
+                UseLayoutRounding="False"
+                IsHitTestVisible="False"
+                Height="8"
+                Width="8"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Foreground="{DynamicResource ForegroundHighBrush}"
+                Data="{StaticResource ChevronPath}" />
+            </Panel>
 
-                  <ItemsControl
-                     Grid.Column="3"
-                     Name="PART_InnerRightContent"
-                     ItemsSource="{TemplateBinding InnerRightContent}">
-                     <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                           <StackPanel Orientation="Horizontal" Margin="0 2 2 2" />
-                        </ItemsPanelTemplate>
-                     </ItemsControl.ItemsPanel>
-                  </ItemsControl>
+            <ItemsControl
+              Grid.Column="3"
+              Name="PART_InnerRightContent"
+              ItemsSource="{TemplateBinding InnerRightContent}">
+              <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                  <StackPanel Orientation="Horizontal" Margin="0 2 2 2" />
+                </ItemsPanelTemplate>
+              </ItemsControl.ItemsPanel>
+            </ItemsControl>
 
-                  <Popup
-                     Name="PART_Popup"
-                     WindowManagerAddShadowHint="False"
-                     IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
-                     MinWidth="{AddBinding
+            <Popup
+              Name="PART_Popup"
+              WindowManagerAddShadowHint="False"
+              IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+              MinWidth="{AddBinding
                         {Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}},
                         12
                      }"
-                     MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                     Placement="AnchorAndGravity"
-                     PlacementAnchor="BottomLeft"
-                     PlacementGravity="BottomRight"
-                     HorizontalAlignment="Stretch"
-                     HorizontalOffset="-6"
-                     VerticalOffset="0"
-                     IsLightDismissEnabled="True"
-                     OverlayDismissEventPassThrough="True"
-                     InheritsTransform="True">
-                     <Panel>
-                        <Border
-                           x:Name="PopupBorder"
-                           Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
-                           BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                           BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                           Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                           HorizontalAlignment="Stretch"
-                           BoxShadow="{DynamicResource EditableComboBoxBoxShadow}"
-                           Margin="6 0 6 6"
-                           CornerRadius="0">
-                           <ScrollViewer
-                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                              IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
-                              <ItemsPresenter
-                                 Name="PART_ItemsPresenter"
-                                 Margin="{DynamicResource ComboBoxDropdownContentMargin}"
-                                 ItemsPanel="{TemplateBinding ItemsPanel}" />
-                           </ScrollViewer>
-                        </Border>
-                     </Panel>
-                  </Popup>
-               </Grid>
-            </DataValidationErrors>
-         </ControlTemplate>
-      </Setter>
+              MaxHeight="{TemplateBinding MaxDropDownHeight}"
+              Placement="AnchorAndGravity"
+              PlacementAnchor="BottomLeft"
+              PlacementGravity="BottomRight"
+              HorizontalAlignment="Stretch"
+              HorizontalOffset="-6"
+              VerticalOffset="0"
+              IsLightDismissEnabled="True"
+              OverlayDismissEventPassThrough="True"
+              InheritsTransform="True">
+              <Panel>
+                <Border
+                  x:Name="PopupBorder"
+                  Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
+                  BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                  BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
+                  Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+                  HorizontalAlignment="Stretch"
+                  BoxShadow="{DynamicResource EditableComboBoxBoxShadow}"
+                  Margin="6 0 6 6"
+                  CornerRadius="0">
+                  <ScrollViewer
+                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                    IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
+                    <ItemsPresenter
+                      Name="PART_ItemsPresenter"
+                      Margin="{DynamicResource ComboBoxDropdownContentMargin}"
+                      ItemsPanel="{TemplateBinding ItemsPanel}" />
+                  </ScrollViewer>
+                </Border>
+              </Panel>
+            </Popup>
+          </Grid>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
 
-      <!-- Error State -->
-      <Style Selector="^:error /template/ Border#Background">
-         <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    <!-- Error State -->
+    <Style Selector="^:error /template/ Border#Background">
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    </Style>
+
+    <!--  Focused State  -->
+    <Style Selector="^:focus-within">
+      <Style Selector="^ /template/ Border#BottomBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1.6" />
+      </Style>
+    </Style>
+
+    <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">
+      <Setter Property="Background" Value="{DynamicResource EditableComboBoxGlyphHoverBrush}" />
+    </Style>
+
+    <Style Selector="^:dropdownopen">
+      <Style Selector="^ /template/ Border#BottomBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1.6" />
+      </Style>
+      <Style Selector="^ /template/ Border#DropDownGlyphBackground">
+        <Setter Property="Background" Value="{DynamicResource EditableComboBoxGlyphPressedBrush}" />
+      </Style>
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Opacity" Value="0.5" />
       </Style>
 
-      <!--  Focused State  -->
-      <Style Selector="^:focus-within">
-         <Style Selector="^ /template/ Border#BottomBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
-            <Setter Property="BorderThickness" Value="0 0 0 1.6" />
-         </Style>
+      <Style Selector="^:dropdown-open-from-top /template/ Popup#PART_Popup">
+        <Setter Property="VerticalOffset" Value="6" />
       </Style>
+    </Style>
 
-      <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">
-         <Setter Property="Background" Value="{DynamicResource EditableComboBoxGlyphHoverBrush}" />
+    <!--  Disabled State  -->
+    <Style Selector="^:disabled">
+      <Style Selector="^ /template/ Border#Background">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
       </Style>
-
-      <Style Selector="^:dropdownopen">
-         <Style Selector="^ /template/ Border#BottomBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
-            <Setter Property="BorderThickness" Value="0 0 0 1.6" />
-         </Style>
-         <Style Selector="^ /template/ Border#DropDownGlyphBackground">
-            <Setter Property="Background" Value="{DynamicResource EditableComboBoxGlyphPressedBrush}" />
-         </Style>
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Opacity" Value="0.5" />
-         </Style>
-
-         <Style Selector="^:dropdown-open-from-top /template/ Popup#PART_Popup">
-            <Setter Property="VerticalOffset" Value="6" />
-         </Style>
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
       </Style>
+    </Style>
+  </ControlTheme>
 
-      <!--  Disabled State  -->
-      <Style Selector="^:disabled">
-         <Style Selector="^ /template/ Border#Background">
-            <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-         </Style>
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
-         </Style>
-      </Style>
-   </ControlTheme>
+  <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox"
+                BasedOn="{StaticResource {x:Type EditableComboBox}}">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionBrush}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Padding" Value="4 3 2 3" />
+    <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
 
-   <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox"
-                 BasedOn="{StaticResource {x:Type EditableComboBox}}">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
-      <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionBrush}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Padding" Value="4 3 2 3" />
-      <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
-
-      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
-      <Setter Property="Mode" Value="Immediate" />
-   </ControlTheme>
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
+    <Setter Property="Mode" Value="Immediate" />
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ScrollBar.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ScrollBar.axaml
@@ -1,365 +1,365 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <Design.PreviewWith>
-      <Border Padding="20">
-         <StackPanel Orientation="Horizontal" Spacing="20">
-            <StackPanel Spacing="20">
-               <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100" />
-               <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100"
-                          IsEnabled="False" />
-               <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100" />
-               <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100"
-                          IsEnabled="False" />
-            </StackPanel>
-            <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="150" />
-            <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="150"
-                       IsEnabled="False" />
-            <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="150" />
-            <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="150"
-                       IsEnabled="False" />
-         </StackPanel>
-      </Border>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <StackPanel Orientation="Horizontal" Spacing="20">
+        <StackPanel Spacing="20">
+          <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100" />
+          <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100"
+                     IsEnabled="False" />
+          <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100" />
+          <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100"
+                     IsEnabled="False" />
+        </StackPanel>
+        <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="150" />
+        <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="150"
+                   IsEnabled="False" />
+        <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="150" />
+        <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="150"
+                   IsEnabled="False" />
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="FluentScrollBarThumb" TargetType="Thumb">
-      <Setter Property="Background" Value="{DynamicResource ScrollBarThumbBrush}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ScrollBarThumbCornerRadius}" />
+  <ControlTheme x:Key="FluentScrollBarThumb" TargetType="Thumb">
+    <Setter Property="Background" Value="{DynamicResource ScrollBarThumbBrush}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ScrollBarThumbCornerRadius}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Border Name="ThumbHitTarget">
+            <Border Width="{TemplateBinding Width}"
+                    Height="{TemplateBinding Height}"
+                    Background="{TemplateBinding Background}"
+                    CornerRadius="{TemplateBinding CornerRadius}" />
+          </Border>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Transitions">
+      <Transitions>
+        <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.1" />
+        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.1" />
+      </Transitions>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="FluentScrollBarPageButton" TargetType="RepeatButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="Opacity" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}" />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="FluentScrollBarLineButton" TargetType="RepeatButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Opacity" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter x:Name="PART_ContentPresenter"
+                          Content="{TemplateBinding Content}" />
+      </ControlTemplate>
+    </Setter>
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
+      </Transitions>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type ScrollBar}" TargetType="ScrollBar">
+    <Setter Property="MinWidth" Value="{DynamicResource ScrollBarSize}" />
+    <Setter Property="MinHeight" Value="{DynamicResource ScrollBarSize}" />
+    <Setter Property="Background" Value="{DynamicResource ScrollBarBackgroundBrush}" />
+
+    <Style Selector="^:vertical">
       <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate>
-               <Border Name="ThumbHitTarget">
-                  <Border Width="{TemplateBinding Width}"
-                          Height="{TemplateBinding Height}"
-                          Background="{TemplateBinding Background}"
-                          CornerRadius="{TemplateBinding CornerRadius}" />
-               </Border>
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="Transitions">
-         <Transitions>
-            <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.1" />
-            <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.1" />
-         </Transitions>
-      </Setter>
-   </ControlTheme>
+        <ControlTemplate>
+          <Grid x:Name="Root">
+            <Border x:Name="VerticalRoot"
+                    Background="{TemplateBinding Background}">
+              <Grid Name="InteractiveElements"
+                    RowDefinitions="Auto,*,Auto">
 
-   <ControlTheme x:Key="FluentScrollBarPageButton" TargetType="RepeatButton">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-      <Setter Property="Opacity" Value="0" />
+                <RepeatButton Name="PART_LineUpButton"
+                              Grid.Row="0"
+                              HorizontalAlignment="Center"
+                              Theme="{StaticResource FluentScrollBarLineButton}"
+                              Focusable="False"
+                              MinWidth="{DynamicResource ScrollBarSize}"
+                              Height="{DynamicResource ScrollBarSize}">
+                  <PathIcon Name="UpArrow"
+                            Data="{DynamicResource ScrollBarLineButtonPath}"
+                            Foreground="{DynamicResource ScrollBarThumbBrush}"
+                            HorizontalAlignment="Center"
+                            Width="7" />
+                </RepeatButton>
+
+                <Track Grid.Row="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}"
+                       IsDirectionReversed="True">
+                  <Track.DecreaseButton>
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource FluentScrollBarPageButton}"
+                                  Focusable="False" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource FluentScrollBarPageButton}"
+                                  Focusable="False" />
+                  </Track.IncreaseButton>
+                  <Thumb Theme="{StaticResource FluentScrollBarThumb}"
+                         Width="7"
+                         MinHeight="{DynamicResource ScrollBarSize}"
+                         RenderTransform="{DynamicResource VerticalScrollThumbShrinkTransform}"
+                         RenderTransformOrigin="50%,100%" />
+                </Track>
+
+                <RepeatButton Name="PART_LineDownButton"
+                              Grid.Row="2"
+                              Theme="{StaticResource FluentScrollBarLineButton}"
+                              HorizontalAlignment="Center"
+                              Focusable="False"
+                              MinWidth="{DynamicResource ScrollBarSize}"
+                              Height="{DynamicResource ScrollBarSize}">
+                  <PathIcon Name="DownArrow"
+                            Data="{DynamicResource ScrollBarLineButtonPath}"
+                            Foreground="{DynamicResource ScrollBarThumbBrush}"
+                            HorizontalAlignment="Center"
+                            Width="7">
+                    <PathIcon.RenderTransform>
+                      <ScaleTransform ScaleY="-1" />
+                    </PathIcon.RenderTransform>
+                  </PathIcon>
+                </RepeatButton>
+              </Grid>
+            </Border>
+          </Grid>
+        </ControlTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:horizontal">
       <Setter Property="Template">
-         <ControlTemplate>
-            <Border Background="{TemplateBinding Background}" />
-         </ControlTemplate>
+        <ControlTemplate>
+          <Grid x:Name="Root">
+            <Border x:Name="HorizontalRoot"
+                    Background="{TemplateBinding Background}">
+              <Grid Name="InteractiveElements"
+                    ColumnDefinitions="Auto,*,Auto">
+
+                <RepeatButton Name="PART_LineUpButton"
+                              Grid.Column="0"
+                              VerticalAlignment="Center"
+                              Theme="{StaticResource FluentScrollBarLineButton}"
+                              Focusable="False"
+                              MinHeight="{DynamicResource ScrollBarSize}"
+                              Width="{DynamicResource ScrollBarSize}">
+                  <PathIcon Name="LeftArrow"
+                            Data="{DynamicResource ScrollBarLineButtonPath}"
+                            Foreground="{DynamicResource ScrollBarThumbBrush}"
+                            HorizontalAlignment="Center"
+                            Width="7">
+                    <PathIcon.RenderTransform>
+                      <RotateTransform Angle="-90" />
+                    </PathIcon.RenderTransform>
+                  </PathIcon>
+                </RepeatButton>
+
+                <Track Grid.Column="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}">
+                  <Track.DecreaseButton>
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource FluentScrollBarPageButton}"
+                                  Focusable="False" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource FluentScrollBarPageButton}"
+                                  Focusable="False" />
+                  </Track.IncreaseButton>
+                  <Thumb Theme="{StaticResource FluentScrollBarThumb}"
+                         Height="7"
+                         MinWidth="{DynamicResource ScrollBarSize}"
+                         RenderTransform="{DynamicResource HorizontalScrollThumbShrinkTransform}"
+                         RenderTransformOrigin="100%,50%" />
+                </Track>
+
+                <RepeatButton Name="PART_LineDownButton"
+                              Grid.Column="2"
+                              Theme="{StaticResource FluentScrollBarLineButton}"
+                              VerticalAlignment="Center"
+                              Focusable="False"
+                              MinHeight="{DynamicResource ScrollBarSize}"
+                              Width="{DynamicResource ScrollBarSize}">
+                  <PathIcon Name="RightArrow"
+                            Data="{DynamicResource ScrollBarLineButtonPath}"
+                            Foreground="{DynamicResource ScrollBarThumbBrush}"
+                            HorizontalAlignment="Center"
+                            Width="7">
+                    <PathIcon.RenderTransform>
+                      <RotateTransform Angle="90" />
+                    </PathIcon.RenderTransform>
+                  </PathIcon>
+                </RepeatButton>
+              </Grid>
+            </Border>
+          </Grid>
+        </ControlTemplate>
       </Setter>
-   </ControlTheme>
+    </Style>
 
-   <ControlTheme x:Key="FluentScrollBarLineButton" TargetType="RepeatButton">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Opacity" Value="0" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <ContentPresenter x:Name="PART_ContentPresenter"
-                              Content="{TemplateBinding Content}" />
-         </ControlTemplate>
+    <Style Selector="^:disabled /template/ Grid#InteractiveElements">
+      <Setter Property="Opacity" Value="0.3" />
+    </Style>
+
+    <Style Selector="^ /template/ RepeatButton:pointerover">
+      <Style Selector="^ PathIcon#UpArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleX="1.2" />
+            <ScaleTransform ScaleY="1.2" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+
+      <Style Selector="^ PathIcon#DownArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleX="1.2" />
+            <ScaleTransform ScaleY="-1.2" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+
+      <Style Selector="^ PathIcon#LeftArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleX="1.2" />
+            <ScaleTransform ScaleY="1.2" />
+            <RotateTransform Angle="-90" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+
+      <Style Selector="^ PathIcon#RightArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleX="1.2" />
+            <ScaleTransform ScaleY="1.2" />
+            <RotateTransform Angle="90" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+    </Style>
+
+    <Style Selector="^ /template/ RepeatButton:pressed">
+      <Style Selector="^ PathIcon#UpArrow">
+        <Setter Property="RenderTransform" Value="none" />
+      </Style>
+      <Style Selector="^ PathIcon#DownArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleY="-1" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+      <Style Selector="^ PathIcon#LeftArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <RotateTransform Angle="-90" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+      <Style Selector="^ PathIcon#RightArrow">
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <ScaleTransform ScaleY="-1" />
+            <RotateTransform Angle="-90" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+    </Style>
+
+    <Style Selector="^ /template/ RepeatButton">
+      <Setter Property="Opacity">
+        <Setter.Value>
+          <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
+            <Binding Source="{StaticResource OpacityHidden}" />
+            <Binding Source="{StaticResource OpacityVisible}" />
+          </MultiBinding>
+        </Setter.Value>
       </Setter>
-      <Setter Property="Transitions">
-         <Transitions>
-            <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
-         </Transitions>
-      </Setter>
-   </ControlTheme>
+    </Style>
 
-   <ControlTheme x:Key="{x:Type ScrollBar}" TargetType="ScrollBar">
-      <Setter Property="MinWidth" Value="{DynamicResource ScrollBarSize}" />
-      <Setter Property="MinHeight" Value="{DynamicResource ScrollBarSize}" />
-      <Setter Property="Background" Value="{DynamicResource ScrollBarBackgroundBrush}" />
-
-      <Style Selector="^:vertical">
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Grid x:Name="Root">
-                  <Border x:Name="VerticalRoot"
-                          Background="{TemplateBinding Background}">
-                     <Grid Name="InteractiveElements"
-                           RowDefinitions="Auto,*,Auto">
-
-                        <RepeatButton Name="PART_LineUpButton"
-                                      Grid.Row="0"
-                                      HorizontalAlignment="Center"
-                                      Theme="{StaticResource FluentScrollBarLineButton}"
-                                      Focusable="False"
-                                      MinWidth="{DynamicResource ScrollBarSize}"
-                                      Height="{DynamicResource ScrollBarSize}">
-                           <PathIcon Name="UpArrow"
-                                     Data="{DynamicResource ScrollBarLineButtonPath}"
-                                     Foreground="{DynamicResource ScrollBarThumbBrush}"
-                                     HorizontalAlignment="Center"
-                                     Width="7" />
-                        </RepeatButton>
-
-                        <Track Grid.Row="1"
-                               Minimum="{TemplateBinding Minimum}"
-                               Maximum="{TemplateBinding Maximum}"
-                               Value="{TemplateBinding Value, Mode=TwoWay}"
-                               DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                               ViewportSize="{TemplateBinding ViewportSize}"
-                               Orientation="{TemplateBinding Orientation}"
-                               IsDirectionReversed="True">
-                           <Track.DecreaseButton>
-                              <RepeatButton Name="PART_PageUpButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource FluentScrollBarPageButton}"
-                                            Focusable="False" />
-                           </Track.DecreaseButton>
-                           <Track.IncreaseButton>
-                              <RepeatButton Name="PART_PageDownButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource FluentScrollBarPageButton}"
-                                            Focusable="False" />
-                           </Track.IncreaseButton>
-                           <Thumb Theme="{StaticResource FluentScrollBarThumb}"
-                                  Width="7"
-                                  MinHeight="{DynamicResource ScrollBarSize}"
-                                  RenderTransform="{DynamicResource VerticalScrollThumbShrinkTransform}"
-                                  RenderTransformOrigin="50%,100%" />
-                        </Track>
-
-                        <RepeatButton Name="PART_LineDownButton"
-                                      Grid.Row="2"
-                                      Theme="{StaticResource FluentScrollBarLineButton}"
-                                      HorizontalAlignment="Center"
-                                      Focusable="False"
-                                      MinWidth="{DynamicResource ScrollBarSize}"
-                                      Height="{DynamicResource ScrollBarSize}">
-                           <PathIcon Name="DownArrow"
-                                     Data="{DynamicResource ScrollBarLineButtonPath}"
-                                     Foreground="{DynamicResource ScrollBarThumbBrush}"
-                                     HorizontalAlignment="Center"
-                                     Width="7">
-                              <PathIcon.RenderTransform>
-                                 <ScaleTransform ScaleY="-1" />
-                              </PathIcon.RenderTransform>
-                           </PathIcon>
-                        </RepeatButton>
-                     </Grid>
-                  </Border>
-               </Grid>
-            </ControlTemplate>
-         </Setter>
-      </Style>
-
-      <Style Selector="^:horizontal">
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Grid x:Name="Root">
-                  <Border x:Name="HorizontalRoot"
-                          Background="{TemplateBinding Background}">
-                     <Grid Name="InteractiveElements"
-                           ColumnDefinitions="Auto,*,Auto">
-
-                        <RepeatButton Name="PART_LineUpButton"
-                                      Grid.Column="0"
-                                      VerticalAlignment="Center"
-                                      Theme="{StaticResource FluentScrollBarLineButton}"
-                                      Focusable="False"
-                                      MinHeight="{DynamicResource ScrollBarSize}"
-                                      Width="{DynamicResource ScrollBarSize}">
-                           <PathIcon Name="LeftArrow"
-                                     Data="{DynamicResource ScrollBarLineButtonPath}"
-                                     Foreground="{DynamicResource ScrollBarThumbBrush}"
-                                     HorizontalAlignment="Center"
-                                     Width="7">
-                              <PathIcon.RenderTransform>
-                                 <RotateTransform Angle="-90" />
-                              </PathIcon.RenderTransform>
-                           </PathIcon>
-                        </RepeatButton>
-
-                        <Track Grid.Column="1"
-                               Minimum="{TemplateBinding Minimum}"
-                               Maximum="{TemplateBinding Maximum}"
-                               Value="{TemplateBinding Value, Mode=TwoWay}"
-                               DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                               ViewportSize="{TemplateBinding ViewportSize}"
-                               Orientation="{TemplateBinding Orientation}">
-                           <Track.DecreaseButton>
-                              <RepeatButton Name="PART_PageUpButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource FluentScrollBarPageButton}"
-                                            Focusable="False" />
-                           </Track.DecreaseButton>
-                           <Track.IncreaseButton>
-                              <RepeatButton Name="PART_PageDownButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource FluentScrollBarPageButton}"
-                                            Focusable="False" />
-                           </Track.IncreaseButton>
-                           <Thumb Theme="{StaticResource FluentScrollBarThumb}"
-                                  Height="7"
-                                  MinWidth="{DynamicResource ScrollBarSize}"
-                                  RenderTransform="{DynamicResource HorizontalScrollThumbShrinkTransform}"
-                                  RenderTransformOrigin="100%,50%" />
-                        </Track>
-
-                        <RepeatButton Name="PART_LineDownButton"
-                                      Grid.Column="2"
-                                      Theme="{StaticResource FluentScrollBarLineButton}"
-                                      VerticalAlignment="Center"
-                                      Focusable="False"
-                                      MinHeight="{DynamicResource ScrollBarSize}"
-                                      Width="{DynamicResource ScrollBarSize}">
-                           <PathIcon Name="RightArrow"
-                                     Data="{DynamicResource ScrollBarLineButtonPath}"
-                                     Foreground="{DynamicResource ScrollBarThumbBrush}"
-                                     HorizontalAlignment="Center"
-                                     Width="7">
-                              <PathIcon.RenderTransform>
-                                 <RotateTransform Angle="90" />
-                              </PathIcon.RenderTransform>
-                           </PathIcon>
-                        </RepeatButton>
-                     </Grid>
-                  </Border>
-               </Grid>
-            </ControlTemplate>
-         </Setter>
-      </Style>
-
-      <Style Selector="^:disabled /template/ Grid#InteractiveElements">
-         <Setter Property="Opacity" Value="0.3" />
-      </Style>
-
-      <Style Selector="^ /template/ RepeatButton:pointerover">
-         <Style Selector="^ PathIcon#UpArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleX="1.2" />
-                  <ScaleTransform ScaleY="1.2" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-
-         <Style Selector="^ PathIcon#DownArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleX="1.2" />
-                  <ScaleTransform ScaleY="-1.2" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-
-         <Style Selector="^ PathIcon#LeftArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleX="1.2" />
-                  <ScaleTransform ScaleY="1.2" />
-                  <RotateTransform Angle="-90" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-
-         <Style Selector="^ PathIcon#RightArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleX="1.2" />
-                  <ScaleTransform ScaleY="1.2" />
-                  <RotateTransform Angle="90" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-      </Style>
-
-      <Style Selector="^ /template/ RepeatButton:pressed">
-         <Style Selector="^ PathIcon#UpArrow">
-            <Setter Property="RenderTransform" Value="none" />
-         </Style>
-         <Style Selector="^ PathIcon#DownArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleY="-1" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-         <Style Selector="^ PathIcon#LeftArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <RotateTransform Angle="-90" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-         <Style Selector="^ PathIcon#RightArrow">
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <ScaleTransform ScaleY="-1" />
-                  <RotateTransform Angle="-90" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-      </Style>
-
-      <Style Selector="^ /template/ RepeatButton">
-         <Setter Property="Opacity">
-            <Setter.Value>
-               <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
-                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
-                  <Binding Source="{StaticResource OpacityHidden}" />
-                  <Binding Source="{StaticResource OpacityVisible}" />
-               </MultiBinding>
-            </Setter.Value>
-         </Setter>
-      </Style>
-
-      <!-- Conditional styles depending on `AllowAutoHide` property -->
-      <!-- The converter is needed to avoid using <Style Selector="^[IsExpanded=True]">, which would apply also for a ScrollBar
+    <!-- Conditional styles depending on `AllowAutoHide` property -->
+    <!-- The converter is needed to avoid using <Style Selector="^[IsExpanded=True]">, which would apply also for a ScrollBar
          that was expanded by pointerover. The shrinking back of the ScrollBar would then only happen after the built-in delay,
          rather than immediately when the pointer moves off  -->
+    <Style Selector="^ /template/ Thumb">
+      <Setter Property="CornerRadius">
+        <Setter.Value>
+          <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
+            <Binding Source="{StaticResource ScrollBarThumbCornerRadius}" />
+            <Binding Source="{StaticResource ScrollBarThumbExpandedCornerRadius}" />
+          </MultiBinding>
+        </Setter.Value>
+      </Setter>
+    </Style>
+    <Style Selector="^:vertical /template/ Thumb">
+      <Setter Property="RenderTransform">
+        <Setter.Value>
+          <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
+            <Binding Source="{StaticResource VerticalScrollThumbShrinkTransform}" />
+            <Binding Source="{StaticResource NoTransform}" />
+          </MultiBinding>
+        </Setter.Value>
+      </Setter>
+    </Style>
+    <Style Selector="^:horizontal /template/ Thumb">
+      <Setter Property="RenderTransform">
+        <Setter.Value>
+          <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
+            <Binding Source="{StaticResource HorizontalScrollThumbShrinkTransform}" />
+            <Binding Source="{StaticResource NoTransform}" />
+          </MultiBinding>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:pointerover">
       <Style Selector="^ /template/ Thumb">
-         <Setter Property="CornerRadius">
-            <Setter.Value>
-               <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
-                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
-                  <Binding Source="{StaticResource ScrollBarThumbCornerRadius}" />
-                  <Binding Source="{StaticResource ScrollBarThumbExpandedCornerRadius}" />
-               </MultiBinding>
-            </Setter.Value>
-         </Setter>
+        <Setter Property="RenderTransform" Value="{StaticResource NoTransform}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ScrollBarThumbExpandedCornerRadius}" />
       </Style>
-      <Style Selector="^:vertical /template/ Thumb">
-         <Setter Property="RenderTransform">
-            <Setter.Value>
-               <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
-                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
-                  <Binding Source="{StaticResource VerticalScrollThumbShrinkTransform}" />
-                  <Binding Source="{StaticResource NoTransform}" />
-               </MultiBinding>
-            </Setter.Value>
-         </Setter>
+      <Style Selector="^ /template/ RepeatButton">
+        <Setter Property="Opacity" Value="1" />
       </Style>
-      <Style Selector="^:horizontal /template/ Thumb">
-         <Setter Property="RenderTransform">
-            <Setter.Value>
-               <MultiBinding Converter="{x:Static DevoMultiConverters.BooleanToChoiceConverter}">
-                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ScrollBar}" Path="AllowAutoHide" />
-                  <Binding Source="{StaticResource HorizontalScrollThumbShrinkTransform}" />
-                  <Binding Source="{StaticResource NoTransform}" />
-               </MultiBinding>
-            </Setter.Value>
-         </Setter>
-      </Style>
+    </Style>
 
-      <Style Selector="^:pointerover">
-         <Style Selector="^ /template/ Thumb">
-            <Setter Property="RenderTransform" Value="{StaticResource NoTransform}" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ScrollBarThumbExpandedCornerRadius}" />
-         </Style>
-         <Style Selector="^ /template/ RepeatButton">
-            <Setter Property="Opacity" Value="1" />
-         </Style>
-      </Style>
-
-   </ControlTheme>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/SplitButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/SplitButton.axaml
@@ -1,159 +1,159 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <ThemeVariantScope RequestedThemeVariant="Light">
-         <StackPanel Spacing="20">
-            <SplitButton Content="Splitted">
-               <SplitButton.Flyout>
-                  <MenuFlyout>
-                     <MenuItem Header="A" />
-                     <MenuItem Header="B" />
-                     <MenuItem Header="C" />
-                  </MenuFlyout>
-               </SplitButton.Flyout>
-            </SplitButton>
+  <Design.PreviewWith>
+    <ThemeVariantScope RequestedThemeVariant="Light">
+      <StackPanel Spacing="20">
+        <SplitButton Content="Splitted">
+          <SplitButton.Flyout>
+            <MenuFlyout>
+              <MenuItem Header="A" />
+              <MenuItem Header="B" />
+              <MenuItem Header="C" />
+            </MenuFlyout>
+          </SplitButton.Flyout>
+        </SplitButton>
 
-            <SplitButton Content="SplitButton">
-               <SplitButton.Flyout>
-                  <Flyout>Hello</Flyout>
-               </SplitButton.Flyout>
-            </SplitButton>
-            <SplitButton CornerRadius="16" Content="Rounded">
-               <SplitButton.Flyout>
-                  <Flyout>Hello</Flyout>
-               </SplitButton.Flyout>
-            </SplitButton>
-            <SplitButton IsEnabled="False">Disabled</SplitButton>
-         </StackPanel>
-      </ThemeVariantScope>
-   </Design.PreviewWith>
+        <SplitButton Content="SplitButton">
+          <SplitButton.Flyout>
+            <Flyout>Hello</Flyout>
+          </SplitButton.Flyout>
+        </SplitButton>
+        <SplitButton CornerRadius="16" Content="Rounded">
+          <SplitButton.Flyout>
+            <Flyout>Hello</Flyout>
+          </SplitButton.Flyout>
+        </SplitButton>
+        <SplitButton IsEnabled="False">Disabled</SplitButton>
+      </StackPanel>
+    </ThemeVariantScope>
+  </Design.PreviewWith>
 
-   <x:Double x:Key="SplitButtonPrimaryButtonSize">26</x:Double>
-   <x:Double x:Key="SplitButtonSecondaryButtonSize">26</x:Double>
-   <x:Double x:Key="SplitButtonSeparatorWidth">1</x:Double>
-   <x:Double x:Key="SplitButtonMinHeight">26</x:Double>
+  <x:Double x:Key="SplitButtonPrimaryButtonSize">26</x:Double>
+  <x:Double x:Key="SplitButtonSecondaryButtonSize">26</x:Double>
+  <x:Double x:Key="SplitButtonSeparatorWidth">1</x:Double>
+  <x:Double x:Key="SplitButtonMinHeight">26</x:Double>
 
-   <converters:MarginMultiplierConverter x:Key="PrimaryButtonBorderMultiplier" Left="True" Top="True" Bottom="True" Indent="1" />
-   <converters:MarginMultiplierConverter x:Key="SecondaryButtonBorderMultiplier" Right="True" Top="True" Bottom="True" Indent="1" />
-   <converters:MarginMultiplierConverter x:Key="SeparatorBorderMultiplier" Top="True" Bottom="True" Indent="1" />
-   <converters:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="TopLeft, TopRight" />
-   <converters:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="TopRight, BottomRight" />
-   <converters:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="BottomLeft, BottomRight" />
-   <converters:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="TopLeft, BottomLeft" />
+  <converters:MarginMultiplierConverter x:Key="PrimaryButtonBorderMultiplier" Left="True" Top="True" Bottom="True" Indent="1" />
+  <converters:MarginMultiplierConverter x:Key="SecondaryButtonBorderMultiplier" Right="True" Top="True" Bottom="True" Indent="1" />
+  <converters:MarginMultiplierConverter x:Key="SeparatorBorderMultiplier" Top="True" Bottom="True" Indent="1" />
+  <converters:CornerRadiusFilterConverter x:Key="TopCornerRadiusFilterConverter" Filter="TopLeft, TopRight" />
+  <converters:CornerRadiusFilterConverter x:Key="RightCornerRadiusFilterConverter" Filter="TopRight, BottomRight" />
+  <converters:CornerRadiusFilterConverter x:Key="BottomCornerRadiusFilterConverter" Filter="BottomLeft, BottomRight" />
+  <converters:CornerRadiusFilterConverter x:Key="LeftCornerRadiusFilterConverter" Filter="TopLeft, BottomLeft" />
 
-   <ControlTheme x:Key="FluentSplitButtonComponent" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}" />
+  <ControlTheme x:Key="FluentSplitButtonComponent" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}" />
 
-   <ControlTheme x:Key="{x:Type SplitButton}" TargetType="SplitButton">
-      <Setter Property="Background" Value="{DynamicResource SplitButtonBackground}" />
-      <Setter Property="Foreground" Value="{DynamicResource SplitButtonForeground}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource SplitButtonBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource SplitButtonBorderThemeThickness}" />
-      <Setter Property="MinHeight" Value="{DynamicResource SplitButtonMinHeight}" />
-      <Setter Property="HorizontalAlignment" Value="Left" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
-      <Setter Property="Focusable" Value="True" />
-      <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Grid>
-               <Grid.ColumnDefinitions>
-                  <ColumnDefinition Width="*" />
-                  <ColumnDefinition Width="Auto" />
-               </Grid.ColumnDefinitions>
+  <ControlTheme x:Key="{x:Type SplitButton}" TargetType="SplitButton">
+    <Setter Property="Background" Value="{DynamicResource SplitButtonBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource SplitButtonForeground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource SplitButtonBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource SplitButtonBorderThemeThickness}" />
+    <Setter Property="MinHeight" Value="{DynamicResource SplitButtonMinHeight}" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="KeyboardNavigation.IsTabStop" Value="True" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid>
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
 
-               <Button
-                  x:Name="PART_PrimaryButton"
-                  Grid.Column="0"
-                  Classes.accent="{Binding 
+          <Button
+            x:Name="PART_PrimaryButton"
+            Grid.Column="0"
+            Classes.accent="{Binding 
                     Classes, 
                      RelativeSource={RelativeSource TemplatedParent}, 
                      Converter={x:Static DevoConverters.HasClass},
                      ConverterParameter=accent
                   }"
-                  Theme="{StaticResource FluentSplitButtonComponent}"
-                  MinWidth="{DynamicResource SplitButtonPrimaryButtonSize}"
-                  Foreground="{TemplateBinding Foreground}"
-                  Background="{TemplateBinding Background}"
-                  BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource PrimaryButtonBorderMultiplier}}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  Content="{TemplateBinding Content}"
-                  ContentTemplate="{TemplateBinding ContentTemplate}"
-                  Command="{TemplateBinding Command}"
-                  CommandParameter="{TemplateBinding CommandParameter}"
-                  CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch"
-                  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                  Padding="{TemplateBinding Padding}"
-                  Focusable="False"
-                  KeyboardNavigation.IsTabStop="False" />
+            Theme="{StaticResource FluentSplitButtonComponent}"
+            MinWidth="{DynamicResource SplitButtonPrimaryButtonSize}"
+            Foreground="{TemplateBinding Foreground}"
+            Background="{TemplateBinding Background}"
+            BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource PrimaryButtonBorderMultiplier}}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            Content="{TemplateBinding Content}"
+            ContentTemplate="{TemplateBinding ContentTemplate}"
+            Command="{TemplateBinding Command}"
+            CommandParameter="{TemplateBinding CommandParameter}"
+            CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource LeftCornerRadiusFilterConverter}}"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+            Padding="{TemplateBinding Padding}"
+            Focusable="False"
+            KeyboardNavigation.IsTabStop="False" />
 
-               <!-- <Border x:Name="SeparatorBorder" -->
-               <!--         Grid.Column="1" -->
-               <!--         Background="Transparent" -->
-               <!--         Width="{DynamicResource SplitButtonSeparatorWidth}" -->
-               <!--         BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource SeparatorBorderMultiplier}}" -->
-               <!--         BorderBrush="{TemplateBinding BorderBrush}" /> -->
+          <!-- <Border x:Name="SeparatorBorder" -->
+          <!--         Grid.Column="1" -->
+          <!--         Background="Transparent" -->
+          <!--         Width="{DynamicResource SplitButtonSeparatorWidth}" -->
+          <!--         BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource SeparatorBorderMultiplier}}" -->
+          <!--         BorderBrush="{TemplateBinding BorderBrush}" /> -->
 
-               <Button
-                  x:Name="PART_SecondaryButton"
-                  Grid.Column="1"
-                  Classes.accent="{Binding 
+          <Button
+            x:Name="PART_SecondaryButton"
+            Grid.Column="1"
+            Classes.accent="{Binding 
                      Classes, 
                      RelativeSource={RelativeSource TemplatedParent}, 
                      Converter={x:Static DevoConverters.HasClass},
                      ConverterParameter=accent
                   }"
-                  Theme="{StaticResource FluentSplitButtonComponent}"
-                  MinWidth="{DynamicResource SplitButtonSecondaryButtonSize}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  Foreground="{TemplateBinding Foreground}"
-                  Background="{TemplateBinding Background}"
-                  BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource SecondaryButtonBorderMultiplier}}"
-                  CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
-                  Padding="0"
-                  HorizontalContentAlignment="Center"
-                  VerticalContentAlignment="Center"
-                  HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch"
-                  Focusable="False"
-                  KeyboardNavigation.IsTabStop="False">
-                  <PathIcon
-                     Name="DropDownGlyph"
-                     UseLayoutRounding="False"
-                     IsHitTestVisible="False"
-                     Width="9"
-                     HorizontalAlignment="Center"
-                     VerticalAlignment="Center"
-                     Foreground="{DynamicResource ForegroundColor}"
-                     Data="{StaticResource ChevronPath}" />
-               </Button>
-            </Grid>
-         </ControlTemplate>
-      </Setter>
+            Theme="{StaticResource FluentSplitButtonComponent}"
+            MinWidth="{DynamicResource SplitButtonSecondaryButtonSize}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            Foreground="{TemplateBinding Foreground}"
+            Background="{TemplateBinding Background}"
+            BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource SecondaryButtonBorderMultiplier}}"
+            CornerRadius="{TemplateBinding CornerRadius, Converter={StaticResource RightCornerRadiusFilterConverter}}"
+            Padding="0"
+            HorizontalContentAlignment="Center"
+            VerticalContentAlignment="Center"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Focusable="False"
+            KeyboardNavigation.IsTabStop="False">
+            <PathIcon
+              Name="DropDownGlyph"
+              UseLayoutRounding="False"
+              IsHitTestVisible="False"
+              Width="9"
+              HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              Foreground="{DynamicResource ForegroundColor}"
+              Data="{StaticResource ChevronPath}" />
+          </Button>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
 
-      <Style Selector="^:flyout-open /template/ Button">
-         <Setter Property="Tag" Value="flyout-open" />
-      </Style>
+    <Style Selector="^:flyout-open /template/ Button">
+      <Setter Property="Tag" Value="flyout-open" />
+    </Style>
 
-      <Style Selector="^:checked /template/ Button">
-         <Setter Property="Tag" Value="checked" />
-      </Style>
+    <Style Selector="^:checked /template/ Button">
+      <Setter Property="Tag" Value="checked" />
+    </Style>
 
-      <Style Selector="^:checked:flyout-open /template/ Button">
-         <Setter Property="Tag" Value="checked-flyout-open" />
-      </Style>
-   </ControlTheme>
+    <Style Selector="^:checked:flyout-open /template/ Button">
+      <Setter Property="Tag" Value="checked-flyout-open" />
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabItem.axaml
@@ -1,372 +1,372 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <Border Width="600" Background="{DynamicResource LayoutBackgroundLowBrush}">
-         <TabControl TabStripPlacement="Top" Margin="5">
-            <TabItem Header="General">
-               <StackPanel Orientation="Horizontal" Spacing="30">
-                  <TextBlock Text="Remote Desktop Size" VerticalAlignment="Center" />
-               </StackPanel>
-            </TabItem>
-            <TabItem Header="Display">
-               <TextBlock Text="Content 2" />
-            </TabItem>
-            <TabItem Header="Local Resources">
-               <TextBlock Text="Content 3" />
-            </TabItem>
-            <TabItem Header="Disabled" IsEnabled="False" />
-         </TabControl>
-      </Border>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Width="600" Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <TabControl TabStripPlacement="Top" Margin="5">
+        <TabItem Header="General">
+          <StackPanel Orientation="Horizontal" Spacing="30">
+            <TextBlock Text="Remote Desktop Size" VerticalAlignment="Center" />
+          </StackPanel>
+        </TabItem>
+        <TabItem Header="Display">
+          <TextBlock Text="Content 2" />
+        </TabItem>
+        <TabItem Header="Local Resources">
+          <TextBlock Text="Content 3" />
+        </TabItem>
+        <TabItem Header="Disabled" IsEnabled="False" />
+      </TabControl>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type TabItem}" TargetType="TabItem">
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="Background" Value="Aqua" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderMidBrush}" />
-      <Setter Property="Margin" Value="0" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border
-               Name="PART_LayoutRoot"
-               Background="Transparent"
-               Margin="0 0 -7 0">
-               <Grid RowDefinitions="4, *, 4" ColumnDefinitions="7, *, 7">
-                  <Border Name="PointerOverBackground" Grid.Row="0" Grid.Column="0"
-                          Grid.RowSpan="3" Grid.ColumnSpan="3"
-                          Background="Transparent"
-                          CornerRadius="4 4 0 0"
-                          Margin="4 0 4 0" />
-                  <Border Name="TopLeftCorner"
-                          Grid.Row="0" Grid.Column="0"
-                          Width="4"
-                          Height="4"
-                          HorizontalAlignment="Right"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="1 1 0 0"
-                          CornerRadius="4 0 0 0 " />
-                  <Border Name="FirstTabTopLeftCorner"
-                          Grid.Row="0" Grid.Column="0"
-                          IsVisible="False"
-                          Width="7"
-                          Height="4"
-                          HorizontalAlignment="Right"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="1 1 0 0"
-                          CornerRadius="4 0 0 0 " />
-                  <Border Name="TopBorder"
-                          Grid.Row="0" Grid.Column="1"
-                          Height="4"
-                          HorizontalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 1 0 0" />
-                  <Border Name="TopRightCorner"
-                          Grid.Row="0" Grid.Column="2"
-                          Width="4"
-                          Height="4"
-                          HorizontalAlignment="Left"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 1 1 0"
-                          CornerRadius="0 4 0 0 " />
-                  <Border Name="LeftBorder"
-                          Grid.Row="1" Grid.Column="0"
-                          Width="4"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="1 0 0 0 ">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="LeftBorder">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-                  <Border Name="FirstTabLeftBorder"
-                          Grid.Row="1" Grid.Column="0"
-                          Grid.RowSpan="2"
-                          IsVisible="False"
-                          Width="7"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="1 0 0 0 " />
-                  <Border Name="TopBorderSelected"
-                          Grid.Row="0" Grid.Column="0"
-                          Grid.ColumnSpan="3"
-                          IsVisible="False"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Top"
-                          CornerRadius="4 4 0 0"
-                          Margin="4 0 4 0"
-                          BorderBrush="{DynamicResource ControlBorderSelectedBrush}"
-                          BorderThickness="0 2 0 0" />
-                  <Border Name="CenterContent" Grid.Row="1" Grid.Column="1"
-                          MinHeight="20"
-                          Padding="{DynamicResource TabItemHeaderPadding}">
-                     <Panel>
-                        <TextBlock
-                           Name="ReserveWidthForSelectedTabText"
-                           FontFamily="{TemplateBinding FontFamily}"
-                           FontSize="13"
-                           FontWeight="Bold"
-                           Foreground="Transparent"
-                           Background="Transparent"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center"
-                           Text="{TemplateBinding Header}" />
-                        <ContentPresenter
-                           Name="PART_ContentPresenter"
-                           FontFamily="{TemplateBinding FontFamily}"
-                           FontSize="{StaticResource ControlFontSize}"
-                           HorizontalAlignment="Left"
-                           VerticalAlignment="Center"
-                           Content="{TemplateBinding Header}"
-                           RecognizesAccessKey="True" />
-                     </Panel>
-                  </Border>
-                  <Border Name="RightBorder"
-                          Grid.Row="1" Grid.Column="2"
-                          Width="4"
-                          HorizontalAlignment="Left"
-                          VerticalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 0 1 0 ">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="RightBorder">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-                  <Border Name="BottomLeftCorner"
-                          Grid.Row="2" Grid.Column="0"
-                          Width="4"
-                          Height="4"
-                          HorizontalAlignment="Left"
-                          Background="Transparent"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 0 1 1   "
-                          CornerRadius="0 0 4 0 ">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="BottomLeftCorner">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-                  <Border Name="BottomLeftBorder"
-                          Grid.Row="2" Grid.Column="0"
-                          Height="4"
-                          HorizontalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 0 0 1">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="BottomLeftBorder">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-                  <Border Name="BottomBorder"
-                          Grid.Row="2" Grid.Column="1"
-                          Height="4"
-                          HorizontalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 0 0 1" />
-                  <Border Name="BottomRightBorder"
-                          Grid.Row="2" Grid.Column="2"
-                          Height="4"
-                          HorizontalAlignment="Stretch"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="0 0 0 1">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="BottomRightBorder">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-                  <Border Name="BottomRightCorner"
-                          Grid.Row="2" Grid.Column="2"
-                          Width="4"
-                          Height="4"
-                          HorizontalAlignment="Right"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          BorderThickness="1 0 0 1"
-                          CornerRadius="0 0 0 4 ">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
-                                      ConverterParameter="BottomRightCorner">
-                           <Binding Path="$parent[TabItem]" />
-                           <Binding Path="$parent[TabControl]" />
-                           <Binding Path="$parent[TabControl].SelectedIndex" />
-                        </MultiBinding>
-                     </Border.IsVisible>
-                  </Border>
-               </Grid>
+  <ControlTheme x:Key="{x:Type TabItem}" TargetType="TabItem">
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="Background" Value="Aqua" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderMidBrush}" />
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Name="PART_LayoutRoot"
+          Background="Transparent"
+          Margin="0 0 -7 0">
+          <Grid RowDefinitions="4, *, 4" ColumnDefinitions="7, *, 7">
+            <Border Name="PointerOverBackground" Grid.Row="0" Grid.Column="0"
+                    Grid.RowSpan="3" Grid.ColumnSpan="3"
+                    Background="Transparent"
+                    CornerRadius="4 4 0 0"
+                    Margin="4 0 4 0" />
+            <Border Name="TopLeftCorner"
+                    Grid.Row="0" Grid.Column="0"
+                    Width="4"
+                    Height="4"
+                    HorizontalAlignment="Right"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="1 1 0 0"
+                    CornerRadius="4 0 0 0 " />
+            <Border Name="FirstTabTopLeftCorner"
+                    Grid.Row="0" Grid.Column="0"
+                    IsVisible="False"
+                    Width="7"
+                    Height="4"
+                    HorizontalAlignment="Right"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="1 1 0 0"
+                    CornerRadius="4 0 0 0 " />
+            <Border Name="TopBorder"
+                    Grid.Row="0" Grid.Column="1"
+                    Height="4"
+                    HorizontalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 1 0 0" />
+            <Border Name="TopRightCorner"
+                    Grid.Row="0" Grid.Column="2"
+                    Width="4"
+                    Height="4"
+                    HorizontalAlignment="Left"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 1 1 0"
+                    CornerRadius="0 4 0 0 " />
+            <Border Name="LeftBorder"
+                    Grid.Row="1" Grid.Column="0"
+                    Width="4"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="1 0 0 0 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="LeftBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
             </Border>
-         </ControlTemplate>
-      </Setter>
+            <Border Name="FirstTabLeftBorder"
+                    Grid.Row="1" Grid.Column="0"
+                    Grid.RowSpan="2"
+                    IsVisible="False"
+                    Width="7"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="1 0 0 0 " />
+            <Border Name="TopBorderSelected"
+                    Grid.Row="0" Grid.Column="0"
+                    Grid.ColumnSpan="3"
+                    IsVisible="False"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Top"
+                    CornerRadius="4 4 0 0"
+                    Margin="4 0 4 0"
+                    BorderBrush="{DynamicResource ControlBorderSelectedBrush}"
+                    BorderThickness="0 2 0 0" />
+            <Border Name="CenterContent" Grid.Row="1" Grid.Column="1"
+                    MinHeight="20"
+                    Padding="{DynamicResource TabItemHeaderPadding}">
+              <Panel>
+                <TextBlock
+                  Name="ReserveWidthForSelectedTabText"
+                  FontFamily="{TemplateBinding FontFamily}"
+                  FontSize="13"
+                  FontWeight="Bold"
+                  Foreground="Transparent"
+                  Background="Transparent"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Center"
+                  Text="{TemplateBinding Header}" />
+                <ContentPresenter
+                  Name="PART_ContentPresenter"
+                  FontFamily="{TemplateBinding FontFamily}"
+                  FontSize="{StaticResource ControlFontSize}"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Center"
+                  Content="{TemplateBinding Header}"
+                  RecognizesAccessKey="True" />
+              </Panel>
+            </Border>
+            <Border Name="RightBorder"
+                    Grid.Row="1" Grid.Column="2"
+                    Width="4"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 1 0 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="RightBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+            <Border Name="BottomLeftCorner"
+                    Grid.Row="2" Grid.Column="0"
+                    Width="4"
+                    Height="4"
+                    HorizontalAlignment="Left"
+                    Background="Transparent"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 1 1   "
+                    CornerRadius="0 0 4 0 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="BottomLeftCorner">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+            <Border Name="BottomLeftBorder"
+                    Grid.Row="2" Grid.Column="0"
+                    Height="4"
+                    HorizontalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 0 1">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="BottomLeftBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+            <Border Name="BottomBorder"
+                    Grid.Row="2" Grid.Column="1"
+                    Height="4"
+                    HorizontalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 0 1" />
+            <Border Name="BottomRightBorder"
+                    Grid.Row="2" Grid.Column="2"
+                    Height="4"
+                    HorizontalAlignment="Stretch"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 0 1">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="BottomRightBorder">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+            <Border Name="BottomRightCorner"
+                    Grid.Row="2" Grid.Column="2"
+                    Width="4"
+                    Height="4"
+                    HorizontalAlignment="Right"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="1 0 0 1"
+                    CornerRadius="0 0 0 4 ">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.TabBorderVisibilityConverter}"
+                              ConverterParameter="BottomRightCorner">
+                  <Binding Path="$parent[TabItem]" />
+                  <Binding Path="$parent[TabControl]" />
+                  <Binding Path="$parent[TabControl].SelectedIndex" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+          </Grid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
 
-      <Style Selector="^[TabStripPlacement=Top]:nth-child(1)">
-         <Style Selector="^ /template/ Border#TopLeftCorner">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-         <Style Selector="^ /template/ Border#LeftBorder">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-         <Style Selector="^ /template/ Border#FirstTabTopLeftCorner">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
-         <Style Selector="^ /template/ Border#FirstTabLeftBorder">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
-         <Style Selector="^ /template/ Border#CenterContent">
-            <Setter Property="Padding" Value="{DynamicResource FirstTabItemHeaderPadding}" />
-         </Style>
-         <Style Selector="^ /template/ Border#TopBorderSelected">
-            <Setter Property="Margin" Value="1 0 4 0" />
-         </Style>
-         <Style Selector="^ /template/ Border#PointerOverBackground">
-            <Setter Property="Margin" Value="0 0 4 0" />
-         </Style>
+    <Style Selector="^[TabStripPlacement=Top]:nth-child(1)">
+      <Style Selector="^ /template/ Border#TopLeftCorner">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+      <Style Selector="^ /template/ Border#LeftBorder">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+      <Style Selector="^ /template/ Border#FirstTabTopLeftCorner">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+      <Style Selector="^ /template/ Border#FirstTabLeftBorder">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+      <Style Selector="^ /template/ Border#CenterContent">
+        <Setter Property="Padding" Value="{DynamicResource FirstTabItemHeaderPadding}" />
+      </Style>
+      <Style Selector="^ /template/ Border#TopBorderSelected">
+        <Setter Property="Margin" Value="1 0 4 0" />
+      </Style>
+      <Style Selector="^ /template/ Border#PointerOverBackground">
+        <Setter Property="Margin" Value="0 0 4 0" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:selected">
+      <Setter Property="ZIndex" Value="2" />
+      <Setter Property="FontWeight" Value="Bold" />
+      <Setter Property="FontSize" Value="13" />
+      <!-- Visibility of the tab border corners in the 9-slice grid is handled through TabBorderVisibilityConverter -->
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+      <Style Selector="^:focus /template/ Border#TopBorderSelected">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+    </Style>
+
+    <!--  PointerOver state  -->
+    <Style Selector="^:pointerover:not(:selected) /template/ Border#PointerOverBackground">
+      <Setter Property="Background" Value="{DynamicResource TabItemPointerOverBrushTransparent}" />
+    </Style>
+
+    <!--  Disabled state  -->
+    <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundDisabled}" />
+    </Style>
+
+    <!--  TabStripPlacement States Group (minimal style clean-up only) -->
+    <Style Selector="^[TabStripPlacement=Left]">
+      <Style Selector="^ /template/ Border#TopRightCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#RightBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomRightCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomLeftCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomRightBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomLeftBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^:nth-last-child(1) /template/ Border#BottomBorder">
+        <Setter Property="BorderThickness" Value="0 0 0 1" />
       </Style>
 
-      <Style Selector="^:selected">
-         <Setter Property="ZIndex" Value="2" />
-         <Setter Property="FontWeight" Value="Bold" />
-         <Setter Property="FontSize" Value="13" />
-         <!-- Visibility of the tab border corners in the 9-slice grid is handled through TabBorderVisibilityConverter -->
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-         <Style Selector="^:focus /template/ Border#TopBorderSelected">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
-      </Style>
+    </Style>
 
-      <!--  PointerOver state  -->
-      <Style Selector="^:pointerover:not(:selected) /template/ Border#PointerOverBackground">
-         <Setter Property="Background" Value="{DynamicResource TabItemPointerOverBrushTransparent}" />
+    <Style Selector="^[TabStripPlacement=Right]">
+      <Setter Property="HorizontalContentAlignment" Value="Right" />
+      <Style Selector="^ /template/ Border#PART_LayoutRoot">
+        <Setter Property="Margin" Value="-7 0 0 0" />
       </Style>
-
-      <!--  Disabled state  -->
-      <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
-         <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundDisabled}" />
+      <Style Selector="^ /template/ Border#TopLeftCorner">
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-
-      <!--  TabStripPlacement States Group (minimal style clean-up only) -->
-      <Style Selector="^[TabStripPlacement=Left]">
-         <Style Selector="^ /template/ Border#TopRightCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#RightBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^:nth-last-child(1) /template/ Border#BottomBorder">
-            <Setter Property="BorderThickness" Value="0 0 0 1" />
-         </Style>
-
+      <Style Selector="^ /template/ Border#LeftBorder">
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-
-      <Style Selector="^[TabStripPlacement=Right]">
-         <Setter Property="HorizontalContentAlignment" Value="Right" />
-         <Style Selector="^ /template/ Border#PART_LayoutRoot">
-            <Setter Property="Margin" Value="-7 0 0 0" />
-         </Style>
-         <Style Selector="^ /template/ Border#TopLeftCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#LeftBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^:nth-last-child(1) /template/ Border#BottomBorder">
-            <Setter Property="BorderThickness" Value="0 0 0 1" />
-         </Style>
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-
-      <Style Selector="^[TabStripPlacement=Bottom]">
-         <Setter Property="HorizontalContentAlignment" Value="Right" />
-         <Style Selector="^ /template/ Border#PART_LayoutRoot">
-            <Setter Property="Margin" Value="-0" />
-         </Style>
-         <Style Selector="^ /template/ Border#TopLeftCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#TopRightCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#TopBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftCorner">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomRightBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomLeftBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^ /template/ Border#LeftBorder">
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style Selector="^:nth-child(1) /template/ Border#LeftBorder">
-            <Setter Property="BorderThickness" Value="1 0 0 0" />
-         </Style>
+      <Style Selector="^ /template/ Border#BottomRightCorner">
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-   </ControlTheme>
+      <Style Selector="^ /template/ Border#BottomLeftCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomRightBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomLeftBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^:nth-last-child(1) /template/ Border#BottomBorder">
+        <Setter Property="BorderThickness" Value="0 0 0 1" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Bottom]">
+      <Setter Property="HorizontalContentAlignment" Value="Right" />
+      <Style Selector="^ /template/ Border#PART_LayoutRoot">
+        <Setter Property="Margin" Value="-0" />
+      </Style>
+      <Style Selector="^ /template/ Border#TopLeftCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#TopRightCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#TopBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomRightCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomLeftCorner">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomRightBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomLeftBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^ /template/ Border#LeftBorder">
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+      <Style Selector="^:nth-child(1) /template/ Border#LeftBorder">
+        <Setter Property="BorderThickness" Value="1 0 0 0" />
+      </Style>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -2,314 +2,314 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Converters">
 
-   <Design.PreviewWith>
-      <!-- <ThemeVariantScope RequestedThemeVariant="Dark"> -->
-      <Border Background="#f0f0f0">
-         <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-            <TextBlock>Name:</TextBlock>
-            <TextBox Watermark="Enter your name">Normal</TextBox>
-            <TextBox Watermark="Enter your name">Administrator</TextBox>
-            <TextBlock>Password:</TextBlock>
-            <TextBox PasswordChar="*" Watermark="Enter your password" />
-            <TextBlock>Notes:</TextBlock>
-            <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
-               Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
-            </TextBox>
-            <TextBox InnerLeftContent="http://" />
-            <TextBox InnerRightContent=".com" />
-            <TextBox
-               InnerLeftContent="http://"
-               InnerRightContent=".com">
-               devolutions
-            </TextBox>
-            <TextBox Classes="clearButton">With 'Clear' button</TextBox>
-            <TextBox Watermark="Enter your name" IsEnabled="False" />
-            <TextBox Watermark="Enter your name" IsEnabled="False">Disabled Filled</TextBox>
-            <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
-            <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-            <TextBlock>Custom Height:</TextBlock>
-            <Grid ColumnDefinitions="*, Auto" HorizontalAlignment="Stretch">
-               <TextBox Grid.Column="0" Watermark="Type here" Height="35" VerticalContentAlignment="Center" />
-               <Button Grid.Column="1" Content="..." HorizontalContentAlignment="Center" Height="35" Width="35"
-                       Margin="5 0 0 0 " />
-            </Grid>
-         </StackPanel>
-      </Border>
-      <!-- </ThemeVariantScope> -->
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <!-- <ThemeVariantScope RequestedThemeVariant="Dark"> -->
+    <Border Background="#f0f0f0">
+      <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
+        <TextBlock>Name:</TextBlock>
+        <TextBox Watermark="Enter your name">Normal</TextBox>
+        <TextBox Watermark="Enter your name">Administrator</TextBox>
+        <TextBlock>Password:</TextBlock>
+        <TextBox PasswordChar="*" Watermark="Enter your password" />
+        <TextBlock>Notes:</TextBlock>
+        <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
+          Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
+        </TextBox>
+        <TextBox InnerLeftContent="http://" />
+        <TextBox InnerRightContent=".com" />
+        <TextBox
+          InnerLeftContent="http://"
+          InnerRightContent=".com">
+          devolutions
+        </TextBox>
+        <TextBox Classes="clearButton">With 'Clear' button</TextBox>
+        <TextBox Watermark="Enter your name" IsEnabled="False" />
+        <TextBox Watermark="Enter your name" IsEnabled="False">Disabled Filled</TextBox>
+        <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
+        <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+        <TextBlock>Custom Height:</TextBlock>
+        <Grid ColumnDefinitions="*, Auto" HorizontalAlignment="Stretch">
+          <TextBox Grid.Column="0" Watermark="Type here" Height="35" VerticalContentAlignment="Center" />
+          <Button Grid.Column="1" Content="..." HorizontalContentAlignment="Center" Height="35" Width="35"
+                  Margin="5 0 0 0 " />
+        </Grid>
+      </StackPanel>
+    </Border>
+    <!-- </ThemeVariantScope> -->
+  </Design.PreviewWith>
 
-   <Thickness x:Key="TextBoxTopHeaderMargin">0,0,0,4</Thickness>
-   <StreamGeometry x:Key="TextBoxClearButtonData">M 11.416016,10 20,1.4160156 18.583984,0 10,8.5839846 1.4160156,0 0,1.4160156 8.5839844,10 0,18.583985 1.4160156,20 10,11.416015 18.583984,20 20,18.583985 Z</StreamGeometry>
-   <StreamGeometry x:Key="PasswordBoxRevealButtonData">m10.051 7.0032c2.215 0 4.0105 1.7901 4.0105 3.9984s-1.7956 3.9984-4.0105 3.9984c-2.215 0-4.0105-1.7901-4.0105-3.9984s1.7956-3.9984 4.0105-3.9984zm0 1.4994c-1.3844 0-2.5066 1.1188-2.5066 2.499s1.1222 2.499 2.5066 2.499 2.5066-1.1188 2.5066-2.499-1.1222-2.499-2.5066-2.499zm0-5.0026c4.6257 0 8.6188 3.1487 9.7267 7.5613 0.10085 0.40165-0.14399 0.80877-0.54686 0.90931-0.40288 0.10054-0.81122-0.14355-0.91208-0.54521-0.94136-3.7492-4.3361-6.4261-8.2678-6.4261-3.9334 0-7.3292 2.6792-8.2689 6.4306-0.10063 0.40171-0.50884 0.64603-0.91177 0.54571s-0.648-0.5073-0.54737-0.90901c1.106-4.4152 5.1003-7.5667 9.728-7.5667z</StreamGeometry>
-   <StreamGeometry x:Key="PasswordBoxHideButtonData">m0.21967 0.21965c-0.26627 0.26627-0.29047 0.68293-0.07262 0.97654l0.07262 0.08412 4.0346 4.0346c-1.922 1.3495-3.3585 3.365-3.9554 5.7495-0.10058 0.4018 0.14362 0.8091 0.54543 0.9097 0.40182 0.1005 0.80909-0.1436 0.90968-0.5455 0.52947-2.1151 1.8371-3.8891 3.5802-5.0341l1.8096 1.8098c-0.70751 0.7215-1.1438 1.71-1.1438 2.8003 0 2.2092 1.7909 4 4 4 1.0904 0 2.0788-0.4363 2.8004-1.1438l5.9193 5.9195c0.2929 0.2929 0.7677 0.2929 1.0606 0 0.2663-0.2662 0.2905-0.6829 0.0726-0.9765l-0.0726-0.0841-6.1135-6.1142 0.0012-0.0015-1.2001-1.1979-2.8699-2.8693 2e-3 -8e-4 -2.8812-2.8782 0.0012-0.0018-1.1333-1.1305-4.3064-4.3058c-0.29289-0.29289-0.76777-0.29289-1.0607 0zm7.9844 9.0458 3.5351 3.5351c-0.45 0.4358-1.0633 0.704-1.7392 0.704-1.3807 0-2.5-1.1193-2.5-2.5 0-0.6759 0.26824-1.2892 0.7041-1.7391zm1.7959-5.7655c-1.0003 0-1.9709 0.14807-2.8889 0.425l1.237 1.2362c0.5358-0.10587 1.0883-0.16119 1.6519-0.16119 3.9231 0 7.3099 2.6803 8.2471 6.4332 0.1004 0.4018 0.5075 0.6462 0.9094 0.5459 0.4019-0.1004 0.6463-0.5075 0.5459-0.9094-1.103-4.417-5.0869-7.5697-9.7024-7.5697zm0.1947 3.5093 3.8013 3.8007c-0.1018-2.0569-1.7488-3.7024-3.8013-3.8007z</StreamGeometry>
+  <Thickness x:Key="TextBoxTopHeaderMargin">0,0,0,4</Thickness>
+  <StreamGeometry x:Key="TextBoxClearButtonData">M 11.416016,10 20,1.4160156 18.583984,0 10,8.5839846 1.4160156,0 0,1.4160156 8.5839844,10 0,18.583985 1.4160156,20 10,11.416015 18.583984,20 20,18.583985 Z</StreamGeometry>
+  <StreamGeometry x:Key="PasswordBoxRevealButtonData">m10.051 7.0032c2.215 0 4.0105 1.7901 4.0105 3.9984s-1.7956 3.9984-4.0105 3.9984c-2.215 0-4.0105-1.7901-4.0105-3.9984s1.7956-3.9984 4.0105-3.9984zm0 1.4994c-1.3844 0-2.5066 1.1188-2.5066 2.499s1.1222 2.499 2.5066 2.499 2.5066-1.1188 2.5066-2.499-1.1222-2.499-2.5066-2.499zm0-5.0026c4.6257 0 8.6188 3.1487 9.7267 7.5613 0.10085 0.40165-0.14399 0.80877-0.54686 0.90931-0.40288 0.10054-0.81122-0.14355-0.91208-0.54521-0.94136-3.7492-4.3361-6.4261-8.2678-6.4261-3.9334 0-7.3292 2.6792-8.2689 6.4306-0.10063 0.40171-0.50884 0.64603-0.91177 0.54571s-0.648-0.5073-0.54737-0.90901c1.106-4.4152 5.1003-7.5667 9.728-7.5667z</StreamGeometry>
+  <StreamGeometry x:Key="PasswordBoxHideButtonData">m0.21967 0.21965c-0.26627 0.26627-0.29047 0.68293-0.07262 0.97654l0.07262 0.08412 4.0346 4.0346c-1.922 1.3495-3.3585 3.365-3.9554 5.7495-0.10058 0.4018 0.14362 0.8091 0.54543 0.9097 0.40182 0.1005 0.80909-0.1436 0.90968-0.5455 0.52947-2.1151 1.8371-3.8891 3.5802-5.0341l1.8096 1.8098c-0.70751 0.7215-1.1438 1.71-1.1438 2.8003 0 2.2092 1.7909 4 4 4 1.0904 0 2.0788-0.4363 2.8004-1.1438l5.9193 5.9195c0.2929 0.2929 0.7677 0.2929 1.0606 0 0.2663-0.2662 0.2905-0.6829 0.0726-0.9765l-0.0726-0.0841-6.1135-6.1142 0.0012-0.0015-1.2001-1.1979-2.8699-2.8693 2e-3 -8e-4 -2.8812-2.8782 0.0012-0.0018-1.1333-1.1305-4.3064-4.3058c-0.29289-0.29289-0.76777-0.29289-1.0607 0zm7.9844 9.0458 3.5351 3.5351c-0.45 0.4358-1.0633 0.704-1.7392 0.704-1.3807 0-2.5-1.1193-2.5-2.5 0-0.6759 0.26824-1.2892 0.7041-1.7391zm1.7959-5.7655c-1.0003 0-1.9709 0.14807-2.8889 0.425l1.237 1.2362c0.5358-0.10587 1.0883-0.16119 1.6519-0.16119 3.9231 0 7.3099 2.6803 8.2471 6.4332 0.1004 0.4018 0.5075 0.6462 0.9094 0.5459 0.4019-0.1004 0.6463-0.5075 0.5459-0.9094-1.103-4.417-5.0869-7.5697-9.7024-7.5697zm0.1947 3.5093 3.8013 3.8007c-0.1018-2.0569-1.7488-3.7024-3.8013-3.8007z</StreamGeometry>
 
-   <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
-   </MenuFlyout>
-   <MenuFlyout x:Key="HorizontalTextBoxContextFlyout"
-               FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
-               ItemContainerTheme="{StaticResource HorizontalMenuItem}">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" />
-   </MenuFlyout>
+  <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
+  </MenuFlyout>
+  <MenuFlyout x:Key="HorizontalTextBoxContextFlyout"
+              FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
+              ItemContainerTheme="{StaticResource HorizontalMenuItem}">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" />
+  </MenuFlyout>
 
-   <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
-      <Setter Property="Background" Value="{DynamicResource TextControlButtonBackground}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrush}" />
-      <Setter Property="Focusable" Value="False" />
-      <Setter Property="MinWidth" Value="34" />
-      <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-      <Setter Property="Width" Value="{Binding $self.Bounds.Height}" />
-      <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}" />
-      <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate TargetType="Button">
-               <ContentPresenter Name="PART_ContentPresenter"
-                                 Background="{TemplateBinding Background}"
-                                 BorderBrush="{TemplateBinding BorderBrush}"
-                                 BorderThickness="{TemplateBinding BorderThickness}"
-                                 Content="{TemplateBinding Content}"
-                                 Padding="{TemplateBinding Padding}" />
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
+  <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource TextControlButtonBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrush}" />
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="MinWidth" Value="34" />
+    <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+    <Setter Property="Width" Value="{Binding $self.Bounds.Height}" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="Button">
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Content="{TemplateBinding Content}"
+                            Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
 
-      <Style Selector="^:pointerover /template/ ContentPresenter">
-         <Setter Property="Background" Value="{DynamicResource TextControlButtonBackgroundPointerOver}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPointerOver}" />
-         <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPointerOver}" />
-      </Style>
+    <Style Selector="^:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource TextControlButtonBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrushPointerOver}" />
+      <Setter Property="Foreground" Value="{DynamicResource TextControlButtonForegroundPointerOver}" />
+    </Style>
 
-      <Style Selector="^:disabled /template/ ContentPresenter">
-         <Setter Property="Opacity" Value="0" />
-      </Style>
-   </ControlTheme>
+    <Style Selector="^:disabled /template/ ContentPresenter">
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+  </ControlTheme>
 
-   <ControlTheme x:Key="FluentTextBoxToggleButton"
-                 TargetType="ToggleButton"
-                 BasedOn="{StaticResource FluentTextBoxButton}">
-      <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate TargetType="ToggleButton">
-               <ContentPresenter Name="PART_ContentPresenter"
-                                 Background="{TemplateBinding Background}"
-                                 Content="{TemplateBinding Content}"
-                                 Padding="{TemplateBinding Padding}" />
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
-   </ControlTheme>
+  <ControlTheme x:Key="FluentTextBoxToggleButton"
+                TargetType="ToggleButton"
+                BasedOn="{StaticResource FluentTextBoxButton}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ToggleButton">
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Background="{TemplateBinding Background}"
+                            Content="{TemplateBinding Content}"
+                            Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type TextBox}" TargetType="TextBox">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
-      <Setter Property="BorderThickness" Value="1 1 1 0" />
-      <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionColorSolid}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
-      <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
-      <Setter Property="Padding" Value="10 2 10 2.5" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
-      <Setter Property="ContextFlyout"
-              Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
-      <Setter Property="FontSize">
-         <Setter.Value>
-            <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
-               <Binding RelativeSource="{RelativeSource Self}" Path="PasswordChar" />
-               <Binding RelativeSource="{RelativeSource Self}" Path="RevealPassword" />
-               <Binding Source="{StaticResource ControlFontSize}" />
-               <Binding Source="{StaticResource PasswordHiddenFontSize}" />
-            </MultiBinding>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors>
-               <Panel>
-                  <Border
-                     Name="PART_BorderElement"
-                     Background="{TemplateBinding Background}"
-                     BorderBrush="{TemplateBinding BorderBrush}"
-                     BorderThickness="{TemplateBinding BorderThickness}"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}" />
-                  <Border
-                     Name="BottomBorderElement"
-                     Background="Transparent"
-                     BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
-                     BorderThickness="0 0 0 1"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}" />
-                  <Border
-                     Name="ErrorBorder"
-                     BorderBrush="{StaticResource SystemControlErrorTextForegroundBrush}"
-                     BorderThickness="1"
-                     CornerRadius="{DynamicResource ControlCornerRadius}"
-                     IsVisible="False" />
-                  <Border
-                     Margin="{TemplateBinding BorderThickness}">
-                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <ContentPresenter Name="PrefixContent"
-                                          Grid.Column="0"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Content="{TemplateBinding InnerLeftContent}"
-                                          Padding="{Binding 
+  <ControlTheme x:Key="{x:Type TextBox}" TargetType="TextBox">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1 1 1 0" />
+    <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionColorSolid}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
+    <Setter Property="Padding" Value="10 2 10 2.5" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ContextFlyout"
+            Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
+    <Setter Property="FontSize">
+      <Setter.Value>
+        <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
+          <Binding RelativeSource="{RelativeSource Self}" Path="PasswordChar" />
+          <Binding RelativeSource="{RelativeSource Self}" Path="RevealPassword" />
+          <Binding Source="{StaticResource ControlFontSize}" />
+          <Binding Source="{StaticResource PasswordHiddenFontSize}" />
+        </MultiBinding>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors>
+          <Panel>
+            <Border
+              Name="PART_BorderElement"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}" />
+            <Border
+              Name="BottomBorderElement"
+              Background="Transparent"
+              BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
+              BorderThickness="0 0 0 1"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}" />
+            <Border
+              Name="ErrorBorder"
+              BorderBrush="{StaticResource SystemControlErrorTextForegroundBrush}"
+              BorderThickness="1"
+              CornerRadius="{DynamicResource ControlCornerRadius}"
+              IsVisible="False" />
+            <Border
+              Margin="{TemplateBinding BorderThickness}">
+              <Grid ColumnDefinitions="Auto,*,Auto">
+                <ContentPresenter Name="PrefixContent"
+                                  Grid.Column="0"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  Content="{TemplateBinding InnerLeftContent}"
+                                  Padding="{Binding 
                                             Padding, 
                                             RelativeSource={RelativeSource TemplatedParent}, 
                                             Converter={x:Static  DevoConverters.ThicknessToSelectiveThicknessConverter},
                                             ConverterParameter={StaticResource TextBoxPrefixPaddingFactors}}"
-                                          IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                        <ScrollViewer Name="PART_ScrollViewer"
-                                      Grid.Column="1"
-                                      Margin="0 2 2 2"
-                                      HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                      VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                      IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                                      AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                                      BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                           <Panel
-                              Margin="{TemplateBinding Padding}">
-                              <TextBlock Name="PART_Watermark"
-                                         Opacity="0.5"
-                                         FontSize="{DynamicResource ControlFontSize}"
-                                         Text="{TemplateBinding Watermark}"
-                                         TextAlignment="{TemplateBinding TextAlignment}"
-                                         TextWrapping="{TemplateBinding TextWrapping}"
-                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                 <TextBlock.IsVisible>
-                                    <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                       <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                                Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                                       <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                                Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                                    </MultiBinding>
-                                 </TextBlock.IsVisible>
-                              </TextBlock>
-                              <TextPresenter Name="PART_TextPresenter"
-                                             Text="{TemplateBinding Text, Mode=TwoWay}"
-                                             CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                             CaretIndex="{TemplateBinding CaretIndex}"
-                                             SelectionStart="{TemplateBinding SelectionStart}"
-                                             SelectionEnd="{TemplateBinding SelectionEnd}"
-                                             TextAlignment="{TemplateBinding TextAlignment}"
-                                             TextWrapping="{TemplateBinding TextWrapping}"
-                                             LineHeight="{TemplateBinding LineHeight}"
-                                             LetterSpacing="{TemplateBinding LetterSpacing}"
-                                             RevealPassword="{TemplateBinding RevealPassword}"
-                                             SelectionBrush="{TemplateBinding SelectionBrush}"
-                                             SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                             CaretBrush="{TemplateBinding CaretBrush}"
-                                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                                 <TextPresenter.PasswordChar>
-                                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
-                                             Converter="{x:Static converters:DevExpressConverters.CharToDevExpressPasswordCharConverter}" />
-                                 </TextPresenter.PasswordChar>
-                              </TextPresenter>
-                           </Panel>
-                           <ScrollViewer.Styles>
-                              <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                                 <Setter Property="Cursor" Value="IBeam" />
-                              </Style>
-                           </ScrollViewer.Styles>
-                        </ScrollViewer>
-                        <ContentPresenter Name="SufixContent"
-                                          Grid.Column="2"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Padding="{Binding 
+                                  IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                <ScrollViewer Name="PART_ScrollViewer"
+                              Grid.Column="1"
+                              Margin="0 2 2 2"
+                              HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                              VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                              IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                              AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                              BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                  <Panel
+                    Margin="{TemplateBinding Padding}">
+                    <TextBlock Name="PART_Watermark"
+                               Opacity="0.5"
+                               FontSize="{DynamicResource ControlFontSize}"
+                               Text="{TemplateBinding Watermark}"
+                               TextAlignment="{TemplateBinding TextAlignment}"
+                               TextWrapping="{TemplateBinding TextWrapping}"
+                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      <TextBlock.IsVisible>
+                        <MultiBinding Converter="{x:Static BoolConverters.And}">
+                          <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                                   Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                          <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                                   Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                        </MultiBinding>
+                      </TextBlock.IsVisible>
+                    </TextBlock>
+                    <TextPresenter Name="PART_TextPresenter"
+                                   Text="{TemplateBinding Text, Mode=TwoWay}"
+                                   CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                   CaretIndex="{TemplateBinding CaretIndex}"
+                                   SelectionStart="{TemplateBinding SelectionStart}"
+                                   SelectionEnd="{TemplateBinding SelectionEnd}"
+                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                   LineHeight="{TemplateBinding LineHeight}"
+                                   LetterSpacing="{TemplateBinding LetterSpacing}"
+                                   RevealPassword="{TemplateBinding RevealPassword}"
+                                   SelectionBrush="{TemplateBinding SelectionBrush}"
+                                   SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                   CaretBrush="{TemplateBinding CaretBrush}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                      <TextPresenter.PasswordChar>
+                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
+                                 Converter="{x:Static converters:DevExpressConverters.CharToDevExpressPasswordCharConverter}" />
+                      </TextPresenter.PasswordChar>
+                    </TextPresenter>
+                  </Panel>
+                  <ScrollViewer.Styles>
+                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                      <Setter Property="Cursor" Value="IBeam" />
+                    </Style>
+                  </ScrollViewer.Styles>
+                </ScrollViewer>
+                <ContentPresenter Name="SufixContent"
+                                  Grid.Column="2"
+                                  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  Padding="{Binding 
                                             Padding, 
                                             RelativeSource={RelativeSource TemplatedParent}, 
                                             Converter={x:Static DevoConverters.ThicknessToSelectiveThicknessConverter},
                                             ConverterParameter={StaticResource TextBoxSufixPaddingFactors}}"
-                                          Content="{TemplateBinding InnerRightContent}"
-                                          IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                     </Grid>
-                  </Border>
-               </Panel>
-            </DataValidationErrors>
-         </ControlTemplate>
+                                  Content="{TemplateBinding InnerRightContent}"
+                                  IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+              </Grid>
+            </Border>
+          </Panel>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
+
+    <!-- Disabled State -->
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundDisabledBrush}" />
+
+      <Style Selector="^ /template/ Border#PART_BorderElement">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxDisabledBorderSelectedBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorderElement">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+
+      <Style Selector="^ /template/ TextBlock#PART_Watermark, ^ /template/ TextBlock#PART_FloatingWatermark">
+        <Setter Property="Foreground" Value="{DynamicResource TextControlPlaceholderForegroundDisabled}" />
+      </Style>
+    </Style>
+
+
+    <!-- Focused State -->
+    <Style Selector="^:focus">
+      <Style Selector="^ /template/ Border#BottomBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
+        <Setter Property="BorderThickness" Value="0 0 0 1.6" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:error /template/ Border#ErrorBorder">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
+      <Setter Property="InnerRightContent">
+        <Template>
+          <ToggleButton Theme="{StaticResource FluentTextBoxToggleButton}"
+                        IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
+                        ClipToBounds="True">
+            <Panel>
+              <PathIcon Data="{StaticResource PasswordBoxRevealButtonData}"
+                        Height="8" Width="12"
+                        IsVisible="{Binding !$parent[ToggleButton].IsChecked}" />
+              <PathIcon Data="{StaticResource PasswordBoxHideButtonData}"
+                        Height="12" Width="12"
+                        IsVisible="{Binding $parent[ToggleButton].IsChecked}" />
+            </Panel>
+          </ToggleButton>
+        </Template>
       </Setter>
+    </Style>
 
-      <!-- Disabled State -->
-      <Style Selector="^:disabled">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundDisabledBrush}" />
+    <Style Selector="^[AcceptsReturn=True] /template/ TextPresenter#PART_TextPresenter">
+      <Setter Property="VerticalAlignment" Value="Top" />
+    </Style>
 
-         <Style Selector="^ /template/ Border#PART_BorderElement">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderBrush" Value="{DynamicResource TextBoxDisabledBorderSelectedBrush}" />
-            <Setter Property="BorderThickness" Value="1" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorderElement">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-
-         <Style Selector="^ /template/ TextBlock#PART_Watermark, ^ /template/ TextBlock#PART_FloatingWatermark">
-            <Setter Property="Foreground" Value="{DynamicResource TextControlPlaceholderForegroundDisabled}" />
-         </Style>
-      </Style>
-
-
-      <!-- Focused State -->
-      <Style Selector="^:focus">
-         <Style Selector="^ /template/ Border#BottomBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderSelectedBrush}" />
-            <Setter Property="BorderThickness" Value="0 0 0 1.6" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:error /template/ Border#ErrorBorder">
-         <Setter Property="IsVisible" Value="True" />
-      </Style>
-
-      <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
-         <Setter Property="InnerRightContent">
-            <Template>
-               <ToggleButton Theme="{StaticResource FluentTextBoxToggleButton}"
-                             IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
-                             ClipToBounds="True">
-                  <Panel>
-                     <PathIcon Data="{StaticResource PasswordBoxRevealButtonData}"
-                               Height="8" Width="12"
-                               IsVisible="{Binding !$parent[ToggleButton].IsChecked}" />
-                     <PathIcon Data="{StaticResource PasswordBoxHideButtonData}"
-                               Height="12" Width="12"
-                               IsVisible="{Binding $parent[ToggleButton].IsChecked}" />
-                  </Panel>
-               </ToggleButton>
-            </Template>
-         </Setter>
-      </Style>
-
-      <Style Selector="^[AcceptsReturn=True] /template/ TextPresenter#PART_TextPresenter">
-         <Setter Property="VerticalAlignment" Value="Top" />
-      </Style>
-
-      <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">
-         <Setter Property="InnerRightContent">
-            <Template>
-               <Button Theme="{StaticResource FluentTextBoxButton}"
-                       Command="{Binding $parent[TextBox].Clear}"
-                       ClipToBounds="True">
-                  <PathIcon Data="{StaticResource TextBoxClearButtonData}" Height="10" Width="10" />
-               </Button>
-            </Template>
-         </Setter>
-      </Style>
-   </ControlTheme>
+    <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">
+      <Setter Property="InnerRightContent">
+        <Template>
+          <Button Theme="{StaticResource FluentTextBoxButton}"
+                  Command="{Binding $parent[TextBox].Clear}"
+                  ClipToBounds="True">
+            <PathIcon Data="{StaticResource TextBoxClearButtonData}" Height="10" Width="10" />
+          </Button>
+        </Template>
+      </Setter>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeView.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeView.axaml
@@ -1,22 +1,22 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  
+
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <TreeView>
           <TreeViewItem Header="Another Test" IsExpanded="True">
-            <TreeViewItem Header="AnnaWindowsVM.localdomain" IsSelected="True"/>
-            <TreeViewItem Header="AnnaWindowsVM.localdomain"/>
-            <TreeViewItem Header="DEVOLUTIONS533.local"/>
-            <TreeViewItem Header="prl-local-ns-server.shared"/>
+            <TreeViewItem Header="AnnaWindowsVM.localdomain" IsSelected="True" />
+            <TreeViewItem Header="AnnaWindowsVM.localdomain" />
+            <TreeViewItem Header="DEVOLUTIONS533.local" />
+            <TreeViewItem Header="prl-local-ns-server.shared" />
           </TreeViewItem>
           <TreeViewItem Header="Test" />
           <TreeViewItem Header="TestData from Xavier">
-            <TreeViewItem Header="AnnaWindowsVM.localdomain"/>
-            <TreeViewItem Header="AnnaWindowsVM.localdomain"/>
-            <TreeViewItem Header="DEVOLUTIONS533.local"/>
-            <TreeViewItem Header="prl-local-ns-server.shared"/>
+            <TreeViewItem Header="AnnaWindowsVM.localdomain" />
+            <TreeViewItem Header="AnnaWindowsVM.localdomain" />
+            <TreeViewItem Header="DEVOLUTIONS533.local" />
+            <TreeViewItem Header="prl-local-ns-server.shared" />
           </TreeViewItem>
         </TreeView>
       </StackPanel>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeViewItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeViewItem.axaml
@@ -17,7 +17,7 @@
       </TreeView>
     </Border>
   </Design.PreviewWith>
-  
+
 
   <x:Double x:Key="TreeViewItemIndent">23</x:Double>
   <converters:MarginMultiplierConverter Indent="{StaticResource TreeViewItemIndent}"
@@ -42,7 +42,7 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource ForegroundHighBrush}"
-                    Data="{StaticResource ChevronPath}" >
+                    Data="{StaticResource ChevronPath}">
             <PathIcon.RenderTransform>
               <RotateTransform Angle="-90" />
             </PathIcon.RenderTransform>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/_index.axaml
@@ -1,24 +1,24 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <MergeResourceInclude Source="Button.axaml" />
-      <MergeResourceInclude Source="ButtonSpinner.axaml" />
-      <MergeResourceInclude Source="CheckBox.axaml" />
-      <MergeResourceInclude Source="ComboBox.axaml" />
-      <MergeResourceInclude Source="ComboBoxItem.axaml" />
-      <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
-      <MergeResourceInclude Source="EditableComboBox.axaml" />
-      <MergeResourceInclude Source="NumericUpDown.axaml" />
-      <MergeResourceInclude Source="ScrollBar.axaml" />
-      <MergeResourceInclude Source="ScrollViewer.axaml" />
-      <MergeResourceInclude Source="SplitButton.axaml" />
-      <MergeResourceInclude Source="TabControl.axaml" />
-      <MergeResourceInclude Source="TabItem.axaml" />
-      <MergeResourceInclude Source="TextBox.axaml" />
-      <MergeResourceInclude Source="TreeView.axaml" />
-      <MergeResourceInclude Source="TreeViewItem.axaml" />
-      <MergeResourceInclude Source="ContextMenu.axaml" />
-      <MergeResourceInclude Source="Window.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <MergeResourceInclude Source="Button.axaml" />
+    <MergeResourceInclude Source="ButtonSpinner.axaml" />
+    <MergeResourceInclude Source="CheckBox.axaml" />
+    <MergeResourceInclude Source="ComboBox.axaml" />
+    <MergeResourceInclude Source="ComboBoxItem.axaml" />
+    <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
+    <MergeResourceInclude Source="EditableComboBox.axaml" />
+    <MergeResourceInclude Source="NumericUpDown.axaml" />
+    <MergeResourceInclude Source="ScrollBar.axaml" />
+    <MergeResourceInclude Source="ScrollViewer.axaml" />
+    <MergeResourceInclude Source="SplitButton.axaml" />
+    <MergeResourceInclude Source="TabControl.axaml" />
+    <MergeResourceInclude Source="TabItem.axaml" />
+    <MergeResourceInclude Source="TextBox.axaml" />
+    <MergeResourceInclude Source="TreeView.axaml" />
+    <MergeResourceInclude Source="TreeViewItem.axaml" />
+    <MergeResourceInclude Source="ContextMenu.axaml" />
+    <MergeResourceInclude Source="Window.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/CharToDevExpressPasswordCharConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/CharToDevExpressPasswordCharConverter.cs
@@ -5,14 +5,14 @@ using Avalonia.Data.Converters;
 
 public class CharToDevExpressPasswordCharConverter : IValueConverter
 {
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        const char blackCircleSymbol = '\u25CF';
-        const char emptyCharacter = '\0';
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    const char blackCircleSymbol = '\u25CF';
+    const char emptyCharacter = '\0';
 
-        return value is char and not emptyCharacter ? blackCircleSymbol : emptyCharacter;
-    }
+    return value is char and not emptyCharacter ? blackCircleSymbol : emptyCharacter;
+  }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/DevExpressConverters.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/DevExpressConverters.cs
@@ -2,5 +2,5 @@ namespace Devolutions.AvaloniaTheme.DevExpress.Converters;
 
 public static partial class DevExpressConverters
 {
-    public static readonly CharToDevExpressPasswordCharConverter CharToDevExpressPasswordCharConverter = new();
+  public static readonly CharToDevExpressPasswordCharConverter CharToDevExpressPasswordCharConverter = new();
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/DevExpressTheme.axaml
@@ -1,21 +1,21 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <!-- Using Fluent Theme as a fallback for anything not defined in DevExpress theme -->
-   <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
+  <!-- Using Fluent Theme as a fallback for anything not defined in DevExpress theme -->
+  <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
 
-   <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
+  <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
 
-   <Styles.Resources>
-      <ResourceDictionary>
-         <ResourceDictionary.MergedDictionaries>
-            <MergeResourceInclude Source="/Accents/Icons.axaml" />
-            <MergeResourceInclude Source="/Controls/_index.axaml" />
-            <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
-         </ResourceDictionary.MergedDictionaries>
-      </ResourceDictionary>
-   </Styles.Resources>
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="/Accents/Icons.axaml" />
+        <MergeResourceInclude Source="/Controls/_index.axaml" />
+        <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
 
-   <!-- Themed Controls -->
-   <StyleInclude Source="/Accents/Styles.axaml" />
+  <!-- Themed Controls -->
+  <StyleInclude Source="/Accents/Styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
-   <PropertyGroup>
-      <Version>1.0.0.0</Version>
-      <Company>Devolutions</Company>
-      <Description>Devolutions Avalonia DevExpress Theme</Description>
-      <PackageId>Devolutions.AvaloniaTheme.DevExpress</PackageId>
-      <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <TargetFramework>net9.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
-      <Nullable>enable</Nullable>
-   </PropertyGroup>
+  <PropertyGroup>
+    <Version>1.0.0.0</Version>
+    <Company>Devolutions</Company>
+    <Description>Devolutions Avalonia DevExpress Theme</Description>
+    <PackageId>Devolutions.AvaloniaTheme.DevExpress</PackageId>
+    <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-   <ItemGroup>
-      <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
-      <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
-   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
+    <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)"/>
+  </ItemGroup>
 
-   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-      <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
-   </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
+  </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -7,14 +7,16 @@ Custom Avalonia Themes developed by [Devolutions](https://devolutions.net/)
 [![NuGet Version](https://img.shields.io/nuget/vpre/Devolutions.AvaloniaTheme.DevExpress)](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.DevExpress)
 ![NuGet Downloads](https://img.shields.io/nuget/dt/Devolutions.AvaloniaTheme.DevExpress)
 
-
 ## DevExpress Theme [Work in Progress]
 
-This theme is currently based on [Avalonia.Themes.Fluent](https://github.com/AvaloniaUI/Avalonia/tree/759facea182b7771ce07baf173c52529f4871004/src/Avalonia.Themes.Fluent), 
-both as a fallback for any controls not covered yet and as starting point for our (somewhat simplified) 
+This theme is currently based
+on [Avalonia.Themes.Fluent](https://github.com/AvaloniaUI/Avalonia/tree/759facea182b7771ce07baf173c52529f4871004/src/Avalonia.Themes.Fluent),
+both as a fallback for any controls not covered yet and as starting point for our (somewhat simplified)
 style definitions targeting DevExpress Winforms look.
 
-While we are prioritizing controls for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/), we welcome contributions from the Avalonia community to add more DevExpress-style controls. 
+While we are prioritizing controls
+for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/), we welcome contributions from
+the Avalonia community to add more DevExpress-style controls.
 
 - [Installation](#installation)
 - [Styled Controls](#styled-controls)
@@ -28,19 +30,24 @@ While we are prioritizing controls for [Devolutions Remote Desktop Manager](http
     - Dark mode support
   - 🔮 Next on the road map ...
     - ScrollViewer/ScrollBar
-    
-
 
 ## Installation
-Install the Devolutions.AvaloniaTheme.DevExpress package via [NuGet](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.DevExpress):
+
+Install the Devolutions.AvaloniaTheme.DevExpress package
+via [NuGet](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.DevExpress):
+
 ``` bash
 Install-Package Devolutions.AvaloniaTheme.DevExpress
 ```
+
 or .NET
+
 ```bash
 dotnet add package Devolutions.AvaloniaTheme.DevExpress
 ```
+
 In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<SimpleTheme />`) with the macOS theme:
+
 ``` xaml
 <Application ...>
   <Application.Styles>

--- a/src/Devolutions.AvaloniaTheme.Linux/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Accents/Styles.axaml
@@ -27,11 +27,11 @@
     <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
     </Style>
-    
+
     <Style Selector="^ TextBlock">
       <Setter Property="Padding" Value="0 0 0 1" />
     </Style>
-    
+
     <Style Selector="^ AccessText">
       <Setter Property="Margin" Value="0 0 0 1" />
     </Style>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/Button.axaml
@@ -1,20 +1,20 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
-    <Design.PreviewWith>
-        <Button />
-    </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Button />
+  </Design.PreviewWith>
 
-    <ControlTheme x:Key="{x:Type Button}" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
-        <Setter Property="MinHeight" Value="{DynamicResource TextControlMinHeight}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
+  <ControlTheme x:Key="{x:Type Button}" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlMinHeight}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
 
-        <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
-            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderDisabled}" />
-        </Style>
-    </ControlTheme>
+    <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource ButtonBackgroundDisabled}" />
+      <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderDisabled}" />
+    </Style>
+  </ControlTheme>
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ButtonSpinner.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ButtonSpinner.axaml
@@ -7,259 +7,260 @@
                     xmlns:sys="using:System"
                     xmlns:avaloniaConverters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
                     x:ClassModifier="internal">
-   <Design.PreviewWith>
-      <ThemeVariantScope RequestedThemeVariant="Light">
-         <StackPanel Spacing="20">
-            <ButtonSpinner Content="Right spinner" />
-            <ButtonSpinner
-               Content="Right spinner half-disabled"
-               ValidSpinDirection="Increase" />
-            <ButtonSpinner ButtonSpinnerLocation="Left"
-                           Content="Left spinner" />
-            <ButtonSpinner ButtonSpinnerLocation="Left"
-                           Content="Left spinner" />
-            <ButtonSpinner BorderThickness="2"
-                           BorderBrush="Blue"
-                           Content="Right Border" />
-            <ButtonSpinner ButtonSpinnerLocation="Left"
-                           BorderThickness="2"
-                           BorderBrush="Blue"
-                           Content="Left Border" />
-            <ButtonSpinner Content="Right disabled"
-                           AllowSpin="False" />
-            <ButtonSpinner ButtonSpinnerLocation="Left"
-                           Content="Left disabled"
-                           AllowSpin="False" />
-            <ButtonSpinner ShowButtonSpinner="False"
-                           Content="Hide spinner" />
-            <ButtonSpinner Content="Error">
-               <DataValidationErrors.Error>
-                  <sys:Exception>
-                     <x:Arguments>
-                        <x:String>Error</x:String>
-                     </x:Arguments>
-                  </sys:Exception>
-               </DataValidationErrors.Error>
-            </ButtonSpinner>
-         </StackPanel>
-      </ThemeVariantScope>
-   </Design.PreviewWith>
 
-   <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerLeftThickness" Indent="1" Left="True" />
-   <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerRightThickness" Indent="1" Right="True" />
-   <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerReverseBorderOffset" Indent="-1" Top="True" Bottom="True" />
+  <Design.PreviewWith>
+    <ThemeVariantScope RequestedThemeVariant="Light">
+      <StackPanel Spacing="20">
+        <ButtonSpinner Content="Right spinner" />
+        <ButtonSpinner
+          Content="Right spinner half-disabled"
+          ValidSpinDirection="Increase" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       Content="Left spinner" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       Content="Left spinner" />
+        <ButtonSpinner BorderThickness="2"
+                       BorderBrush="Blue"
+                       Content="Right Border" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       BorderThickness="2"
+                       BorderBrush="Blue"
+                       Content="Left Border" />
+        <ButtonSpinner Content="Right disabled"
+                       AllowSpin="False" />
+        <ButtonSpinner ButtonSpinnerLocation="Left"
+                       Content="Left disabled"
+                       AllowSpin="False" />
+        <ButtonSpinner ShowButtonSpinner="False"
+                       Content="Hide spinner" />
+        <ButtonSpinner Content="Error">
+          <DataValidationErrors.Error>
+            <sys:Exception>
+              <x:Arguments>
+                <x:String>Error</x:String>
+              </x:Arguments>
+            </sys:Exception>
+          </DataValidationErrors.Error>
+        </ButtonSpinner>
+      </StackPanel>
+    </ThemeVariantScope>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="ButtonSpinnerRepeatButtonPathIcon" TargetType="PathIcon" BasedOn="{StaticResource {x:Type PathIcon}}">
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border
-               Background="{TemplateBinding Background}"
-               BoxShadow="{Binding BoxShadow, RelativeSource={RelativeSource FindAncestor, AncestorType=ContentPresenter}, Mode=OneWay}">
-               <Viewbox Height="{TemplateBinding Height}" Width="{TemplateBinding Width}">
-                  <Path Fill="{TemplateBinding Foreground}" Data="{TemplateBinding Data}" Stretch="Uniform" />
-               </Viewbox>
-            </Border>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+  <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerLeftThickness" Indent="1" Left="True" />
+  <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerRightThickness" Indent="1" Right="True" />
+  <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerReverseBorderOffset" Indent="-1" Top="True" Bottom="True" />
 
-   <ControlTheme x:Key="ButtonSpinnerRepeatButton" TargetType="RepeatButton">
-      <Setter Property="Template">
-         <ControlTemplate>
-            <ContentPresenter x:Name="PART_ContentPresenter"
+  <ControlTheme x:Key="ButtonSpinnerRepeatButtonPathIcon" TargetType="PathIcon" BasedOn="{StaticResource {x:Type PathIcon}}">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Background="{TemplateBinding Background}"
+          BoxShadow="{Binding BoxShadow, RelativeSource={RelativeSource FindAncestor, AncestorType=ContentPresenter}, Mode=OneWay}">
+          <Viewbox Height="{TemplateBinding Height}" Width="{TemplateBinding Width}">
+            <Path Fill="{TemplateBinding Foreground}" Data="{TemplateBinding Data}" Stretch="Uniform" />
+          </Viewbox>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="ButtonSpinnerRepeatButton" TargetType="RepeatButton">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter x:Name="PART_ContentPresenter"
+                          Background="{TemplateBinding Background}"
+                          Foreground="{TemplateBinding Foreground}"
+                          BorderBrush="{TemplateBinding BorderBrush}"
+                          CornerRadius="{TemplateBinding CornerRadius}"
+                          BorderThickness="{TemplateBinding BorderThickness}"
+                          Content="{TemplateBinding Content}"
+                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                          Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
+                          Padding="{TemplateBinding Padding}"
+                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundHover}" />
+    </Style>
+
+    <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundPressed}" />
+      <Setter Property="BoxShadow" Value="inset 1 2 3 1 #15000000" />
+    </Style>
+
+    <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundDisabled}" />
+      <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type ButtonSpinner}" TargetType="ButtonSpinner">
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Padding" Value="10, 0" />
+    <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorder}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinHeight}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Focusable" Value="True" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors>
+          <Border Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  MinHeight="{TemplateBinding MinHeight}">
+            <DockPanel ClipToBounds="True">
+              <StackPanel Name="PART_SpinnerPanel"
+                          TabIndex="2"
+                          DockPanel.Dock="Right"
+                          Orientation="Horizontal"
+                          IsVisible="{TemplateBinding ShowButtonSpinner}">
+                <RepeatButton Name="PART_DecreaseButton"
+                              IsTabStop="{TemplateBinding IsTabStop}"
+                              Theme="{StaticResource ButtonSpinnerRepeatButton}"
                               Background="{TemplateBinding Background}"
                               Foreground="{TemplateBinding Foreground}"
                               BorderBrush="{TemplateBinding BorderBrush}"
-                              CornerRadius="{TemplateBinding CornerRadius}"
-                              BorderThickness="{TemplateBinding BorderThickness}"
-                              Content="{TemplateBinding Content}"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerLeftThickness}}"
+                              VerticalAlignment="Stretch"
+                              VerticalContentAlignment="Center"
+                              MinWidth="32"
+                              MinHeight="0">
+                  <Panel>
+                    <PathIcon Name="IncreaseIconShadow"
+                              Width="32"
+                              Height="32"
+                              Foreground="{DynamicResource RepeatButtonIconShadow}"
+                              Margin="0 -1 0 1"
+                              Padding="0 -1 0 1"
                               Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
-                              Padding="{TemplateBinding Padding}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-         </ControlTemplate>
-      </Setter>
+                              Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
+                    <PathIcon Width="32"
+                              Height="32"
+                              Foreground="{TemplateBinding Foreground}"
+                              Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
+                              Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
+                  </Panel>
+                </RepeatButton>
+                <RepeatButton Name="PART_IncreaseButton"
+                              IsTabStop="{TemplateBinding IsTabStop}"
+                              Theme="{StaticResource ButtonSpinnerRepeatButton}"
+                              Background="{TemplateBinding Background}"
+                              Foreground="{TemplateBinding Foreground}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerLeftThickness}}"
+                              VerticalAlignment="Stretch"
+                              VerticalContentAlignment="Center"
+                              MinWidth="32"
+                              MinHeight="0">
+                  <Panel>
+                    <PathIcon Name="DecreaseIconShadow"
+                              Width="32"
+                              Height="32"
+                              Foreground="{DynamicResource RepeatButtonIconShadow}"
+                              Margin="0 -1 0 1"
+                              Padding="0 -1 0 1"
+                              Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
+                              Data="{StaticResource ButtonSpinnerIncreaseButtonIcon}" />
+                    <PathIcon Width="32"
+                              Height="32"
+                              Foreground="{TemplateBinding Foreground}"
+                              Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
+                              Data="{StaticResource ButtonSpinnerIncreaseButtonIcon}" />
+                  </Panel>
+                </RepeatButton>
+              </StackPanel>
 
-      <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-         <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundHover}" />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                TabIndex="1"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Content="{TemplateBinding Content}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Padding="{TemplateBinding Padding}" />
+            </DockPanel>
+          </Border>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:left">
+      <Style Selector="^ /template/ StackPanel#PART_SpinnerPanel">
+        <Setter Property="DockPanel.Dock" Value="Left" />
       </Style>
-
-      <Style Selector="^:pressed /template/ ContentPresenter#PART_ContentPresenter">
-         <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundPressed}" />
-         <Setter Property="BoxShadow" Value="inset 1 2 3 1 #15000000" />
-      </Style>
-
-      <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
-         <Setter Property="Background" Value="{DynamicResource RepeatButtonBackgroundDisabled}" />
-         <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type ButtonSpinner}" TargetType="ButtonSpinner">
-      <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
-      <Setter Property="Padding" Value="10, 0" />
-      <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorder}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="MinHeight" Value="{DynamicResource TextControlThemeMinHeight}" />
-      <Setter Property="MinWidth" Value="{DynamicResource TextControlThemeMinHeight}" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="Focusable" Value="True" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors>
-               <Border Background="{TemplateBinding Background}"
-                       BorderBrush="{TemplateBinding BorderBrush}"
-                       BorderThickness="{TemplateBinding BorderThickness}"
-                       CornerRadius="{TemplateBinding CornerRadius}"
-                       MinHeight="{TemplateBinding MinHeight}">
-                  <DockPanel ClipToBounds="True">
-                     <StackPanel Name="PART_SpinnerPanel"
-                                 TabIndex="2"
-                                 DockPanel.Dock="Right"
-                                 Orientation="Horizontal"
-                                 IsVisible="{TemplateBinding ShowButtonSpinner}">
-                        <RepeatButton Name="PART_DecreaseButton"
-                                      IsTabStop="{TemplateBinding IsTabStop}"
-                                      Theme="{StaticResource ButtonSpinnerRepeatButton}"
-                                      Background="{TemplateBinding Background}"
-                                      Foreground="{TemplateBinding Foreground}"
-                                      BorderBrush="{TemplateBinding BorderBrush}"
-                                      BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerLeftThickness}}"
-                                      VerticalAlignment="Stretch"
-                                      VerticalContentAlignment="Center"
-                                      MinWidth="32"
-                                      MinHeight="0">
-                           <Panel>
-                              <PathIcon Name="IncreaseIconShadow"
-                                        Width="32"
-                                        Height="32"
-                                        Foreground="{DynamicResource RepeatButtonIconShadow}"
-                                        Margin="0 -1 0 1"
-                                        Padding="0 -1 0 1"
-                                        Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
-                                        Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
-                              <PathIcon Width="32"
-                                        Height="32"
-                                        Foreground="{TemplateBinding Foreground}"
-                                        Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
-                                        Data="{StaticResource ButtonSpinnerDecreaseButtonIcon}" />
-                           </Panel>
-                        </RepeatButton>
-                        <RepeatButton Name="PART_IncreaseButton"
-                                      IsTabStop="{TemplateBinding IsTabStop}"
-                                      Theme="{StaticResource ButtonSpinnerRepeatButton}"
-                                      Background="{TemplateBinding Background}"
-                                      Foreground="{TemplateBinding Foreground}"
-                                      BorderBrush="{TemplateBinding BorderBrush}"
-                                      BorderThickness="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerLeftThickness}}"
-                                      VerticalAlignment="Stretch"
-                                      VerticalContentAlignment="Center"
-                                      MinWidth="32"
-                                      MinHeight="0">
-                           <Panel>
-                              <PathIcon Name="DecreaseIconShadow"
-                                        Width="32"
-                                        Height="32"
-                                        Foreground="{DynamicResource RepeatButtonIconShadow}"
-                                        Margin="0 -1 0 1"
-                                        Padding="0 -1 0 1"
-                                        Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
-                                        Data="{StaticResource ButtonSpinnerIncreaseButtonIcon}" />
-                              <PathIcon Width="32"
-                                        Height="32"
-                                        Foreground="{TemplateBinding Foreground}"
-                                        Theme="{StaticResource ButtonSpinnerRepeatButtonPathIcon}"
-                                        Data="{StaticResource ButtonSpinnerIncreaseButtonIcon}" />
-                           </Panel>
-                        </RepeatButton>
-                     </StackPanel>
-
-                     <ContentPresenter Name="PART_ContentPresenter"
-                                       TabIndex="1"
-                                       ContentTemplate="{TemplateBinding ContentTemplate}"
-                                       Content="{TemplateBinding Content}"
-                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Padding="{TemplateBinding Padding}" />
-                  </DockPanel>
-               </Border>
-            </DataValidationErrors>
-         </ControlTemplate>
-      </Setter>
-
-      <Style Selector="^:left">
-         <Style Selector="^ /template/ StackPanel#PART_SpinnerPanel">
-            <Setter Property="DockPanel.Dock" Value="Left" />
-         </Style>
-         <Style Selector="^ /template/ RepeatButton">
-            <Setter Property="BorderThickness" Value="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerRightThickness}}" />
-         </Style>
-         <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
-            <Setter
-               Property="CornerRadius"
-               Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Left}}" />
-         </Style>
-      </Style>
-      <Style Selector="^:right">
-         <Style Selector="^ /template/ RepeatButton#PART_IncreaseButton">
-            <Setter
-               Property="CornerRadius"
-               Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Right}}" />
-         </Style>
-      </Style>
-
       <Style Selector="^ /template/ RepeatButton">
-         <Style Selector="^ PathIcon#IncreaseIconShadow">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
-         <Style Selector="^ PathIcon#DecreaseIconShadow">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
+        <Setter Property="BorderThickness" Value="{TemplateBinding BorderThickness, Converter={StaticResource ButtonSpinnerRightThickness}}" />
+      </Style>
+      <Style Selector="^ /template/ RepeatButton#PART_DecreaseButton">
+        <Setter
+          Property="CornerRadius"
+          Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Left}}" />
+      </Style>
+    </Style>
+    <Style Selector="^:right">
+      <Style Selector="^ /template/ RepeatButton#PART_IncreaseButton">
+        <Setter
+          Property="CornerRadius"
+          Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Right}}" />
+      </Style>
+    </Style>
 
-         <Style Selector="^:disabled">
-            <Style Selector="^ PathIcon">
-               <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
-            </Style>
-
-            <Style Selector="^ PathIcon#IncreaseIconShadow">
-               <Setter Property="IsVisible" Value="False" />
-            </Style>
-            <Style Selector="^ PathIcon#DecreaseIconShadow">
-               <Setter Property="IsVisible" Value="False" />
-            </Style>
-         </Style>
+    <Style Selector="^ /template/ RepeatButton">
+      <Style Selector="^ PathIcon#IncreaseIconShadow">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+      <Style Selector="^ PathIcon#DecreaseIconShadow">
+        <Setter Property="IsVisible" Value="True" />
       </Style>
 
-      <!-- <Style Selector="^ /template/ RepeatButton:disabled PathIcon"> -->
-      <!--     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}"/> -->
-      <!-- -->
-      <!--     <Style Selector="^#IncreaseIconShadow"> -->
-      <!--       <Setter Property="IsVisible" Value="False" /> -->
-      <!--     </Style> -->
-      <!--     <Style Selector="^#DecreaseIconShadow"> -->
-      <!--       <Setter Property="IsVisible" Value="False" /> -->
-      <!--     </Style> -->
-      <!-- </Style> -->
+      <Style Selector="^:disabled">
+        <Style Selector="^ PathIcon">
+          <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}" />
+        </Style>
 
-      <!-- <Style Selector="^:disabled /template/ PathIcon#IncreaseIconShadow"> -->
-      <!--   <Setter Property="IsVisible" Value="False" /> -->
-      <!-- </Style> -->
-      <!-- -->
-      <!-- <Style Selector="^:disabled /template/ PathIcon#DecreaseIconShadow"> -->
-      <!--   <Setter Property="IsVisible" Value="False" /> -->
-      <!-- </Style> -->
+        <Style Selector="^ PathIcon#IncreaseIconShadow">
+          <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <Style Selector="^ PathIcon#DecreaseIconShadow">
+          <Setter Property="IsVisible" Value="False" />
+        </Style>
+      </Style>
+    </Style>
 
-      <Style Selector="^ /template/ TextBox:pointerover Border#PART_BorderElement">
-         <Setter Property="BorderBrush" Value="Transparent" />
-         <Setter Property="Background" Value="Transparent" />
-      </Style>
-      <Style Selector="^:error">
-         <Setter Property="BorderBrush" Value="{DynamicResource SystemErrorTextColor}" />
-      </Style>
-   </ControlTheme>
+    <!-- <Style Selector="^ /template/ RepeatButton:disabled PathIcon"> -->
+    <!--     <Setter Property="Foreground" Value="{DynamicResource RepeatButtonForegroundDisabled}"/> -->
+    <!-- -->
+    <!--     <Style Selector="^#IncreaseIconShadow"> -->
+    <!--       <Setter Property="IsVisible" Value="False" /> -->
+    <!--     </Style> -->
+    <!--     <Style Selector="^#DecreaseIconShadow"> -->
+    <!--       <Setter Property="IsVisible" Value="False" /> -->
+    <!--     </Style> -->
+    <!-- </Style> -->
+
+    <!-- <Style Selector="^:disabled /template/ PathIcon#IncreaseIconShadow"> -->
+    <!--   <Setter Property="IsVisible" Value="False" /> -->
+    <!-- </Style> -->
+    <!-- -->
+    <!-- <Style Selector="^:disabled /template/ PathIcon#DecreaseIconShadow"> -->
+    <!--   <Setter Property="IsVisible" Value="False" /> -->
+    <!-- </Style> -->
+
+    <Style Selector="^ /template/ TextBox:pointerover Border#PART_BorderElement">
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="^:error">
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemErrorTextColor}" />
+    </Style>
+  </ControlTheme>
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CheckBox.axaml
@@ -5,6 +5,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
+
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="20">
@@ -17,7 +18,7 @@
   </Design.PreviewWith>
 
   <StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>
-  
+
   <ControlTheme x:Key="{x:Type CheckBox}" TargetType="CheckBox">
     <Setter Property="Padding" Value="8,0,0,0" />
     <Setter Property="HorizontalAlignment" Value="Left" />
@@ -62,14 +63,14 @@
             </Viewbox>
           </Grid>
           <ContentPresenter x:Name="PART_ContentPresenter"
-                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                          Content="{TemplateBinding Content}"
-                          Margin="{TemplateBinding Padding}"
-                          RecognizesAccessKey="True"
-                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                          TextWrapping="Wrap"
-                          Grid.Column="1" />
+                            ContentTemplate="{TemplateBinding ContentTemplate}"
+                            Content="{TemplateBinding Content}"
+                            Margin="{TemplateBinding Padding}"
+                            RecognizesAccessKey="True"
+                            HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                            TextWrapping="Wrap"
+                            Grid.Column="1" />
         </Grid>
       </ControlTemplate>
     </Setter>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ContextMenu.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ContextMenu.axaml
@@ -5,6 +5,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
+
   <Design.PreviewWith>
     <Border Background="{DynamicResource SystemAccentColor}"
             Margin="16"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/DataGrid.axaml
@@ -22,7 +22,7 @@
       </DataGrid.Columns>
     </DataGrid>
   </Design.PreviewWith>
-  
+
   <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource DataGridColumnHeaderForegroundColor}" />
   <SolidColorBrush x:Key="DataGridColumnHeaderBackground" Color="{DynamicResource DataGridColumnHeaderBackgroundColor}" />
   <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackground" Color="{DynamicResource SystemListLowColor}" />
@@ -350,7 +350,7 @@
         </Border>
       </ControlTemplate>
     </Setter>
-    
+
     <ControlTheme.Children>
       <Style Selector="^:nth-child(2n)">
         <Setter Property="Background"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ListBox.axaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
-  
+
   <ControlTheme x:Key="{x:Type ListBox}" TargetType="ListBox" BasedOn="{StaticResource {x:Type ListBox}}">
     <Setter Property="Background" Value="{DynamicResource ScrollControlBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/NumericUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/NumericUpDown.axaml
@@ -3,138 +3,138 @@
     https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Themes.Fluent/Controls/NumericUpDown.xaml
 -->
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:sys="clr-namespace:System;assembly=System.Runtime"
+  x:ClassModifier="internal">
 
-   x:ClassModifier="internal">
-   <Design.PreviewWith>
-      <Border Padding="20">
-         <StackPanel Spacing="20">
-            <NumericUpDown
-               Minimum="0"
-               Maximum="10"
-               Increment="0.5"
-               Watermark="Enter text" />
-            <NumericUpDown
-               Minimum="0"
-               Maximum="10"
-               Increment="0.5"
-               VerticalContentAlignment="Center"
-               HorizontalContentAlignment="Center"
-               ButtonSpinnerLocation="Left"
-               Watermark="Enter text" />
-            <NumericUpDown ButtonSpinnerLocation="Left">
-               <NumericUpDown.InnerLeftContent>
-                  <TextBlock
-                     Text="m"
-                     TextAlignment="Center"
-                     VerticalAlignment="Center" />
-               </NumericUpDown.InnerLeftContent>
-               <NumericUpDown.InnerRightContent>
-                  <Button Content="X" />
-               </NumericUpDown.InnerRightContent>
-            </NumericUpDown>
-            <NumericUpDown ButtonSpinnerLocation="Right">
-               <NumericUpDown.InnerLeftContent>
-                  <Button Content="X" />
-               </NumericUpDown.InnerLeftContent>
-               <NumericUpDown.InnerRightContent>
-                  <TextBlock
-                     Text="m"
-                     TextAlignment="Center"
-                     VerticalAlignment="Center" />
-               </NumericUpDown.InnerRightContent>
-            </NumericUpDown>
-            <NumericUpDown>
-               <DataValidationErrors.Error>
-                  <sys:Exception>
-                     <x:Arguments>
-                        <x:String>Error</x:String>
-                     </x:Arguments>
-                  </sys:Exception>
-               </DataValidationErrors.Error>
-            </NumericUpDown>
-         </StackPanel>
-      </Border>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <StackPanel Spacing="20">
+        <NumericUpDown
+          Minimum="0"
+          Maximum="10"
+          Increment="0.5"
+          Watermark="Enter text" />
+        <NumericUpDown
+          Minimum="0"
+          Maximum="10"
+          Increment="0.5"
+          VerticalContentAlignment="Center"
+          HorizontalContentAlignment="Center"
+          ButtonSpinnerLocation="Left"
+          Watermark="Enter text" />
+        <NumericUpDown ButtonSpinnerLocation="Left">
+          <NumericUpDown.InnerLeftContent>
+            <TextBlock
+              Text="m"
+              TextAlignment="Center"
+              VerticalAlignment="Center" />
+          </NumericUpDown.InnerLeftContent>
+          <NumericUpDown.InnerRightContent>
+            <Button Content="X" />
+          </NumericUpDown.InnerRightContent>
+        </NumericUpDown>
+        <NumericUpDown ButtonSpinnerLocation="Right">
+          <NumericUpDown.InnerLeftContent>
+            <Button Content="X" />
+          </NumericUpDown.InnerLeftContent>
+          <NumericUpDown.InnerRightContent>
+            <TextBlock
+              Text="m"
+              TextAlignment="Center"
+              VerticalAlignment="Center" />
+          </NumericUpDown.InnerRightContent>
+        </NumericUpDown>
+        <NumericUpDown>
+          <DataValidationErrors.Error>
+            <sys:Exception>
+              <x:Arguments>
+                <x:String>Error</x:String>
+              </x:Arguments>
+            </sys:Exception>
+          </DataValidationErrors.Error>
+        </NumericUpDown>
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type NumericUpDown}" TargetType="NumericUpDown">
-      <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
-      <Setter Property="Background" Value="{DynamicResource InputBackground}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
-      <Setter Property="Height" Value="{DynamicResource InputDefaultHeight}" />
-      <Setter Property="MinWidth" Value="{DynamicResource NumericUpDownMinWidth}" />
-      <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors>
-               <Panel>
-                  <ButtonSpinner
-                     Name="PART_Spinner"
-                     Background="{TemplateBinding Background}"
-                     BorderThickness="{TemplateBinding BorderThickness}"
-                     BorderBrush="{TemplateBinding BorderBrush}"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}"
-                     IsTabStop="False"
-                     Padding="0"
-                     HorizontalContentAlignment="Stretch"
-                     VerticalContentAlignment="Stretch"
-                     AllowSpin="{TemplateBinding AllowSpin}"
-                     ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
-                     ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
-                     <TextBox
-                        Name="PART_TextBox"
-                        Classes="no-focus-border"
-                        Background="Transparent"
-                        BorderBrush="Transparent"
-                        Margin="-1"
-                        Padding="{TemplateBinding Padding}"
-                        MinWidth="0"
-                        Foreground="{TemplateBinding Foreground}"
-                        Watermark="{TemplateBinding Watermark}"
-                        IsReadOnly="{TemplateBinding IsReadOnly}"
-                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        Text="{TemplateBinding Text}"
-                        TextAlignment="{TemplateBinding TextAlignment}"
-                        AcceptsReturn="False"
-                        TextWrapping="NoWrap"
-                        Focusable="{TemplateBinding Focusable}"
-                        InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
-                        InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
-                  </ButtonSpinner>
-                  <Border
-                     Name="PART_FocusBorder"
-                     Margin="0"
-                     Background="Transparent"
-                     IsHitTestVisible="False"
-                     CornerRadius="{DynamicResource ControlCornerRadius}" />
-               </Panel>
-            </DataValidationErrors>
-         </ControlTemplate>
-      </Setter>
-      <!-- Focused State -->
-      <Style Selector="^:focus-within /template/ Border#PART_FocusBorder">
-         <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
-         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
-      </Style>
+  <ControlTheme x:Key="{x:Type NumericUpDown}" TargetType="NumericUpDown">
+    <Setter Property="Foreground" Value="{DynamicResource TextControlForeground}" />
+    <Setter Property="Background" Value="{DynamicResource InputBackground}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
+    <Setter Property="Height" Value="{DynamicResource InputDefaultHeight}" />
+    <Setter Property="MinWidth" Value="{DynamicResource NumericUpDownMinWidth}" />
+    <Setter Property="Padding" Value="{DynamicResource TextControlThemePadding}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors>
+          <Panel>
+            <ButtonSpinner
+              Name="PART_Spinner"
+              Background="{TemplateBinding Background}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}"
+              IsTabStop="False"
+              Padding="0"
+              HorizontalContentAlignment="Stretch"
+              VerticalContentAlignment="Stretch"
+              AllowSpin="{TemplateBinding AllowSpin}"
+              ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
+              ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
+              <TextBox
+                Name="PART_TextBox"
+                Classes="no-focus-border"
+                Background="Transparent"
+                BorderBrush="Transparent"
+                Margin="-1"
+                Padding="{TemplateBinding Padding}"
+                MinWidth="0"
+                Foreground="{TemplateBinding Foreground}"
+                Watermark="{TemplateBinding Watermark}"
+                IsReadOnly="{TemplateBinding IsReadOnly}"
+                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                Text="{TemplateBinding Text}"
+                TextAlignment="{TemplateBinding TextAlignment}"
+                AcceptsReturn="False"
+                TextWrapping="NoWrap"
+                Focusable="{TemplateBinding Focusable}"
+                InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
+                InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
+            </ButtonSpinner>
+            <Border
+              Name="PART_FocusBorder"
+              Margin="0"
+              Background="Transparent"
+              IsHitTestVisible="False"
+              CornerRadius="{DynamicResource ControlCornerRadius}" />
+          </Panel>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
+    <!-- Focused State -->
+    <Style Selector="^:focus-within /template/ Border#PART_FocusBorder">
+      <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
+      <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
+    </Style>
 
-      <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox">
-         <Setter
-            Property="CornerRadius"
-            Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Right}}" />
-      </Style>
-      <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox">
-         <Setter
-            Property="CornerRadius"
-            Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Left}}" />
-      </Style>
-   </ControlTheme>
+    <Style Selector="^[ButtonSpinnerLocation=Left] /template/ TextBox">
+      <Setter
+        Property="CornerRadius"
+        Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Right}}" />
+    </Style>
+    <Style Selector="^[ButtonSpinnerLocation=Right] /template/ TextBox">
+      <Setter
+        Property="CornerRadius"
+        Value="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.CornerRadiusExtractor}, ConverterParameter={x:Static CornerRadiusSubset.Left}}" />
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TabControl.axaml
@@ -5,86 +5,87 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
-    <Design.PreviewWith>
-        <Border Width="400">
-            <TabControl>
-                <TabItem Header="Arch">
-                    <Border Background="AntiqueWhite" Height="100">
-                        <TextBlock Text="Content" Foreground="Black" FontSize="20" />
-                    </Border>
-                </TabItem>
-                <TabItem Header="Leaf">
-                    <Border Background="Green" Height="100" />
-                </TabItem>
-                <TabItem Header="Disabled" IsEnabled="False" />
-            </TabControl>
+
+  <Design.PreviewWith>
+    <Border Width="400">
+      <TabControl>
+        <TabItem Header="Arch">
+          <Border Background="AntiqueWhite" Height="100">
+            <TextBlock Text="Content" Foreground="Black" FontSize="20" />
+          </Border>
+        </TabItem>
+        <TabItem Header="Leaf">
+          <Border Background="Green" Height="100" />
+        </TabItem>
+        <TabItem Header="Disabled" IsEnabled="False" />
+      </TabControl>
+    </Border>
+  </Design.PreviewWith>
+
+  <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 0</Thickness>
+
+  <ControlTheme x:Key="TabPaneTheme" TargetType="TabControl">
+    <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
+    <Setter Property="BorderThickness" Value="1" />
+
+    <Setter Property="Padding" Value="10" />
+    <Setter Property="Background" Value="{DynamicResource TabControlBackground}" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Background="{TemplateBinding Background}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}">
+          <DockPanel>
+            <Border Name="PART_ItemsPresenterBorder"
+                    DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 0 1"
+                    Padding="4, 0, 4, -1"
+                    CornerRadius="0">
+              <ItemsPresenter Name="PART_ItemsPresenter"
+                              ItemsPanel="{TemplateBinding ItemsPanel}" />
+            </Border>
+            <ContentPresenter Name="PART_SelectedContentHost"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding SelectedContent}"
+                              ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+          </DockPanel>
         </Border>
-    </Design.PreviewWith>
+      </ControlTemplate>
+    </Setter>
 
-    <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 0</Thickness>
+    <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+      <Setter Property="Orientation" Value="Vertical" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+      <Setter Property="Orientation" Value="Vertical" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter">
+      <Setter Property="Margin" Value="{DynamicResource TabControlTopPlacementItemMargin}" />
+    </Style>
 
-    <ControlTheme x:Key="TabPaneTheme" TargetType="TabControl">
-        <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
-        <Setter Property="BorderThickness" Value="1" />
-        
-        <Setter Property="Padding" Value="10" />
-        <Setter Property="Background" Value="{DynamicResource TabControlBackground}" />
-        <Setter Property="CornerRadius" Value="0" />
-        <Setter Property="Template">
-            <ControlTemplate>
-                <Border BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
-                        Background="{TemplateBinding Background}"
-                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                    <DockPanel>
-                        <Border Name="PART_ItemsPresenterBorder"
-                                DockPanel.Dock="{TemplateBinding TabStripPlacement}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="0 0 0 1"
-                                Padding="4, 0, 4, -1"
-                                CornerRadius="0">
-                            <ItemsPresenter Name="PART_ItemsPresenter"
-                                            ItemsPanel="{TemplateBinding ItemsPanel}" />
-                        </Border>
-                        <ContentPresenter Name="PART_SelectedContentHost"
-                                          Margin="{TemplateBinding Padding}"
-                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          Content="{TemplateBinding SelectedContent}"
-                                          ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
-                    </DockPanel>
-                </Border>
-            </ControlTemplate>
-        </Setter>
+    <Style
+      Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter Border#PART_SelectedPipe">
+      <Setter Property="Height" Value="3" />
+      <Setter Property="CornerRadius" Value="0" />
+    </Style>
 
-        <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-            <Setter Property="Orientation" Value="Vertical" />
-        </Style>
-        <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-            <Setter Property="Orientation" Value="Vertical" />
-        </Style>
-        <Style Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter">
-            <Setter Property="Margin" Value="{DynamicResource TabControlTopPlacementItemMargin}" />
-        </Style>
+    <Style Selector="^[TabStripPlacement=Left] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="0 0 1 0" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="1 0 0 0" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="0 1 0 0" />
+    </Style>
+  </ControlTheme>
 
-        <Style
-            Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter Border#PART_SelectedPipe">
-            <Setter Property="Height" Value="3" />
-            <Setter Property="CornerRadius" Value="0" />
-        </Style>
-
-        <Style Selector="^[TabStripPlacement=Left] /template/ Border#PART_ItemsPresenterBorder">
-            <Setter Property="BorderThickness" Value="0 0 1 0" />
-        </Style>
-        <Style Selector="^[TabStripPlacement=Right] /template/ Border#PART_ItemsPresenterBorder">
-            <Setter Property="BorderThickness" Value="1 0 0 0" />
-        </Style>
-        <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#PART_ItemsPresenterBorder">
-            <Setter Property="BorderThickness" Value="0 1 0 0" />
-        </Style>
-    </ControlTheme>
-
-    <StaticResource x:Key="{x:Type TabControl}" ResourceKey="TabPaneTheme" />
+  <StaticResource x:Key="{x:Type TabControl}" ResourceKey="TabPaneTheme" />
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TabItem.axaml
@@ -3,15 +3,16 @@
     https://github.com/AvaloniaUI/Avalonia/blob/603a2bdb43b7e8b2d1c8919f9d0669af7b33f117/src/Avalonia.Themes.Fluent/Controls/TabItem.xaml
 -->
 <ResourceDictionary
-    xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    x:ClassModifier="internal">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:ClassModifier="internal">
+
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <TabItem Header="Leaf" />
         <TabItem Header="Arch" IsSelected="True" />
-        <TabItem Header="Background" Background="Yellow"/>
+        <TabItem Header="Background" Background="Yellow" />
       </StackPanel>
     </Border>
   </Design.PreviewWith>
@@ -34,26 +35,25 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Border
-            Name="PART_LayoutRoot"
-            Background="{TemplateBinding Background}"
-            BorderBrush="{TemplateBinding BorderBrush}"
-            BorderThickness="{TemplateBinding BorderThickness}"
-            CornerRadius="{TemplateBinding CornerRadius}"
-            Padding="{TemplateBinding Padding}">
+          Name="PART_LayoutRoot"
+          Background="{TemplateBinding Background}"
+          BorderBrush="{TemplateBinding BorderBrush}"
+          BorderThickness="{TemplateBinding BorderThickness}"
+          CornerRadius="{TemplateBinding CornerRadius}"
+          Padding="{TemplateBinding Padding}">
           <Panel>
             <ContentPresenter
-                Name="PART_ContentPresenter"
-                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                Content="{TemplateBinding Header}"
-                ContentTemplate="{TemplateBinding HeaderTemplate}"
-                Padding="10, 0"
-                RecognizesAccessKey="True"
-                />
+              Name="PART_ContentPresenter"
+              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+              Content="{TemplateBinding Header}"
+              ContentTemplate="{TemplateBinding HeaderTemplate}"
+              Padding="10, 0"
+              RecognizesAccessKey="True" />
             <Border Name="PART_SelectedPipe"
                     Background="{DynamicResource TabItemHeaderSelectedPipeFill}"
                     CornerRadius="0"
-                    IsVisible="False"/>
+                    IsVisible="False" />
           </Panel>
         </Border>
       </ControlTemplate>
@@ -75,8 +75,8 @@
       <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundUnselectedPointerOver}" />
     </Style>
     <Style Selector="^:pointerover:not(:selected) /template/ Border#PART_SelectedPipe">
-        <Setter Property="IsVisible" Value="True" />
-        <Setter Property="Background" Value="{DynamicResource TabItemHeaderPointerOverPipe}" />
+      <Setter Property="IsVisible" Value="True" />
+      <Setter Property="Background" Value="{DynamicResource TabItemHeaderPointerOverPipe}" />
     </Style>
 
     <!--  Selected PointerOver state  -->

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TextBox.axaml
@@ -5,6 +5,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:ClassModifier="internal">
+
   <Design.PreviewWith>
     <Border Padding="20">
       <StackPanel Spacing="20">
@@ -13,8 +14,8 @@
         <TextBox Classes="clearButton">Clear</TextBox>
         <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
         <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-        <TextBox Watermark="Watermark"/>
-        <TextBox Watermark="Floating Watermark" UseFloatingWatermark="True"/>
+        <TextBox Watermark="Watermark" />
+        <TextBox Watermark="Floating Watermark" UseFloatingWatermark="True" />
         <TextBox Watermark="Floating Watermark" UseFloatingWatermark="True">Content</TextBox>
       </StackPanel>
     </Border>
@@ -24,26 +25,31 @@
   <StreamGeometry x:Key="TextBoxClearButtonData">M 11.416016,10 20,1.4160156 18.583984,0 10,8.5839846 1.4160156,0 0,1.4160156 8.5839844,10 0,18.583985 1.4160156,20 10,11.416015 18.583984,20 20,18.583985 Z</StreamGeometry>
   <StreamGeometry x:Key="PasswordBoxRevealButtonData">m10.051 7.0032c2.215 0 4.0105 1.7901 4.0105 3.9984s-1.7956 3.9984-4.0105 3.9984c-2.215 0-4.0105-1.7901-4.0105-3.9984s1.7956-3.9984 4.0105-3.9984zm0 1.4994c-1.3844 0-2.5066 1.1188-2.5066 2.499s1.1222 2.499 2.5066 2.499 2.5066-1.1188 2.5066-2.499-1.1222-2.499-2.5066-2.499zm0-5.0026c4.6257 0 8.6188 3.1487 9.7267 7.5613 0.10085 0.40165-0.14399 0.80877-0.54686 0.90931-0.40288 0.10054-0.81122-0.14355-0.91208-0.54521-0.94136-3.7492-4.3361-6.4261-8.2678-6.4261-3.9334 0-7.3292 2.6792-8.2689 6.4306-0.10063 0.40171-0.50884 0.64603-0.91177 0.54571s-0.648-0.5073-0.54737-0.90901c1.106-4.4152 5.1003-7.5667 9.728-7.5667z</StreamGeometry>
   <StreamGeometry x:Key="PasswordBoxHideButtonData">m0.21967 0.21965c-0.26627 0.26627-0.29047 0.68293-0.07262 0.97654l0.07262 0.08412 4.0346 4.0346c-1.922 1.3495-3.3585 3.365-3.9554 5.7495-0.10058 0.4018 0.14362 0.8091 0.54543 0.9097 0.40182 0.1005 0.80909-0.1436 0.90968-0.5455 0.52947-2.1151 1.8371-3.8891 3.5802-5.0341l1.8096 1.8098c-0.70751 0.7215-1.1438 1.71-1.1438 2.8003 0 2.2092 1.7909 4 4 4 1.0904 0 2.0788-0.4363 2.8004-1.1438l5.9193 5.9195c0.2929 0.2929 0.7677 0.2929 1.0606 0 0.2663-0.2662 0.2905-0.6829 0.0726-0.9765l-0.0726-0.0841-6.1135-6.1142 0.0012-0.0015-1.2001-1.1979-2.8699-2.8693 2e-3 -8e-4 -2.8812-2.8782 0.0012-0.0018-1.1333-1.1305-4.3064-4.3058c-0.29289-0.29289-0.76777-0.29289-1.0607 0zm7.9844 9.0458 3.5351 3.5351c-0.45 0.4358-1.0633 0.704-1.7392 0.704-1.3807 0-2.5-1.1193-2.5-2.5 0-0.6759 0.26824-1.2892 0.7041-1.7391zm1.7959-5.7655c-1.0003 0-1.9709 0.14807-2.8889 0.425l1.237 1.2362c0.5358-0.10587 1.0883-0.16119 1.6519-0.16119 3.9231 0 7.3099 2.6803 8.2471 6.4332 0.1004 0.4018 0.5075 0.6462 0.9094 0.5459 0.4019-0.1004 0.6463-0.5075 0.5459-0.9094-1.103-4.417-5.0869-7.5697-9.7024-7.5697zm0.1947 3.5093 3.8013 3.8007c-0.1018-2.0569-1.7488-3.7024-3.8013-3.8007z</StreamGeometry>
-  
+
   <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
-    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}" IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
-    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}" IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}"/>
-    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}" IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}"/>
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}" IsEnabled="{Binding $parent[TextBox].CanCut}"
+              InputGesture="{x:Static TextBox.CutGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}" IsEnabled="{Binding $parent[TextBox].CanCopy}"
+              InputGesture="{x:Static TextBox.CopyGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}" IsEnabled="{Binding $parent[TextBox].CanPaste}"
+              InputGesture="{x:Static TextBox.PasteGesture}" />
   </MenuFlyout>
   <MenuFlyout x:Key="HorizontalTextBoxContextFlyout" FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}" ItemContainerTheme="{StaticResource HorizontalMenuItem}">
-    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}" IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
-    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}" IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}" IsEnabled="{Binding $parent[TextBox].CanCut}"
+              IsVisible="{Binding $parent[TextBox].CanCut}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}" IsEnabled="{Binding $parent[TextBox].CanCopy}"
+              IsVisible="{Binding $parent[TextBox].CanCopy}" />
     <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}" IsEnabled="{Binding $parent[TextBox].CanPaste}" />
   </MenuFlyout>
 
   <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
     <Setter Property="Background" Value="{DynamicResource TextControlButtonBackground}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextControlButtonBorderBrush}" />
-    <Setter Property="Focusable" Value="False"/>
+    <Setter Property="Focusable" Value="False" />
     <Setter Property="MinWidth" Value="34" />
     <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-    <Setter Property="Width" Value="{Binding $self.Bounds.Height}"/>
-    <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}"/>
+    <Setter Property="Width" Value="{Binding $self.Bounds.Height}" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}" />
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
@@ -52,8 +58,7 @@
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"
                             Content="{TemplateBinding Content}"
-                            Padding="{TemplateBinding Padding}">
-          </ContentPresenter>
+                            Padding="{TemplateBinding Padding}" />
         </ControlTemplate>
       </Setter.Value>
     </Setter>
@@ -78,8 +83,7 @@
                           Background="{TemplateBinding Background}"
                           Content="{TemplateBinding Content}"
                           CornerRadius="{TemplateBinding CornerRadius}"
-                          Padding="{TemplateBinding Padding}">
-        </ContentPresenter>
+                          Padding="{TemplateBinding Padding}" />
       </ControlTemplate>
     </Setter>
 
@@ -115,19 +119,16 @@
               BorderThickness="{TemplateBinding BorderThickness}"
               CornerRadius="{TemplateBinding CornerRadius}"
               MinWidth="{TemplateBinding MinWidth}"
-              MinHeight="{TemplateBinding MinHeight}">
-            </Border>
+              MinHeight="{TemplateBinding MinHeight}" />
 
             <Border
               Margin="{TemplateBinding BorderThickness}">
               <Grid ColumnDefinitions="Auto,*,Auto" Margin="{TemplateBinding Padding}">
                 <ContentPresenter Grid.Column="0"
-                                  Grid.ColumnSpan="1"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Content="{TemplateBinding InnerLeftContent}"/>
+                                  Content="{TemplateBinding InnerLeftContent}" />
                 <DockPanel x:Name="PART_InnerDockPanel"
-                           Grid.Column="1"
-                           Grid.ColumnSpan="1">
+                           Grid.Column="1">
                   <TextBlock Name="PART_FloatingWatermark"
                              Foreground="{DynamicResource SystemAccentColor}"
                              IsVisible="False"
@@ -141,36 +142,36 @@
                                 BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
                     <Panel>
                       <TextBlock Name="PART_Watermark"
-                              Opacity="0.5"
-                              Text="{TemplateBinding Watermark}"
-                              TextAlignment="{TemplateBinding TextAlignment}"
-                              TextWrapping="{TemplateBinding TextWrapping}"
-                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                 Opacity="0.5"
+                                 Text="{TemplateBinding Watermark}"
+                                 TextAlignment="{TemplateBinding TextAlignment}"
+                                 TextWrapping="{TemplateBinding TextWrapping}"
+                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                         <TextBlock.IsVisible>
                           <MultiBinding Converter="{x:Static BoolConverters.And}">
-                            <Binding ElementName="PART_TextPresenter" Path="PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
-                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text" Converter="{x:Static StringConverters.IsNullOrEmpty}"/>
+                            <Binding ElementName="PART_TextPresenter" Path="PreeditText" Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text" Converter="{x:Static StringConverters.IsNullOrEmpty}" />
                           </MultiBinding>
                         </TextBlock.IsVisible>
                       </TextBlock>
                       <TextPresenter Name="PART_TextPresenter"
-                                    Text="{TemplateBinding Text, Mode=TwoWay}"
-                                    CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                    CaretIndex="{TemplateBinding CaretIndex}"
-                                    SelectionStart="{TemplateBinding SelectionStart}"
-                                    SelectionEnd="{TemplateBinding SelectionEnd}"
-                                    TextAlignment="{TemplateBinding TextAlignment}"
-                                    TextWrapping="{TemplateBinding TextWrapping}"
-                                    LineHeight="{TemplateBinding LineHeight}"
-                                    LetterSpacing="{TemplateBinding LetterSpacing}"
-                                    PasswordChar="{TemplateBinding PasswordChar}"
-                                    RevealPassword="{TemplateBinding RevealPassword}"
-                                    SelectionBrush="{TemplateBinding SelectionBrush}"
-                                    SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                    CaretBrush="{TemplateBinding CaretBrush}"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                     Text="{TemplateBinding Text, Mode=TwoWay}"
+                                     CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                     CaretIndex="{TemplateBinding CaretIndex}"
+                                     SelectionStart="{TemplateBinding SelectionStart}"
+                                     SelectionEnd="{TemplateBinding SelectionEnd}"
+                                     TextAlignment="{TemplateBinding TextAlignment}"
+                                     TextWrapping="{TemplateBinding TextWrapping}"
+                                     LineHeight="{TemplateBinding LineHeight}"
+                                     LetterSpacing="{TemplateBinding LetterSpacing}"
+                                     PasswordChar="{TemplateBinding PasswordChar}"
+                                     RevealPassword="{TemplateBinding RevealPassword}"
+                                     SelectionBrush="{TemplateBinding SelectionBrush}"
+                                     SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                     CaretBrush="{TemplateBinding CaretBrush}"
+                                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                     </Panel>
                     <ScrollViewer.Styles>
                       <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
@@ -180,9 +181,8 @@
                   </ScrollViewer>
                 </DockPanel>
                 <ContentPresenter Grid.Column="2"
-                                  Grid.ColumnSpan="1"
                                   VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                  Content="{TemplateBinding InnerRightContent}"/>
+                                  Content="{TemplateBinding InnerRightContent}" />
               </Grid>
             </Border>
           </Panel>
@@ -208,20 +208,20 @@
       </Style>
 
       <Style Selector="^ /template/ Border#PART_BorderElement">
-        <Setter Property="Background" Value="{DynamicResource TextControlBackgroundFocused}"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}"/>
+        <Setter Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource TextControlBorderBrushFocused}" />
         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThicknessFocused}" />
       </Style>
     </Style>
 
     <Style Selector="^:error /template/ Border#PART_BorderElement">
-      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}"/>
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
     </Style>
 
     <Style Selector="^ /template/ TextBlock#PART_FloatingWatermark">
-      <Setter Property="Cursor" Value="IBeam"/>
+      <Setter Property="Cursor" Value="IBeam" />
     </Style>
-    
+
     <Style Selector="^[UseFloatingWatermark=true]:not(:empty) /template/ TextBlock#PART_FloatingWatermark">
       <Setter Property="IsVisible" Value="True" />
     </Style>
@@ -237,10 +237,10 @@
             <Panel>
               <PathIcon Data="{StaticResource PasswordBoxRevealButtonData}"
                         Height="8" Width="12"
-                        IsVisible="{Binding !$parent[ToggleButton].IsChecked}"/>
+                        IsVisible="{Binding !$parent[ToggleButton].IsChecked}" />
               <PathIcon Data="{StaticResource PasswordBoxHideButtonData}"
                         Height="12" Width="12"
-                        IsVisible="{Binding $parent[ToggleButton].IsChecked}"/>
+                        IsVisible="{Binding $parent[ToggleButton].IsChecked}" />
             </Panel>
           </ToggleButton>
         </Template>
@@ -253,7 +253,7 @@
           <Button Theme="{StaticResource FluentTextBoxButton}"
                   Command="{Binding $parent[TextBox].Clear}"
                   ClipToBounds="True">
-            <PathIcon Data="{StaticResource TextBoxClearButtonData}" Height="10" Width="10"/>
+            <PathIcon Data="{StaticResource TextBoxClearButtonData}" Height="10" Width="10" />
           </Button>
         </Template>
       </Setter>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -1,32 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
-   <PropertyGroup>
-      <Version>1.0.0.0</Version>
-      <Company>Devolutions</Company>
-      <Description>Devolutions Avalonia Linux Theme</Description>
-      <PackageId>Devolutions.AvaloniaTheme.Linux</PackageId>
-      <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <TargetFramework>net9.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
-      <Nullable>enable</Nullable>
-      <RootNamespace>Devolutions.AvaloniaThemes.Linux</RootNamespace>
-   </PropertyGroup>
-   <ItemGroup>
-      <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
-      <!-- 
-              Avalonia.Svg.Skia 11.2.7.1 require at least 3.116, which is bugged atm on linux.
-              https://github.com/mono/SkiaSharp/issues/3117
-              [3.118,3.119] should work once released, but are just in preview so far.  
-              This should be updated accordingly once out.
-              - sbergerondrouin 2025-04-29 
-            -->
-      <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,11.2.7.1)" />
-      <PackageReference Include="SkiaSharp" Version="[2.88.9,3.116.0)" />
-       <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-      <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
-   </ItemGroup>
+  <PropertyGroup>
+    <Version>1.0.0.0</Version>
+    <Company>Devolutions</Company>
+    <Description>Devolutions Avalonia Linux Theme</Description>
+    <PackageId>Devolutions.AvaloniaTheme.Linux</PackageId>
+    <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Devolutions.AvaloniaThemes.Linux</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
+    <!-- 
+            Avalonia.Svg.Skia 11.2.7.1 require at least 3.116, which is bugged atm on linux.
+            https://github.com/mono/SkiaSharp/issues/3117
+            [3.118,3.119] should work once released, but are just in preview so far.  
+            This should be updated accordingly once out.
+            - sbergerondrouin 2025-04-29 
+          -->
+    <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,11.2.7.1)"/>
+    <PackageReference Include="SkiaSharp" Version="[2.88.9,3.116.0)"/>
+    <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
+  </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/LinuxTheme.axaml
@@ -1,22 +1,22 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <!-- Using Fluent Theme as a fallback for anything not defined in Linux theme -->
-   <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
+  <!-- Using Fluent Theme as a fallback for anything not defined in Linux theme -->
+  <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
 
-   <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
+  <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
 
-   <Styles.Resources>
-      <ResourceDictionary>
-         <ResourceDictionary.MergedDictionaries>
-            <MergeResourceInclude Source="/Accents/Icons.axaml" />
-            <!-- <MergeResourceInclude Source="/Converters/_index.axaml" /> -->
-            <MergeResourceInclude Source="/Controls/_index.axaml" />
-            <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
-         </ResourceDictionary.MergedDictionaries>
-      </ResourceDictionary>
-   </Styles.Resources>
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="/Accents/Icons.axaml" />
+        <!-- <MergeResourceInclude Source="/Converters/_index.axaml" /> -->
+        <MergeResourceInclude Source="/Controls/_index.axaml" />
+        <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
 
-   <!-- Themed Controls -->
-   <StyleInclude Source="/Accents/Styles.axaml" />
+  <!-- Themed Controls -->
+  <StyleInclude Source="/Accents/Styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.Linux/README.md
+++ b/src/Devolutions.AvaloniaTheme.Linux/README.md
@@ -14,14 +14,16 @@ on [Avalonia.Themes.Fluent](https://github.com/AvaloniaUI/Avalonia/tree/759facea
 both as a fallback for any controls not covered yet and as starting point for our style definitions targeting a
 Linux look similar to Ubuntu’s default “Yaru” GTK theme..
 
-While we are prioritizing controls for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/), we welcome contributions from the Avalonia community to add more controls.
+While we are prioritizing controls
+for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/), we welcome contributions from
+the Avalonia community to add more controls.
 
 - [Installation](#installation)
 - [Styled Controls](#styled-controls)
-    - Available in the current build
-    - 🚧 In progress ...
-        - Dark mode support
-    - 🔮 Next on the road map ...
+  - Available in the current build
+  - 🚧 In progress ...
+    - Dark mode support
+  - 🔮 Next on the road map ...
 
 ## Installation
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/Styles.axaml
@@ -1,37 +1,37 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <Style Selector="Menu.MacOS_Theme_MenuOpensAbove > MenuItem > Border > Panel > Popup">
-      <Setter Property="Placement" Value="TopEdgeAlignedLeft" />
-      <Setter Property="VerticalOffset" Value="{DynamicResource MenuPopupAboveVerticalOffset}" />
-      <Style Selector="^ Border">
-         <Setter Property="Margin" Value="{DynamicResource MenuPopupAboveMargin}" />
-      </Style>
-   </Style>
+  <Style Selector="Menu.MacOS_Theme_MenuOpensAbove > MenuItem > Border > Panel > Popup">
+    <Setter Property="Placement" Value="TopEdgeAlignedLeft" />
+    <Setter Property="VerticalOffset" Value="{DynamicResource MenuPopupAboveVerticalOffset}" />
+    <Style Selector="^ Border">
+      <Setter Property="Margin" Value="{DynamicResource MenuPopupAboveMargin}" />
+    </Style>
+  </Style>
 
-   <Style Selector="MenuItem Svg">
-      <Setter Property="Width" Value="15" />
-      <Setter Property="Height" Value="15" />
-   </Style>
+  <Style Selector="MenuItem Svg">
+    <Setter Property="Width" Value="15" />
+    <Setter Property="Height" Value="15" />
+  </Style>
 
-   <Style Selector="Svg">
-      <Setter Property="Css">
-         <Setter.Value>
-            <Binding Source="{StaticResource DefaultIconFillBrush}" Converter="{x:Static DevoConverters.ColorToCssFillConverter}" ConverterParameter='.st0' />
-         </Setter.Value>
-      </Setter>
-   </Style>
+  <Style Selector="Svg">
+    <Setter Property="Css">
+      <Setter.Value>
+        <Binding Source="{StaticResource DefaultIconFillBrush}" Converter="{x:Static DevoConverters.ColorToCssFillConverter}" ConverterParameter='.st0' />
+      </Setter.Value>
+    </Setter>
+  </Style>
 
-   <Style Selector="Svg:disabled">
-      <Setter Property="Css">
-         <Setter.Value>
-            <Binding Source="{StaticResource SvgIconDisabledColorBrush}" Converter="{x:Static DevoConverters.ColorToCssFillConverter}" />
-         </Setter.Value>
-      </Setter>
-   </Style>
+  <Style Selector="Svg:disabled">
+    <Setter Property="Css">
+      <Setter.Value>
+        <Binding Source="{StaticResource SvgIconDisabledColorBrush}" Converter="{x:Static DevoConverters.ColorToCssFillConverter}" />
+      </Setter.Value>
+    </Setter>
+  </Style>
 
-   <!-- Custom Classes used as ConverterParameters in Template styles - declared here to make them available to the IDE's parser to avoid false error highlighting -->
-   <Style Selector=".MacOS_Theme_MenuLabelBelowIcon" />
-   <Style Selector=".MacOS_Theme_MenuItemIconOnly" />
+  <!-- Custom Classes used as ConverterParameters in Template styles - declared here to make them available to the IDE's parser to avoid false error highlighting -->
+  <Style Selector=".MacOS_Theme_MenuLabelBelowIcon" />
+  <Style Selector=".MacOS_Theme_MenuItemIconOnly" />
 
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -1,441 +1,442 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-   <ResourceDictionary.ThemeDictionaries>
-      <ResourceDictionary x:Key="Light">
-         <Color x:Key="BackgroundColor">#ffffff</Color>
-         <Color x:Key="ForegroundColor">#000000</Color>
 
-         <Color x:Key="AccentForegroundColor">#ffffff</Color>
-         <Color x:Key="ErrorTextColor">#C50500</Color>
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Light">
+      <Color x:Key="BackgroundColor">#ffffff</Color>
+      <Color x:Key="ForegroundColor">#000000</Color>
 
-         <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
+      <Color x:Key="AccentForegroundColor">#ffffff</Color>
+      <Color x:Key="ErrorTextColor">#C50500</Color>
 
-         <Color x:Key="ControlBorderHighColor">#4a000000</Color> <!-- 29% -->
-         <Color x:Key="ControlBorderMidColor">#29000000</Color> <!-- 16% -->
-         <Color x:Key="ControlBorderLowColor">#14000000</Color> <!-- 8% -->
+      <Color x:Key="ControlBackgroundHighColor">#ffffff</Color>
 
-         <Color x:Key="GridSplitterLineColor">#4D000000</Color> <!-- 30% -->
-         <Color x:Key="SvgIconDisabledColor">#b2b2b2</Color>
-         <Color x:Key="ToolTipBackgroundColor">#e1e1e1</Color>
-         <Color x:Key="ToolTipBorderColor">Transparent</Color>
+      <Color x:Key="ControlBorderHighColor">#4a000000</Color> <!-- 29% -->
+      <Color x:Key="ControlBorderMidColor">#29000000</Color> <!-- 16% -->
+      <Color x:Key="ControlBorderLowColor">#14000000</Color> <!-- 8% -->
 
-         <Color x:Key="TabControlBackgroundColor">#f2f2f2</Color>
-         <Color x:Key="PopupBackgroundColor">#e7e7e7</Color>
-         <Color x:Key="TextBoxBackgroundColor">#ffffff</Color>
-         <Color x:Key="TextBoxClearButtonBackgroundColor">#808080</Color>
-         <Color x:Key="ButtonSpinnerButtonPressedColor">#e9e9e9</Color>
+      <Color x:Key="GridSplitterLineColor">#4D000000</Color> <!-- 30% -->
+      <Color x:Key="SvgIconDisabledColor">#b2b2b2</Color>
+      <Color x:Key="ToolTipBackgroundColor">#e1e1e1</Color>
+      <Color x:Key="ToolTipBorderColor">Transparent</Color>
 
-         <Color x:Key="ScrollBarTrackColor">#fbfbfb</Color>
-         <Color x:Key="ScrollBarTrackBorderColor">#d6d6d6</Color>
+      <Color x:Key="TabControlBackgroundColor">#f2f2f2</Color>
+      <Color x:Key="PopupBackgroundColor">#e7e7e7</Color>
+      <Color x:Key="TextBoxBackgroundColor">#ffffff</Color>
+      <Color x:Key="TextBoxClearButtonBackgroundColor">#808080</Color>
+      <Color x:Key="ButtonSpinnerButtonPressedColor">#e9e9e9</Color>
 
-         <Color x:Key="DefaultIconColor">#000000</Color>
+      <Color x:Key="ScrollBarTrackColor">#fbfbfb</Color>
+      <Color x:Key="ScrollBarTrackBorderColor">#d6d6d6</Color>
 
-         <Color x:Key="TransparentColor">Transparent</Color>
+      <Color x:Key="DefaultIconColor">#000000</Color>
 
-         <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" Opacity="1" />
+      <Color x:Key="TransparentColor">Transparent</Color>
 
-         <SolidColorBrush x:Key="ForegroundHighMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.73" />
-         <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />
-         <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.25" />
+      <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" Opacity="1" />
 
-         <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.12" />
-         <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
-         <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.03" />
+      <SolidColorBrush x:Key="ForegroundHighMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.73" />
+      <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />
+      <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.25" />
 
-         <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
-         <SolidColorBrush x:Key="LayoutBorderMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
-         <SolidColorBrush x:Key="LayoutBorderLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.02" />
+      <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.12" />
+      <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
+      <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.03" />
 
-         <SolidColorBrush x:Key="ControlBackgroundDisabledHighBrush" Color="{DynamicResource BackgroundColor}"
-                          Opacity="0.5" />
-         <BoxShadows x:Key="ControlBackgroundRecessedShadow">inset 0 5 3 -2 #bfbfbf</BoxShadows>
-         <BoxShadows x:Key="PopupShadow">0 0 1 0 #66000000, 0 0 1.5 00 #4D000000, 0 7 22 0 #40000000</BoxShadows>
+      <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
+      <SolidColorBrush x:Key="LayoutBorderMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
+      <SolidColorBrush x:Key="LayoutBorderLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.02" />
 
-         <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.44" />
-         <SolidColorBrush x:Key="ScrollBarDisabledThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
-         <x:Double x:Key="ScrollBarThumbOpacity">0.33</x:Double>
+      <SolidColorBrush x:Key="ControlBackgroundDisabledHighBrush" Color="{DynamicResource BackgroundColor}"
+                       Opacity="0.5" />
+      <BoxShadows x:Key="ControlBackgroundRecessedShadow">inset 0 5 3 -2 #bfbfbf</BoxShadows>
+      <BoxShadows x:Key="PopupShadow">0 0 1 0 #66000000, 0 0 1.5 00 #4D000000, 0 7 22 0 #40000000</BoxShadows>
 
-         <StaticResource x:Key="CheckBoxBackgroundBrush" ResourceKey="ControlBackgroundHighBrush" />
+      <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.44" />
+      <SolidColorBrush x:Key="ScrollBarDisabledThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
+      <x:Double x:Key="ScrollBarThumbOpacity">0.33</x:Double>
 
-         <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.10" />
-         <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.20" />
+      <StaticResource x:Key="CheckBoxBackgroundBrush" ResourceKey="ControlBackgroundHighBrush" />
 
-         <BoxShadows x:Key="TextBoxBorderShadows">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
-         <BoxShadows x:Key="ControlBorderBoxShadow">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
-         <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26000000, 0 0 0 0.5 #08000000</BoxShadows>
-         <BoxShadows x:Key="ToolTipBorderShadow">0 0 1 0 #66000000, 0 7 17 0 #30000000</BoxShadows>
-         <Thickness x:Key="ButtonBorderThickness">0.6 0.6 0.6 1</Thickness>
-         <Thickness x:Key="ControlBorderThickness">0.6</Thickness>
-         <Thickness x:Key="TabControlBorderThickness">0 0.6 0 0</Thickness>
-         <Thickness x:Key="ToolTipBorderThickness">0</Thickness>
+      <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.10" />
+      <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.20" />
 
+      <BoxShadows x:Key="TextBoxBorderShadows">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
+      <BoxShadows x:Key="ControlBorderBoxShadow">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
+      <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26000000, 0 0 0 0.5 #08000000</BoxShadows>
+      <BoxShadows x:Key="ToolTipBorderShadow">0 0 1 0 #66000000, 0 7 17 0 #30000000</BoxShadows>
+      <Thickness x:Key="ButtonBorderThickness">0.6 0.6 0.6 1</Thickness>
+      <Thickness x:Key="ControlBorderThickness">0.6</Thickness>
+      <Thickness x:Key="TabControlBorderThickness">0 0.6 0 0</Thickness>
+      <Thickness x:Key="ToolTipBorderThickness">0</Thickness>
 
-         <!-- DestinationRect Height must match TreeViewItem Height * 2 -->
-         <ImageBrush x:Key="StripedBackgroundBrush"
-                     Source="avares://Devolutions.AvaloniaTheme.MacOS/Accents/Assets/Alternating_Row_Background_Light.png"
-                     TileMode="Tile"
-                     Stretch="None"
-                     DestinationRect="0 0 40 44" />
 
-         <SolidColorBrush x:Key="DataGridItemBackgroundAlternating"
-                          Color="{DynamicResource ForegroundColor}" Opacity="0.04" />
+      <!-- DestinationRect Height must match TreeViewItem Height * 2 -->
+      <ImageBrush x:Key="StripedBackgroundBrush"
+                  Source="avares://Devolutions.AvaloniaTheme.MacOS/Accents/Assets/Alternating_Row_Background_Light.png"
+                  TileMode="Tile"
+                  Stretch="None"
+                  DestinationRect="0 0 40 44" />
 
-         <StaticResource x:Key="ControlBorderRaisedTopColor" ResourceKey="ControlBorderLowColor" />
-         <StaticResource x:Key="ControlBorderRaisedBottomColor" ResourceKey="ControlBorderMidColor" />
+      <SolidColorBrush x:Key="DataGridItemBackgroundAlternating"
+                       Color="{DynamicResource ForegroundColor}" Opacity="0.04" />
 
-         <StaticResource x:Key="ControlBorderRecessedTopColor" ResourceKey="ControlBorderMidColor" />
-         <StaticResource x:Key="ControlBorderRecessedBottomColor" ResourceKey="ControlBorderLowColor" />
+      <StaticResource x:Key="ControlBorderRaisedTopColor" ResourceKey="ControlBorderLowColor" />
+      <StaticResource x:Key="ControlBorderRaisedBottomColor" ResourceKey="ControlBorderMidColor" />
 
-         <StaticResource x:Key="AccentButtonTopColor" ResourceKey="SystemAccentColorLight1" />
-         <StaticResource x:Key="AccentButtonBottomColor" ResourceKey="SystemAccentColor" />
+      <StaticResource x:Key="ControlBorderRecessedTopColor" ResourceKey="ControlBorderMidColor" />
+      <StaticResource x:Key="ControlBorderRecessedBottomColor" ResourceKey="ControlBorderLowColor" />
 
-         <SolidColorBrush x:Key="ControlBackgroundActiveHighBrush" Color="{DynamicResource ForegroundColor}"
-                          Opacity="0.05" />
+      <StaticResource x:Key="AccentButtonTopColor" ResourceKey="SystemAccentColorLight1" />
+      <StaticResource x:Key="AccentButtonBottomColor" ResourceKey="SystemAccentColor" />
 
-         <StaticResource x:Key="ControlBackgroundAccentRecessedTopColor" ResourceKey="SystemAccentColor" />
-         <StaticResource x:Key="ControlBackgroundAccentRecessedBottomColor" ResourceKey="SystemAccentColorDark1" />
+      <SolidColorBrush x:Key="ControlBackgroundActiveHighBrush" Color="{DynamicResource ForegroundColor}"
+                       Opacity="0.05" />
 
-         <StaticResource x:Key="ControlBorderAccentColor" ResourceKey="TransparentColor" />
+      <StaticResource x:Key="ControlBackgroundAccentRecessedTopColor" ResourceKey="SystemAccentColor" />
+      <StaticResource x:Key="ControlBackgroundAccentRecessedBottomColor" ResourceKey="SystemAccentColorDark1" />
 
-         <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="TransparentBrush" />
-         <Thickness x:Key="MenuFlyoutPresenterBorderThickness">0</Thickness>
+      <StaticResource x:Key="ControlBorderAccentColor" ResourceKey="TransparentColor" />
 
-         <StaticResource x:Key="SortIconForegroundBrush" ResourceKey="ForegroundLowBrush" />
+      <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="TransparentBrush" />
+      <Thickness x:Key="MenuFlyoutPresenterBorderThickness">0</Thickness>
 
-         <StaticResource x:Key="MenuItemForegroundBrush" ResourceKey="ForegroundHighBrush" />
+      <StaticResource x:Key="SortIconForegroundBrush" ResourceKey="ForegroundLowBrush" />
 
-         <StaticResource x:Key="TabStripVerticalBackgroundBrush" ResourceKey="LayoutBackgroundHighBrush" />
+      <StaticResource x:Key="MenuItemForegroundBrush" ResourceKey="ForegroundHighBrush" />
 
-         <SolidColorBrush x:Key='ComboBoxDropDownBorderBrush'>#bababa</SolidColorBrush>
-         <BoxShadows x:Key='ComboBoxBoxShadow'>0 0 0 1 #99bababa</BoxShadows>
-         <SolidColorBrush x:Key='EditableComboBoxItemHoverBackground'>#2355d8</SolidColorBrush>
-      </ResourceDictionary>
+      <StaticResource x:Key="TabStripVerticalBackgroundBrush" ResourceKey="LayoutBackgroundHighBrush" />
 
-      <ResourceDictionary x:Key="Dark">
-         <Color x:Key="BackgroundColor">#000000</Color>
-         <Color x:Key="ForegroundColor">#ffffff</Color>
+      <SolidColorBrush x:Key='ComboBoxDropDownBorderBrush'>#bababa</SolidColorBrush>
+      <BoxShadows x:Key='ComboBoxBoxShadow'>0 0 0 1 #99bababa</BoxShadows>
+      <SolidColorBrush x:Key='EditableComboBoxItemHoverBackground'>#2355d8</SolidColorBrush>
+    </ResourceDictionary>
 
-         <Color x:Key="AccentForegroundColor">#deecf9</Color>
-         <Color x:Key="ErrorTextColor">#ed7083</Color>
+    <ResourceDictionary x:Key="Dark">
+      <Color x:Key="BackgroundColor">#000000</Color>
+      <Color x:Key="ForegroundColor">#ffffff</Color>
 
-         <Color x:Key="ControlBackgroundHighColor">#595959</Color>
+      <Color x:Key="AccentForegroundColor">#deecf9</Color>
+      <Color x:Key="ErrorTextColor">#ed7083</Color>
 
-         <Color x:Key="ControlBorderHighColor">#4affffff</Color> <!-- 29% -->
-         <Color x:Key="ControlBorderMidColor">#33ffffff</Color> <!-- 20% -->
-         <Color x:Key="ControlBorderLowColor">#14ffffff</Color> <!-- 8% -->
+      <Color x:Key="ControlBackgroundHighColor">#595959</Color>
 
-         <Color x:Key="GridSplitterLineColor">#30ffffff</Color> <!-- 19% -->
-         <Color x:Key="SvgIconDisabledColor">#757575</Color>
-         <Color x:Key="ToolTipBackgroundColor">#2a2a2a</Color>
-         <Color x:Key="ToolTipBorderColor">#4a4a4a</Color>
+      <Color x:Key="ControlBorderHighColor">#4affffff</Color> <!-- 29% -->
+      <Color x:Key="ControlBorderMidColor">#33ffffff</Color> <!-- 20% -->
+      <Color x:Key="ControlBorderLowColor">#14ffffff</Color> <!-- 8% -->
 
-         <Color x:Key="TabControlBackgroundColor">#282828</Color>
-         <Color x:Key="PopupBackgroundColor">#262626</Color>
-         <Color x:Key="TextBoxBackgroundColor">#2c2c2c</Color>
-         <Color x:Key="TextBoxClearButtonBackgroundColor">#7F7F7F</Color>
-         <Color x:Key="ButtonSpinnerButtonPressedColor">#808080</Color>
+      <Color x:Key="GridSplitterLineColor">#30ffffff</Color> <!-- 19% -->
+      <Color x:Key="SvgIconDisabledColor">#757575</Color>
+      <Color x:Key="ToolTipBackgroundColor">#2a2a2a</Color>
+      <Color x:Key="ToolTipBorderColor">#4a4a4a</Color>
 
-         <Color x:Key="ScrollBarTrackColor">#2c2c2c</Color>
-         <Color x:Key="ScrollBarTrackBorderColor">#3f3f3f</Color>
+      <Color x:Key="TabControlBackgroundColor">#282828</Color>
+      <Color x:Key="PopupBackgroundColor">#262626</Color>
+      <Color x:Key="TextBoxBackgroundColor">#2c2c2c</Color>
+      <Color x:Key="TextBoxClearButtonBackgroundColor">#7F7F7F</Color>
+      <Color x:Key="ButtonSpinnerButtonPressedColor">#808080</Color>
 
-         <Color x:Key="DefaultIconColor">#b8b8b8</Color>
+      <Color x:Key="ScrollBarTrackColor">#2c2c2c</Color>
+      <Color x:Key="ScrollBarTrackBorderColor">#3f3f3f</Color>
 
-         <SolidColorBrush x:Key="BackgroundBrush" Color="#212121" />
+      <Color x:Key="DefaultIconColor">#b8b8b8</Color>
 
-         <SolidColorBrush x:Key="ForegroundHighMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.73" />
-         <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
-         <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.35" />
+      <SolidColorBrush x:Key="BackgroundBrush" Color="#212121" />
 
-         <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
-         <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
-         <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.09" />
+      <SolidColorBrush x:Key="ForegroundHighMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.73" />
+      <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
+      <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.35" />
 
-         <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
-         <SolidColorBrush x:Key="LayoutBorderMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
-         <SolidColorBrush x:Key="LayoutBorderLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
+      <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
+      <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
+      <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.09" />
 
-         <SolidColorBrush x:Key="ControlBackgroundDisabledHighBrush"
-                          Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
-         <BoxShadows x:Key="ControlBackgroundRecessedShadow">inset 0 5 3 -2 #ff0000</BoxShadows>
-         <BoxShadows x:Key="PopupShadow">0 0 1 0 #66000000, 0 0 1.5 00 #4d000000, 0 7 22 0 #40000000</BoxShadows>
+      <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
+      <SolidColorBrush x:Key="LayoutBorderMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
+      <SolidColorBrush x:Key="LayoutBorderLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
 
-         <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />
-         <SolidColorBrush x:Key="ScrollBarDisabledThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
-         <x:Double x:Key="ScrollBarThumbOpacity">0.6</x:Double>
+      <SolidColorBrush x:Key="ControlBackgroundDisabledHighBrush"
+                       Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
+      <BoxShadows x:Key="ControlBackgroundRecessedShadow">inset 0 5 3 -2 #ff0000</BoxShadows>
+      <BoxShadows x:Key="PopupShadow">0 0 1 0 #66000000, 0 0 1.5 00 #4d000000, 0 7 22 0 #40000000</BoxShadows>
 
-         <StaticResource x:Key="CheckBoxBackgroundBrush" ResourceKey="ControlBackgroundRecessedBrush" />
+      <SolidColorBrush x:Key="ScrollBarThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />
+      <SolidColorBrush x:Key="ScrollBarDisabledThumbBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
+      <x:Double x:Key="ScrollBarThumbOpacity">0.6</x:Double>
 
-         <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
-         <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
+      <StaticResource x:Key="CheckBoxBackgroundBrush" ResourceKey="ControlBackgroundRecessedBrush" />
 
-         <BoxShadows x:Key="TextBoxBorderShadows">0 1 1 0 #4dffffff</BoxShadows>
-         <BoxShadows x:Key="ControlBorderBoxShadow">0 0 Transparent</BoxShadows>
-         <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26ffffff, 0 0 0 0.5 #08ffffff</BoxShadows>
-         <BoxShadows x:Key="ToolTipBorderShadow">0 0 1 0 #ff000000</BoxShadows>
+      <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
+      <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
 
-         <Thickness x:Key="ButtonBorderThickness">0 1 0 0</Thickness>
-         <Thickness x:Key="ButtonBorderAccentThickness">0 1 0 0</Thickness>
-         <Thickness x:Key="ControlBorderThickness">0 0.6 0 0</Thickness>
-         <Thickness x:Key="TabControlBorderThickness">0 0.6 0 0.6</Thickness>
-         <Thickness x:Key="ToolTipBorderThickness">0.6</Thickness>
+      <BoxShadows x:Key="TextBoxBorderShadows">0 1 1 0 #4dffffff</BoxShadows>
+      <BoxShadows x:Key="ControlBorderBoxShadow">0 0 Transparent</BoxShadows>
+      <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26ffffff, 0 0 0 0.5 #08ffffff</BoxShadows>
+      <BoxShadows x:Key="ToolTipBorderShadow">0 0 1 0 #ff000000</BoxShadows>
 
-         <!-- DestinationRect Height must match TreeViewItem Height * 2 -->
-         <ImageBrush x:Key="StripedBackgroundBrush"
-                     Source="avares://Devolutions.AvaloniaTheme.MacOS/Accents/Assets/Alternating_Row_Background_Dark.png"
-                     TileMode="Tile"
-                     Stretch="None"
-                     DestinationRect="0 0 40 44" />
-         <SolidColorBrush x:Key="DataGridItemBackgroundAlternating"
-                          Color="{DynamicResource ForegroundColor}" Opacity="0.05" />
+      <Thickness x:Key="ButtonBorderThickness">0 1 0 0</Thickness>
+      <Thickness x:Key="ButtonBorderAccentThickness">0 1 0 0</Thickness>
+      <Thickness x:Key="ControlBorderThickness">0 0.6 0 0</Thickness>
+      <Thickness x:Key="TabControlBorderThickness">0 0.6 0 0.6</Thickness>
+      <Thickness x:Key="ToolTipBorderThickness">0.6</Thickness>
 
-         <StaticResource x:Key="ControlBorderRaisedTopColor" ResourceKey="ControlBorderMidColor" />
-         <StaticResource x:Key="ControlBorderRaisedBottomColor" ResourceKey="ControlBorderLowColor" />
+      <!-- DestinationRect Height must match TreeViewItem Height * 2 -->
+      <ImageBrush x:Key="StripedBackgroundBrush"
+                  Source="avares://Devolutions.AvaloniaTheme.MacOS/Accents/Assets/Alternating_Row_Background_Dark.png"
+                  TileMode="Tile"
+                  Stretch="None"
+                  DestinationRect="0 0 40 44" />
+      <SolidColorBrush x:Key="DataGridItemBackgroundAlternating"
+                       Color="{DynamicResource ForegroundColor}" Opacity="0.05" />
 
-         <StaticResource x:Key="ControlBorderRecessedTopColor" ResourceKey="ControlBorderLowColor" />
-         <StaticResource x:Key="ControlBorderRecessedBottomColor" ResourceKey="ControlBorderMidColor" />
+      <StaticResource x:Key="ControlBorderRaisedTopColor" ResourceKey="ControlBorderMidColor" />
+      <StaticResource x:Key="ControlBorderRaisedBottomColor" ResourceKey="ControlBorderLowColor" />
 
-         <StaticResource x:Key="AccentButtonTopColor" ResourceKey="SystemAccentColor" />
-         <StaticResource x:Key="AccentButtonBottomColor" ResourceKey="SystemAccentColorDark1" />
+      <StaticResource x:Key="ControlBorderRecessedTopColor" ResourceKey="ControlBorderLowColor" />
+      <StaticResource x:Key="ControlBorderRecessedBottomColor" ResourceKey="ControlBorderMidColor" />
 
-         <SolidColorBrush x:Key="ControlBackgroundActiveHighBrush" Color="{DynamicResource ForegroundColor}"
-                          Opacity="0.37" />
+      <StaticResource x:Key="AccentButtonTopColor" ResourceKey="SystemAccentColor" />
+      <StaticResource x:Key="AccentButtonBottomColor" ResourceKey="SystemAccentColorDark1" />
 
-         <StaticResource x:Key="ControlBackgroundAccentRecessedTopColor" ResourceKey="SystemAccentColorLight1" />
-         <StaticResource x:Key="ControlBackgroundAccentRecessedBottomColor" ResourceKey="SystemAccentColor" />
+      <SolidColorBrush x:Key="ControlBackgroundActiveHighBrush" Color="{DynamicResource ForegroundColor}"
+                       Opacity="0.37" />
 
-         <StaticResource x:Key="ControlBorderAccentColor" ResourceKey="SystemAccentColorLight1" />
+      <StaticResource x:Key="ControlBackgroundAccentRecessedTopColor" ResourceKey="SystemAccentColorLight1" />
+      <StaticResource x:Key="ControlBackgroundAccentRecessedBottomColor" ResourceKey="SystemAccentColor" />
 
-         <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="ControlBorderBrush" />
-         <Thickness x:Key="MenuFlyoutPresenterBorderThickness">1</Thickness>
+      <StaticResource x:Key="ControlBorderAccentColor" ResourceKey="SystemAccentColorLight1" />
 
-         <StaticResource x:Key="SortIconForegroundBrush" ResourceKey="ForegroundMidBrush" />
+      <StaticResource x:Key="MenuFlyoutPresenterBorderBrush" ResourceKey="ControlBorderBrush" />
+      <Thickness x:Key="MenuFlyoutPresenterBorderThickness">1</Thickness>
 
-         <StaticResource x:Key="MenuItemForegroundBrush" ResourceKey="ForegroundMidBrush" />
+      <StaticResource x:Key="SortIconForegroundBrush" ResourceKey="ForegroundMidBrush" />
 
-         <StaticResource x:Key="TabStripVerticalBackgroundBrush" ResourceKey="LayoutBackgroundLowBrush" />
+      <StaticResource x:Key="MenuItemForegroundBrush" ResourceKey="ForegroundMidBrush" />
 
-         <SolidColorBrush x:Key='ComboBoxDropDownBorderBrush'>#525250</SolidColorBrush>
-         <BoxShadows x:Key='ComboBoxBoxShadow'>0 0 0 1 #050505</BoxShadows>
-         <SolidColorBrush x:Key='EditableComboBoxItemHoverBackground'>#214ac6</SolidColorBrush>
-      </ResourceDictionary>
-   </ResourceDictionary.ThemeDictionaries>
+      <StaticResource x:Key="TabStripVerticalBackgroundBrush" ResourceKey="LayoutBackgroundLowBrush" />
 
+      <SolidColorBrush x:Key='ComboBoxDropDownBorderBrush'>#525250</SolidColorBrush>
+      <BoxShadows x:Key='ComboBoxBoxShadow'>0 0 0 1 #050505</BoxShadows>
+      <SolidColorBrush x:Key='EditableComboBoxItemHoverBackground'>#214ac6</SolidColorBrush>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
 
-   <!-- TODO: Appkit buttons have DD at the bottom, EE at the top & fading -> try sub-pixel rendering (UseLayoutRounding) (s. `default button issues.psd` ... -->
-   <FontFamily x:Key="MacOsThemeFontFamily">Inter, Helvetica Neue, Segoe UI, SF Pro, sans-serif</FontFamily>
 
-   <LinearGradientBrush x:Key="ControlBackgroundRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColor}" />
-      <GradientStop Offset="1" Color="{DynamicResource ControlBorderMidColor}" />
-   </LinearGradientBrush>
+  <!-- TODO: Appkit buttons have DD at the bottom, EE at the top & fading -> try sub-pixel rendering (UseLayoutRounding) (s. `default button issues.psd` ... -->
+  <FontFamily x:Key="MacOsThemeFontFamily">Inter, Helvetica Neue, Segoe UI, SF Pro, sans-serif</FontFamily>
 
-   <LinearGradientBrush x:Key="ControlBackgroundAccentRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource AccentButtonTopColor}" />
-      <GradientStop Offset="1" Color="{DynamicResource AccentButtonBottomColor}" />
-   </LinearGradientBrush>
-
-   <LinearGradientBrush x:Key="ButtonBackgroundAccentRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource ControlBackgroundAccentRecessedTopColor}" />
-      <GradientStop Offset="1" Color="{DynamicResource ControlBackgroundAccentRecessedBottomColor}" />
-   </LinearGradientBrush>
-
-   <LinearGradientBrush x:Key="ControlBorderRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource ControlBorderRaisedTopColor}" />
-      <GradientStop Offset="1" Color="{DynamicResource ControlBorderRaisedBottomColor}" />
-   </LinearGradientBrush>
-
-   <LinearGradientBrush x:Key="ControlBorderRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
-      <GradientStop Offset="0" Color="{DynamicResource ControlBorderRecessedTopColor}" />
-      <GradientStop Offset="1" Color="{DynamicResource ControlBorderRecessedBottomColor}" />
-   </LinearGradientBrush>
-
-   <CornerRadius x:Key="LayoutCornerRadius">5</CornerRadius>
-   <CornerRadius x:Key="ControlCornerRadius">5</CornerRadius>
-   <CornerRadius x:Key="SelectionCornerRadius">4</CornerRadius>
-
-   <Thickness x:Key="BorderThickness">1</Thickness>
-
-   <Thickness x:Key="InputControlsSpaceForFocusBorder">1.5</Thickness>
-   <Thickness x:Key="TabControlSpaceForFocusFactors">3</Thickness>
-
-   <x:Double x:Key="DefaultFontSize">13</x:Double>
-   <x:Double x:Key="ControlFontSize">13</x:Double>
-   <x:Double x:Key="PasswordHiddenFontSize">11</x:Double>
-
-   <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
-
-   <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.85" />
-   <!-- <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" /> -->
-   <SolidColorBrush x:Key="ForegroundMidLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.34" />
-   <!-- <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.25" /> -->
-
-   <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
-
-   <SolidColorBrush x:Key="SelectionInInactiveWindow" Color="{DynamicResource ForegroundColor}" Opacity="0.15" />
-
-   <SolidColorBrush x:Key="ControlForegroundAccentHighBrush" Color="{DynamicResource AccentForegroundColor}" />
-   <SolidColorBrush x:Key="ControlForegroundAccentInactiveHighBrush" Color="{DynamicResource ForegroundColor}"
-                    Opacity="0.85" />
-
-   <SolidColorBrush x:Key="ControlBackgroundHighBrush" Color="{DynamicResource ControlBackgroundHighColor}" />
-   <SolidColorBrush x:Key="ControlBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
-   <SolidColorBrush x:Key="ControlBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.9" />
-   <SolidColorBrush x:Key="ControlBackgroundAccentHighBrush" Color="{StaticResource SystemAccentColor}" />
-   <SolidColorBrush x:Key="ControlBackgroundAccentMidBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.63" />
-
-   <SolidColorBrush x:Key="ControlBorderAccentBrush" Color="{DynamicResource ControlBorderAccentColor}" />
-
-   <BoxShadows x:Key="ControlBackgroundRaisedShadow">2 2 3 -2 #bfbfbf</BoxShadows>
-
-   <SolidColorBrush x:Key="ControlBorderBrush" Color="{DynamicResource ControlBorderMidColor}" />
-   <SolidColorBrush x:Key="ControlBorderDisabledBrush" Color="{DynamicResource ControlBorderLowColor}" />
-
-   <SolidColorBrush x:Key="FocusBorderBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.5" />
-   <Thickness x:Key="FocusBorderThickness">3.5</Thickness>
-   <Thickness x:Key="FocusBorderMargin">-3</Thickness>
-
-   <SolidColorBrush x:Key="DefaultIconFillBrush" Color="{DynamicResource DefaultIconColor}" />
-
-   <!-- Button Resources (& button-like parts of other controls) -->
-   <Thickness x:Key="ButtonPadding">10 1.4 10 2.6</Thickness>
-   <FontWeight x:Key="ButtonFontWeight">400</FontWeight>
-   <SolidColorBrush x:Key="ButtonBorderAccentBrush" Color="{DynamicResource ControlBorderAccentColor}" />
-
-   <!-- TODO: To be replaced by templated button control (accent colour with hard-coded gradient overlay) -->
-   <VisualBrush x:Key="TempButtonAccentBackgroundPrecise" Stretch="Fill">
-      <VisualBrush.Visual>
-         <Panel>
-            <!-- <Rectangle Fill="{StaticResource SystemAccentColor}" Width="20" Height="20" /> // might not have access to Logical tree where resources are defined-->
-            <Rectangle Fill="#007aff" Width="20" Height="20" />
-            <Rectangle>
-               <Rectangle.Fill>
-                  <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-                     <GradientStop Offset="0" Color="white" />
-                     <GradientStop Offset="1" Color="Transparent" />
-                  </LinearGradientBrush>
-               </Rectangle.Fill>
-               <Rectangle.OpacityMask>
-                  <SolidColorBrush Color="White" Opacity="0.17" />
-               </Rectangle.OpacityMask>
-            </Rectangle>
-         </Panel>
-      </VisualBrush.Visual>
-   </VisualBrush>
-
-   <VisualBrush x:Key="TempButtonAccentPressedBackgroundPrecise" Stretch="Fill">
-      <VisualBrush.Visual>
-         <Panel>
-            <!-- <Rectangle Fill="{StaticResource ControlBackgroundAccentMidBrush}" Width="20" Height="20" /> -->
-            <Rectangle Fill="#005FC6" Width="20" Height="20" />
-            <Rectangle>
-               <Rectangle.Fill>
-                  <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
-                     <GradientStop Offset="0" Color="white" />
-                     <GradientStop Offset="1" Color="Transparent" />
-                  </LinearGradientBrush>
-               </Rectangle.Fill>
-               <Rectangle.OpacityMask>
-                  <SolidColorBrush Color="White" Opacity="0.17" />
-               </Rectangle.OpacityMask>
-            </Rectangle>
-         </Panel>
-      </VisualBrush.Visual>
-   </VisualBrush>
-
-   <!-- TabControl & TabItem Resources -->
-   <Thickness x:Key="TabItemPadding">8 2</Thickness>
-   <SolidColorBrush x:Key="TabControlBackgroundBrush" Color="{DynamicResource TabControlBackgroundColor}" />
-
-   <!-- CheckBox Resources -->
-   <CornerRadius x:Key="CheckBoxCornerRadius">3</CornerRadius>
-
-   <!-- ComboBox & ComboBoxItem Resources -->
-   <Thickness x:Key="ComboBoxItemMargin">2 0</Thickness>
-   <Thickness x:Key="ComboBoxItemPadding">5 3</Thickness>
-   <x:Int32 x:Key="ComboBoxItemHeight">22</x:Int32>
-   <Thickness x:Key="ComboBoxShadowMargin">4</Thickness>
-   <!-- InitialFirstItemDistance must match ComboBoxShadowMargin.bottom + PopupPadding.top -->
-   <x:Int32 x:Key="InitialFirstItemDistance">9</x:Int32>
-   <x:Int32 x:Key="PopupTrimHeight">30</x:Int32> <!-- includes Margin, Padding, Shadow -->
-   <x:Int32 x:Key="PopupSideMarginWidth">12</x:Int32> <!-- must match PopupMargin l/r values -->
-   <Thickness x:Key="PopupMargin">12 1 12 29</Thickness> <!-- to accommodate shadow -->
-   <Thickness x:Key="PopupPadding">3 5</Thickness>
-   <SolidColorBrush x:Key="PopupBackgroundBrush" Color="{DynamicResource PopupBackgroundColor}" />
-
-   <!-- TextBox Resources -->
-   <SolidColorBrush x:Key="TextBoxClearButtonBackgroundBrush"
-                    Color="{DynamicResource TextBoxClearButtonBackgroundColor}" />
-   <SolidColorBrush x:Key="TextBoxSelectionHighlightBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.3" />
-   <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="{DynamicResource TextBoxBackgroundColor}" />
-   <SolidColorBrush x:Key="TextBoxBackgroundDisabledHighBrush"
-                    Color="{DynamicResource BackgroundColor}" Opacity="0.5" />
-
-   <!-- TreeView Resources -->
-   <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SystemAccentColor}" />
-   <SolidColorBrush x:Key="TreeViewItemForegroundSelected" Color="{DynamicResource AccentForegroundColor}" />
-   <x:Double x:Key="TreeViewItemChevronSize">8</x:Double>
-   <x:Double x:Key="TreeViewItemIndent">13</x:Double>
-   <Thickness x:Key="TreeViewItemChevronMargin">4, 0, 5, 0</Thickness>
-
-   <!-- DataGrid Resources -->
-   <SolidColorBrush x:Key="DataGridItemBackgroundSelected" Color="{StaticResource SystemAccentColor}" />
-   <SolidColorBrush x:Key="DataGridForegroundSelectedBrush" Color="{DynamicResource AccentForegroundColor}" />
-   <x:Double x:Key="DataGridColumnHeaderFontSize">11</x:Double>
-   <x:Double x:Key="DataGridSortChevronSize">7</x:Double>
-
-   <!-- Menu & MenuItem Resources -->
-   <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource PopupBackgroundColor}" />
-   <x:Double x:Key="MenuFlyoutSubItemPopupHorizontalOffset">-14</x:Double>
-   <x:Double x:Key="MenuFlyoutSubItemPopupVerticalOffset">-7</x:Double>
-   <x:Double x:Key="MenuPopupHorizontalOffset">-12</x:Double>
-   <x:Double x:Key="MenuPopupVerticalOffset">6</x:Double>
-   <x:Double x:Key="MenuToolBarPopupVerticalOffset">-10</x:Double>
-   <x:Double x:Key="MenuPopupAboveVerticalOffset">-5</x:Double>
-   <Thickness x:Key="MenuPopupAboveMargin">12 1 12 2</Thickness>
-   <Thickness x:Key="MenuBarPadding">6</Thickness>
-   <Thickness x:Key="MenuFlyoutPadding">5 2 5 2</Thickness>
-   <Thickness x:Key="MenuFlyoutSeparatorThemePadding">8,5,8,5</Thickness>
-   <Thickness x:Key="MenuIconPresenterMargin">0,0,4,0</Thickness>
-   <Thickness x:Key="MenuInputGestureTextMargin">24,0,0,0</Thickness>
-   <Thickness x:Key="MenuItemPadding">9 4 7 2</Thickness>
-   <Thickness x:Key="MenuToolBarItemPadding">4 0 4 4</Thickness>
-   <Thickness x:Key="MenuToolBarItemIconPadding">10 5 8 5</Thickness>
-   <Thickness x:Key="MenuToolBarItemActiveBackgroundMargin">-10 -3 -8 -3</Thickness>
-   <Thickness x:Key="MenuItemActiveBackgroundMargin">-6,-2,-7,-2</Thickness>
-   <Thickness x:Key="MenuItemIconPadding">0</Thickness>
-   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
-   <SolidColorBrush x:Key="SvgIconDisabledColorBrush" Color="{DynamicResource SvgIconDisabledColor}" />
-   <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
-   <x:Double x:Key="MenuHeaderFontSizeSmall">10</x:Double>
-
-   <!-- ScrollBar Resources -->
-   <x:Double x:Key="ScrollBarThumbWidth">6</x:Double>
-   <x:Double x:Key="ScrollBarExpandedStaticThumbWidth">8</x:Double>
-   <x:Double x:Key="ScrollBarExpandedThumbWidth">9</x:Double>
-   <x:Double x:Key="ScrollBarMinLength">10</x:Double>
-   <SolidColorBrush x:Key="ScrollBarTrackBrush" Color="{DynamicResource ScrollBarTrackColor}" />
-   <SolidColorBrush x:Key="ScrollBarTrackBorderBrush" Color="{DynamicResource ScrollBarTrackBorderColor}" />
-   <Thickness x:Key="ScrollBarTrackBorderThickness">1</Thickness>
-   <Thickness x:Key="ScrollBarSeparatorBorderFactors">0 0 1 1</Thickness>
-   <Thickness x:Key="ScrollBarTrackHorizontalBorderFactors">0 1 0 1</Thickness>
-   <Thickness x:Key="ScrollBarTrackVerticalBorderFactors">1 0 1 0</Thickness>
-
-   <!-- ToolTip Resources -->
-   <x:Double x:Key="ToolTipContentMaxWidth">320</x:Double>
-   <CornerRadius x:Key="ToolTipCornerRadius">0 0 1 0</CornerRadius>
-   <Thickness x:Key="ToolTipPadding">5 2 4 2</Thickness>
-   <x:Double x:Key="ToolTipFontSize">11</x:Double>
-
-   <!-- ButtonSpinner Resources -->
-   <SolidColorBrush x:Key="ButtonSpinnerButtonPressedBrush" Color="{DynamicResource ButtonSpinnerButtonPressedColor}" />
-
-
-   <!-- DEVELOPMENT ONLY -->
-   <!-- <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.13" /> -->
-
-   <SolidColorBrush x:Key="TestGreen" Color="Green" Opacity="0.84" />
-   <SolidColorBrush x:Key="TestRed" Color="Red" />
-   <SolidColorBrush x:Key="TestBlue" Color="Blue" />
-   <SolidColorBrush x:Key="TestYellow" Color="Yellow" />
+  <LinearGradientBrush x:Key="ControlBackgroundRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource ControlBorderLowColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlBorderMidColor}" />
+  </LinearGradientBrush>
+
+  <LinearGradientBrush x:Key="ControlBackgroundAccentRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource AccentButtonTopColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource AccentButtonBottomColor}" />
+  </LinearGradientBrush>
+
+  <LinearGradientBrush x:Key="ButtonBackgroundAccentRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource ControlBackgroundAccentRecessedTopColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlBackgroundAccentRecessedBottomColor}" />
+  </LinearGradientBrush>
+
+  <LinearGradientBrush x:Key="ControlBorderRaisedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource ControlBorderRaisedTopColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlBorderRaisedBottomColor}" />
+  </LinearGradientBrush>
+
+  <LinearGradientBrush x:Key="ControlBorderRecessedBrush" StartPoint="0%,0%" EndPoint="0%,100%">
+    <GradientStop Offset="0" Color="{DynamicResource ControlBorderRecessedTopColor}" />
+    <GradientStop Offset="1" Color="{DynamicResource ControlBorderRecessedBottomColor}" />
+  </LinearGradientBrush>
+
+  <CornerRadius x:Key="LayoutCornerRadius">5</CornerRadius>
+  <CornerRadius x:Key="ControlCornerRadius">5</CornerRadius>
+  <CornerRadius x:Key="SelectionCornerRadius">4</CornerRadius>
+
+  <Thickness x:Key="BorderThickness">1</Thickness>
+
+  <Thickness x:Key="InputControlsSpaceForFocusBorder">1.5</Thickness>
+  <Thickness x:Key="TabControlSpaceForFocusFactors">3</Thickness>
+
+  <x:Double x:Key="DefaultFontSize">13</x:Double>
+  <x:Double x:Key="ControlFontSize">13</x:Double>
+  <x:Double x:Key="PasswordHiddenFontSize">11</x:Double>
+
+  <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
+
+  <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.85" />
+  <!-- <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" /> -->
+  <SolidColorBrush x:Key="ForegroundMidLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.34" />
+  <!-- <SolidColorBrush x:Key="ForegroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.25" /> -->
+
+  <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />
+
+  <SolidColorBrush x:Key="SelectionInInactiveWindow" Color="{DynamicResource ForegroundColor}" Opacity="0.15" />
+
+  <SolidColorBrush x:Key="ControlForegroundAccentHighBrush" Color="{DynamicResource AccentForegroundColor}" />
+  <SolidColorBrush x:Key="ControlForegroundAccentInactiveHighBrush" Color="{DynamicResource ForegroundColor}"
+                   Opacity="0.85" />
+
+  <SolidColorBrush x:Key="ControlBackgroundHighBrush" Color="{DynamicResource ControlBackgroundHighColor}" />
+  <SolidColorBrush x:Key="ControlBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
+  <SolidColorBrush x:Key="ControlBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.9" />
+  <SolidColorBrush x:Key="ControlBackgroundAccentHighBrush" Color="{StaticResource SystemAccentColor}" />
+  <SolidColorBrush x:Key="ControlBackgroundAccentMidBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.63" />
+
+  <SolidColorBrush x:Key="ControlBorderAccentBrush" Color="{DynamicResource ControlBorderAccentColor}" />
+
+  <BoxShadows x:Key="ControlBackgroundRaisedShadow">2 2 3 -2 #bfbfbf</BoxShadows>
+
+  <SolidColorBrush x:Key="ControlBorderBrush" Color="{DynamicResource ControlBorderMidColor}" />
+  <SolidColorBrush x:Key="ControlBorderDisabledBrush" Color="{DynamicResource ControlBorderLowColor}" />
+
+  <SolidColorBrush x:Key="FocusBorderBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.5" />
+  <Thickness x:Key="FocusBorderThickness">3.5</Thickness>
+  <Thickness x:Key="FocusBorderMargin">-3</Thickness>
+
+  <SolidColorBrush x:Key="DefaultIconFillBrush" Color="{DynamicResource DefaultIconColor}" />
+
+  <!-- Button Resources (& button-like parts of other controls) -->
+  <Thickness x:Key="ButtonPadding">10 1.4 10 2.6</Thickness>
+  <FontWeight x:Key="ButtonFontWeight">400</FontWeight>
+  <SolidColorBrush x:Key="ButtonBorderAccentBrush" Color="{DynamicResource ControlBorderAccentColor}" />
+
+  <!-- TODO: To be replaced by templated button control (accent colour with hard-coded gradient overlay) -->
+  <VisualBrush x:Key="TempButtonAccentBackgroundPrecise" Stretch="Fill">
+    <VisualBrush.Visual>
+      <Panel>
+        <!-- <Rectangle Fill="{StaticResource SystemAccentColor}" Width="20" Height="20" /> // might not have access to Logical tree where resources are defined-->
+        <Rectangle Fill="#007aff" Width="20" Height="20" />
+        <Rectangle>
+          <Rectangle.Fill>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+              <GradientStop Offset="0" Color="white" />
+              <GradientStop Offset="1" Color="Transparent" />
+            </LinearGradientBrush>
+          </Rectangle.Fill>
+          <Rectangle.OpacityMask>
+            <SolidColorBrush Color="White" Opacity="0.17" />
+          </Rectangle.OpacityMask>
+        </Rectangle>
+      </Panel>
+    </VisualBrush.Visual>
+  </VisualBrush>
+
+  <VisualBrush x:Key="TempButtonAccentPressedBackgroundPrecise" Stretch="Fill">
+    <VisualBrush.Visual>
+      <Panel>
+        <!-- <Rectangle Fill="{StaticResource ControlBackgroundAccentMidBrush}" Width="20" Height="20" /> -->
+        <Rectangle Fill="#005FC6" Width="20" Height="20" />
+        <Rectangle>
+          <Rectangle.Fill>
+            <LinearGradientBrush StartPoint="0%,0%" EndPoint="0%,100%">
+              <GradientStop Offset="0" Color="white" />
+              <GradientStop Offset="1" Color="Transparent" />
+            </LinearGradientBrush>
+          </Rectangle.Fill>
+          <Rectangle.OpacityMask>
+            <SolidColorBrush Color="White" Opacity="0.17" />
+          </Rectangle.OpacityMask>
+        </Rectangle>
+      </Panel>
+    </VisualBrush.Visual>
+  </VisualBrush>
+
+  <!-- TabControl & TabItem Resources -->
+  <Thickness x:Key="TabItemPadding">8 2</Thickness>
+  <SolidColorBrush x:Key="TabControlBackgroundBrush" Color="{DynamicResource TabControlBackgroundColor}" />
+
+  <!-- CheckBox Resources -->
+  <CornerRadius x:Key="CheckBoxCornerRadius">3</CornerRadius>
+
+  <!-- ComboBox & ComboBoxItem Resources -->
+  <Thickness x:Key="ComboBoxItemMargin">2 0</Thickness>
+  <Thickness x:Key="ComboBoxItemPadding">5 3</Thickness>
+  <x:Int32 x:Key="ComboBoxItemHeight">22</x:Int32>
+  <Thickness x:Key="ComboBoxShadowMargin">4</Thickness>
+  <!-- InitialFirstItemDistance must match ComboBoxShadowMargin.bottom + PopupPadding.top -->
+  <x:Int32 x:Key="InitialFirstItemDistance">9</x:Int32>
+  <x:Int32 x:Key="PopupTrimHeight">30</x:Int32> <!-- includes Margin, Padding, Shadow -->
+  <x:Int32 x:Key="PopupSideMarginWidth">12</x:Int32> <!-- must match PopupMargin l/r values -->
+  <Thickness x:Key="PopupMargin">12 1 12 29</Thickness> <!-- to accommodate shadow -->
+  <Thickness x:Key="PopupPadding">3 5</Thickness>
+  <SolidColorBrush x:Key="PopupBackgroundBrush" Color="{DynamicResource PopupBackgroundColor}" />
+
+  <!-- TextBox Resources -->
+  <SolidColorBrush x:Key="TextBoxClearButtonBackgroundBrush"
+                   Color="{DynamicResource TextBoxClearButtonBackgroundColor}" />
+  <SolidColorBrush x:Key="TextBoxSelectionHighlightBrush" Color="{StaticResource SystemAccentColor}" Opacity="0.3" />
+  <SolidColorBrush x:Key="TextBoxBackgroundBrush" Color="{DynamicResource TextBoxBackgroundColor}" />
+  <SolidColorBrush x:Key="TextBoxBackgroundDisabledHighBrush"
+                   Color="{DynamicResource BackgroundColor}" Opacity="0.5" />
+
+  <!-- TreeView Resources -->
+  <SolidColorBrush x:Key="TreeViewItemBackgroundSelected" Color="{StaticResource SystemAccentColor}" />
+  <SolidColorBrush x:Key="TreeViewItemForegroundSelected" Color="{DynamicResource AccentForegroundColor}" />
+  <x:Double x:Key="TreeViewItemChevronSize">8</x:Double>
+  <x:Double x:Key="TreeViewItemIndent">13</x:Double>
+  <Thickness x:Key="TreeViewItemChevronMargin">4, 0, 5, 0</Thickness>
+
+  <!-- DataGrid Resources -->
+  <SolidColorBrush x:Key="DataGridItemBackgroundSelected" Color="{StaticResource SystemAccentColor}" />
+  <SolidColorBrush x:Key="DataGridForegroundSelectedBrush" Color="{DynamicResource AccentForegroundColor}" />
+  <x:Double x:Key="DataGridColumnHeaderFontSize">11</x:Double>
+  <x:Double x:Key="DataGridSortChevronSize">7</x:Double>
+
+  <!-- Menu & MenuItem Resources -->
+  <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource PopupBackgroundColor}" />
+  <x:Double x:Key="MenuFlyoutSubItemPopupHorizontalOffset">-14</x:Double>
+  <x:Double x:Key="MenuFlyoutSubItemPopupVerticalOffset">-7</x:Double>
+  <x:Double x:Key="MenuPopupHorizontalOffset">-12</x:Double>
+  <x:Double x:Key="MenuPopupVerticalOffset">6</x:Double>
+  <x:Double x:Key="MenuToolBarPopupVerticalOffset">-10</x:Double>
+  <x:Double x:Key="MenuPopupAboveVerticalOffset">-5</x:Double>
+  <Thickness x:Key="MenuPopupAboveMargin">12 1 12 2</Thickness>
+  <Thickness x:Key="MenuBarPadding">6</Thickness>
+  <Thickness x:Key="MenuFlyoutPadding">5 2 5 2</Thickness>
+  <Thickness x:Key="MenuFlyoutSeparatorThemePadding">8,5,8,5</Thickness>
+  <Thickness x:Key="MenuIconPresenterMargin">0,0,4,0</Thickness>
+  <Thickness x:Key="MenuInputGestureTextMargin">24,0,0,0</Thickness>
+  <Thickness x:Key="MenuItemPadding">9 4 7 2</Thickness>
+  <Thickness x:Key="MenuToolBarItemPadding">4 0 4 4</Thickness>
+  <Thickness x:Key="MenuToolBarItemIconPadding">10 5 8 5</Thickness>
+  <Thickness x:Key="MenuToolBarItemActiveBackgroundMargin">-10 -3 -8 -3</Thickness>
+  <Thickness x:Key="MenuItemActiveBackgroundMargin">-6,-2,-7,-2</Thickness>
+  <Thickness x:Key="MenuItemIconPadding">0</Thickness>
+  <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
+  <SolidColorBrush x:Key="SvgIconDisabledColorBrush" Color="{DynamicResource SvgIconDisabledColor}" />
+  <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>
+  <x:Double x:Key="MenuHeaderFontSizeSmall">10</x:Double>
+
+  <!-- ScrollBar Resources -->
+  <x:Double x:Key="ScrollBarThumbWidth">6</x:Double>
+  <x:Double x:Key="ScrollBarExpandedStaticThumbWidth">8</x:Double>
+  <x:Double x:Key="ScrollBarExpandedThumbWidth">9</x:Double>
+  <x:Double x:Key="ScrollBarMinLength">10</x:Double>
+  <SolidColorBrush x:Key="ScrollBarTrackBrush" Color="{DynamicResource ScrollBarTrackColor}" />
+  <SolidColorBrush x:Key="ScrollBarTrackBorderBrush" Color="{DynamicResource ScrollBarTrackBorderColor}" />
+  <Thickness x:Key="ScrollBarTrackBorderThickness">1</Thickness>
+  <Thickness x:Key="ScrollBarSeparatorBorderFactors">0 0 1 1</Thickness>
+  <Thickness x:Key="ScrollBarTrackHorizontalBorderFactors">0 1 0 1</Thickness>
+  <Thickness x:Key="ScrollBarTrackVerticalBorderFactors">1 0 1 0</Thickness>
+
+  <!-- ToolTip Resources -->
+  <x:Double x:Key="ToolTipContentMaxWidth">320</x:Double>
+  <CornerRadius x:Key="ToolTipCornerRadius">0 0 1 0</CornerRadius>
+  <Thickness x:Key="ToolTipPadding">5 2 4 2</Thickness>
+  <x:Double x:Key="ToolTipFontSize">11</x:Double>
+
+  <!-- ButtonSpinner Resources -->
+  <SolidColorBrush x:Key="ButtonSpinnerButtonPressedBrush" Color="{DynamicResource ButtonSpinnerButtonPressedColor}" />
+
+
+  <!-- DEVELOPMENT ONLY -->
+  <!-- <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.13" /> -->
+
+  <SolidColorBrush x:Key="TestGreen" Color="Green" Opacity="0.84" />
+  <SolidColorBrush x:Key="TestRed" Color="Red" />
+  <SolidColorBrush x:Key="TestBlue" Color="Blue" />
+  <SolidColorBrush x:Key="TestYellow" Color="Yellow" />
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -1,103 +1,103 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <StackPanel Width="110">
-         <Button Content="Cancel" Margin="10" />
-         <Button Content="Test" Margin="10 " IsEnabled="False" />
-         <Button Classes="accent" Content="Open" Margin="10 " />
-         <Button Classes="accent" Content="Open" Margin="10 " IsEnabled="False" />
-      </StackPanel>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <StackPanel Width="110">
+      <Button Content="Cancel" Margin="10" />
+      <Button Content="Test" Margin="10 " IsEnabled="False" />
+      <Button Classes="accent" Content="Open" Margin="10 " />
+      <Button Classes="accent" Content="Open" Margin="10 " IsEnabled="False" />
+    </StackPanel>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type Button}" TargetType="Button">
-      <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThickness}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
-      <Setter Property="HorizontalContentAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="FontWeight" Value="{DynamicResource ButtonFontWeight}" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Panel Name="ReservedSpaceForFocus"
-                   Margin="{StaticResource InputControlsSpaceForFocusBorder}">
-               <Border Name="BackgroundElement"
-                       Background="{TemplateBinding Background}"
-                       BorderBrush="{TemplateBinding BorderBrush}"
-                       BorderThickness="{TemplateBinding BorderThickness}"
-                       CornerRadius="{TemplateBinding CornerRadius}" />
-               <ContentPresenter Name="PART_ContentPresenter"
-                                 Content="{TemplateBinding Content}"
-                                 Foreground="{TemplateBinding Foreground}"
-                                 Padding="{TemplateBinding Padding}"
-                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                 FontSize="{TemplateBinding FontSize}"
-                                 FontWeight="{TemplateBinding FontWeight}" />
-               <Border Name="FocusBorderElement"
-                       Margin="{StaticResource FocusBorderMargin}"
-                       BorderThickness="{StaticResource FocusBorderThickness}"
-                       CornerRadius="7" />
-            </Panel>
-         </ControlTemplate>
-      </Setter>
+  <ControlTheme x:Key="{x:Type Button}" TargetType="Button">
+    <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThickness}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
+    <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource ButtonFontWeight}" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel Name="ReservedSpaceForFocus"
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <Border Name="BackgroundElement"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding CornerRadius}" />
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Content="{TemplateBinding Content}"
+                            Foreground="{TemplateBinding Foreground}"
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            FontSize="{TemplateBinding FontSize}"
+                            FontWeight="{TemplateBinding FontWeight}" />
+          <Border Name="FocusBorderElement"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  CornerRadius="7" />
+        </Panel>
+      </ControlTemplate>
+    </Setter>
 
-      <!-- Tabbing focus -->
-      <Style Selector="^:focus-visible">
-         <Style Selector="^ /template/ Border#FocusBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
-         </Style>
+    <!-- Tabbing focus -->
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
       </Style>
+    </Style>
+
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundActiveHighBrush}" />
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderDisabledBrush}" />
+    </Style>
+
+    <Style Selector="^.accent">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
+      <Setter Property="Foreground" Value="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ForegroundHighBrush}" />
+      <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ButtonBorderAccentBrush, ControlBorderRaisedBrush}" />
 
       <Style Selector="^:pressed">
-         <Setter Property="Background" Value="{DynamicResource ControlBackgroundActiveHighBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundAccentRecessedBrush}" />
       </Style>
       <Style Selector="^:disabled">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-         <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderDisabledBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThickness}" />
       </Style>
+    </Style>
 
-      <Style Selector="^.accent">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
-         <Setter Property="Foreground" Value="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ForegroundHighBrush}" />
-         <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ButtonBorderAccentBrush, ControlBorderRaisedBrush}" />
-
-         <Style Selector="^:pressed">
-            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundAccentRecessedBrush}" />
-         </Style>
-         <Style Selector="^:disabled">
-            <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-            <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
-            <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThickness}" />
-         </Style>
+    <Style Selector="^.accentPrecise">
+      <Setter Property="Background" Value="{DynamicResource TempButtonAccentBackgroundPrecise}" />
+      <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Style Selector="^:pressed">
+        <Setter Property="Background" Value="{DynamicResource TempButtonAccentPressedBackgroundPrecise}" />
       </Style>
-
-      <Style Selector="^.accentPrecise">
-         <Setter Property="Background" Value="{DynamicResource TempButtonAccentBackgroundPrecise}" />
-         <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
-         <Setter Property="BorderThickness" Value="0" />
-         <Style Selector="^:pressed">
-            <Setter Property="Background" Value="{DynamicResource TempButtonAccentPressedBackgroundPrecise}" />
-         </Style>
-         <Style Selector="^:disabled">
-            <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-            <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
-            <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
-         </Style>
+      <Style Selector="^:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
+        <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
       </Style>
-   </ControlTheme>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -1,166 +1,166 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <ThemeVariantScope RequestedThemeVariant="Dark">
-         <StackPanel>
-            <Border Background="#212121">
-               <Border Background="{DynamicResource LayoutBackgroundLowBrush}" Margin="5">
-                  <StackPanel Margin="10">
-                     <CheckBox IsChecked="True">Emulate 3 buttons</CheckBox>
-                     <CheckBox IsChecked="False">Swap mouse bu</CheckBox>
-                     <CheckBox IsChecked="True" IsEnabled="False">Auto scale with</CheckBox>
-                     <CheckBox IsEnabled="False">Unchecked disabled </CheckBox>
-                     <CheckBox IsThreeState="True" IsChecked="{x:Null}">Unknown by default</CheckBox>
-                     <CheckBox IsThreeState="True" IsChecked="{x:Null}" IsEnabled="False">
-                        Indeterminate
-                     </CheckBox>
-                     <CheckBox Width="120">Checkbox should wrap its text</CheckBox>
-                  </StackPanel>
-               </Border>
+  <Design.PreviewWith>
+    <ThemeVariantScope RequestedThemeVariant="Dark">
+      <StackPanel>
+        <Border Background="#212121">
+          <Border Background="{DynamicResource LayoutBackgroundLowBrush}" Margin="5">
+            <StackPanel Margin="10">
+              <CheckBox IsChecked="True">Emulate 3 buttons</CheckBox>
+              <CheckBox IsChecked="False">Swap mouse bu</CheckBox>
+              <CheckBox IsChecked="True" IsEnabled="False">Auto scale with</CheckBox>
+              <CheckBox IsEnabled="False">Unchecked disabled </CheckBox>
+              <CheckBox IsThreeState="True" IsChecked="{x:Null}">Unknown by default</CheckBox>
+              <CheckBox IsThreeState="True" IsChecked="{x:Null}" IsEnabled="False">
+                Indeterminate
+              </CheckBox>
+              <CheckBox Width="120">Checkbox should wrap its text</CheckBox>
+            </StackPanel>
+          </Border>
+        </Border>
+      </StackPanel>
+    </ThemeVariantScope>
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type CheckBox}" TargetType="CheckBox">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
+    <Setter Property="Padding" Value="6 0 0 0" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="HorizontalAlignment" Value="Left" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="CornerRadius" Value="{DynamicResource CheckBoxCornerRadius}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontStretch" Value="Condensed" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel Name="ReservedSpaceForFocus"
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <Grid ColumnDefinitions="Auto,*" MinHeight="20" ClipToBounds="False">
+            <Border
+              Name="FocusBorderElement"
+              VerticalAlignment="Center"
+              Margin="{StaticResource FocusBorderMargin}"
+              BorderThickness="{StaticResource FocusBorderThickness}"
+              CornerRadius="5">
+              <Border
+                Name="border"
+                Width="14"
+                Height="14"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                BoxShadow="{DynamicResource ControlBackgroundRecessedShadow}">
+                <Panel>
+                  <Path
+                    Name="CheckMark"
+                    Width="9"
+                    Height="9"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Data="{DynamicResource CheckMarkPath}"
+                    FlowDirection="LeftToRight"
+                    Stretch="Fill"
+                    Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
+
+                  <Rectangle
+                    Name="IndeterminateMark"
+                    Width="8"
+                    Height="2"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Stretch="Uniform"
+                    Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
+                </Panel>
+              </Border>
             </Border>
-         </StackPanel>
-      </ThemeVariantScope>
-   </Design.PreviewWith>
-
-   <ControlTheme x:Key="{x:Type CheckBox}" TargetType="CheckBox">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource CheckBoxBackgroundBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
-      <Setter Property="Padding" Value="6 0 0 0" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Left" />
-      <Setter Property="HorizontalContentAlignment" Value="Left" />
-      <Setter Property="CornerRadius" Value="{DynamicResource CheckBoxCornerRadius}" />
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="FontStretch" Value="Condensed" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Panel Name="ReservedSpaceForFocus"
-                   Margin="{StaticResource InputControlsSpaceForFocusBorder}">
-               <Grid ColumnDefinitions="Auto,*" MinHeight="20" ClipToBounds="False">
-                  <Border
-                     Name="FocusBorderElement"
-                     VerticalAlignment="Center"
-                     Margin="{StaticResource FocusBorderMargin}"
-                     BorderThickness="{StaticResource FocusBorderThickness}"
-                     CornerRadius="5">
-                     <Border
-                        Name="border"
-                        Width="14"
-                        Height="14"
-                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                        Background="{TemplateBinding Background}"
-                        BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        CornerRadius="{TemplateBinding CornerRadius}"
-                        BoxShadow="{DynamicResource ControlBackgroundRecessedShadow}">
-                        <Panel>
-                           <Path
-                              Name="CheckMark"
-                              Width="9"
-                              Height="9"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Data="{DynamicResource CheckMarkPath}"
-                              FlowDirection="LeftToRight"
-                              Stretch="Fill"
-                              Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
-
-                           <Rectangle
-                              Name="IndeterminateMark"
-                              Width="8"
-                              Height="2"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Stretch="Uniform"
-                              Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
-                        </Panel>
-                     </Border>
-                  </Border>
-                  <ContentPresenter
-                     Name="PART_ContentPresenter"
-                     Grid.Column="1"
-                     Margin="{TemplateBinding Padding}"
-                     HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                     VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                     Content="{TemplateBinding Content}"
-                     ContentTemplate="{TemplateBinding ContentTemplate}"
-                     IsVisible="{TemplateBinding Content, Converter={x:Static ObjectConverters.IsNotNull}}"
-                     RecognizesAccessKey="True"
-                     TextWrapping="Wrap"
-                     TextElement.Foreground="{TemplateBinding Foreground}" />
-               </Grid>
-            </Panel>
-         </ControlTemplate>
-      </Setter><!-- Tabbing focus -->
-      <Style Selector="^:focus-visible">
-         <Style Selector="^ /template/ Border#FocusBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
-         </Style>
+            <ContentPresenter
+              Name="PART_ContentPresenter"
+              Grid.Column="1"
+              Margin="{TemplateBinding Padding}"
+              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+              Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              IsVisible="{TemplateBinding Content, Converter={x:Static ObjectConverters.IsNotNull}}"
+              RecognizesAccessKey="True"
+              TextWrapping="Wrap"
+              TextElement.Foreground="{TemplateBinding Foreground}" />
+          </Grid>
+        </Panel>
+      </ControlTemplate>
+    </Setter><!-- Tabbing focus -->
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
       </Style>
-      <Style Selector="^ /template/ Path#CheckMark">
-         <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ Path#CheckMark">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^ /template/ Rectangle#IndeterminateMark">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:checked">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
+      <Style Selector="^/template/ Border#border">
+        <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
+        <Setter Property="BoxShadow" Value="0 0 Transparent" /> <!-- TODO: How do you set it to None? -->
       </Style>
-      <Style Selector="^ /template/ Rectangle#IndeterminateMark">
-         <Setter Property="IsVisible" Value="False" />
+      <Style Selector="^/template/ Path#CheckMark">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+    </Style>
+    <Style Selector="^:indeterminate">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
+      <Style Selector="^/template/ Border#border">
+        <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
+        <Setter Property="BoxShadow" Value="0 0 Transparent" /> <!-- TODO: How do you set it to None? -->
+      </Style>
+      <Style Selector="^/template/ Rectangle#IndeterminateMark">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+    </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
+      <Style Selector="^/template/ Border#border">
+        <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderDisabledBrush}" />
+      </Style>
+      <Style Selector="^/template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
       </Style>
       <Style Selector="^:checked">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
-         <Style Selector="^/template/ Border#border">
-            <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
-            <Setter Property="BoxShadow" Value="0 0 Transparent" /> <!-- TODO: How do you set it to None? -->
-         </Style>
-         <Style Selector="^/template/ Path#CheckMark">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
+        <Style Selector="^/template/ Border#border">
+          <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
+          <Setter Property="BoxShadow" Value="{DynamicResource ControlBackgroundRecessedShadow}" />
+        </Style>
+        <Style Selector="^/template/ Path#CheckMark">
+          <Setter Property="IsVisible" Value="True" />
+          <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+        </Style>
       </Style>
       <Style Selector="^:indeterminate">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
-         <Style Selector="^/template/ Border#border">
-            <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
-            <Setter Property="BoxShadow" Value="0 0 Transparent" /> <!-- TODO: How do you set it to None? -->
-         </Style>
-         <Style Selector="^/template/ Rectangle#IndeterminateMark">
-            <Setter Property="IsVisible" Value="True" />
-         </Style>
+        <Style Selector="^/template/ Border#border">
+          <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
+        </Style>
+        <Style Selector="^/template/ Rectangle#IndeterminateMark">
+          <Setter Property="IsVisible" Value="True" />
+          <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+        </Style>
       </Style>
-      <Style Selector="^:disabled">
-         <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
-         <Style Selector="^/template/ Border#border">
-            <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderDisabledBrush}" />
-         </Style>
-         <Style Selector="^/template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-         </Style>
-         <Style Selector="^:checked">
-            <Style Selector="^/template/ Border#border">
-               <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
-               <Setter Property="BoxShadow" Value="{DynamicResource ControlBackgroundRecessedShadow}" />
-            </Style>
-            <Style Selector="^/template/ Path#CheckMark">
-               <Setter Property="IsVisible" Value="True" />
-               <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
-            </Style>
-         </Style>
-         <Style Selector="^:indeterminate">
-            <Style Selector="^/template/ Border#border">
-               <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
-            </Style>
-            <Style Selector="^/template/ Rectangle#IndeterminateMark">
-               <Setter Property="IsVisible" Value="True" />
-               <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
-            </Style>
-         </Style>
-      </Style>
-   </ControlTheme>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -1,218 +1,218 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <Border Margin="10" Background="{DynamicResource LayoutBackgroundHighBrush}">
-         <StackPanel Margin="20" Height="400" Width="180" Spacing="5">
-            <ComboBox SelectedIndex="2" MaxDropDownHeight="100">
-               <ComboBoxItem>Option 1</ComboBoxItem>
-               <ComboBoxItem>Option 2</ComboBoxItem>
-               <ComboBoxItem>Option 3</ComboBoxItem>
-            </ComboBox>
-            <ComboBox SelectedIndex="3" MaxDropDownHeight="100" IsEnabled="False">
-               <ComboBoxItem>Option 1</ComboBoxItem>
-               <ComboBoxItem>Option 2</ComboBoxItem>
-               <ComboBoxItem>Option 3</ComboBoxItem>
-            </ComboBox>
-            <ComboBox MaxDropDownHeight="100" PlaceholderText="Choose one">
-               <ComboBoxItem>Option 1</ComboBoxItem>
-               <ComboBoxItem>Option 2</ComboBoxItem>
-               <ComboBoxItem>Option 3</ComboBoxItem>
-               <ComboBoxItem>Option 4</ComboBoxItem>
-               <ComboBoxItem>Option 5</ComboBoxItem>
-               <ComboBoxItem>Option 6</ComboBoxItem>
-               <ComboBoxItem>Option 7</ComboBoxItem>
-               <ComboBoxItem>Option 8</ComboBoxItem>
-               <ComboBoxItem>Option 9</ComboBoxItem>
-            </ComboBox>
-         </StackPanel>
-      </Border>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <Border Margin="10" Background="{DynamicResource LayoutBackgroundHighBrush}">
+      <StackPanel Margin="20" Height="400" Width="180" Spacing="5">
+        <ComboBox SelectedIndex="2" MaxDropDownHeight="100">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+        </ComboBox>
+        <ComboBox SelectedIndex="3" MaxDropDownHeight="100" IsEnabled="False">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+        </ComboBox>
+        <ComboBox MaxDropDownHeight="100" PlaceholderText="Choose one">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+          <ComboBoxItem>Option 5</ComboBoxItem>
+          <ComboBoxItem>Option 6</ComboBoxItem>
+          <ComboBoxItem>Option 7</ComboBoxItem>
+          <ComboBoxItem>Option 8</ComboBoxItem>
+          <ComboBoxItem>Option 9</ComboBoxItem>
+        </ComboBox>
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="PopUpToggleButton" TargetType="ToggleButton">
-      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
-      <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
-      <Setter Property="CornerRadius" Value="{StaticResource SelectionCornerRadius}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <ContentPresenter
-               Name="PART_ContentPresenter"
-               Background="{TemplateBinding Background}"
-               BorderBrush="{TemplateBinding BorderBrush}"
-               BorderThickness="{TemplateBinding BorderThickness}"
-               CornerRadius="{TemplateBinding CornerRadius}"
-               Content="{TemplateBinding Content}"
-               ContentTemplate="{TemplateBinding ContentTemplate}"
-               Padding="{TemplateBinding Padding}"
-               RecognizesAccessKey="True"
-               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-         </ControlTemplate>
-      </Setter>
-      <Style Selector="^:disabled">
-         <Setter Property="BorderThickness" Value="0" />
-         <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-         </Style>
+  <ControlTheme x:Key="PopUpToggleButton" TargetType="ToggleButton">
+    <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundHighBrush}" />
+    <Setter Property="BorderBrush" Value="{WindowActiveResourceToggler ControlBorderAccentBrush, ControlBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
+    <Setter Property="CornerRadius" Value="{StaticResource SelectionCornerRadius}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter
+          Name="PART_ContentPresenter"
+          Background="{TemplateBinding Background}"
+          BorderBrush="{TemplateBinding BorderBrush}"
+          BorderThickness="{TemplateBinding BorderThickness}"
+          CornerRadius="{TemplateBinding CornerRadius}"
+          Content="{TemplateBinding Content}"
+          ContentTemplate="{TemplateBinding ContentTemplate}"
+          Padding="{TemplateBinding Padding}"
+          RecognizesAccessKey="True"
+          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:disabled">
+      <Setter Property="BorderThickness" Value="0" />
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
       </Style>
-   </ControlTheme>
+    </Style>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type ComboBox}" TargetType="ComboBox">
-      <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="Padding" Value="8 1 6 2" />
-      <Setter Property="MinHeight" Value="20" />
-      <Setter Property="PlaceholderForeground" Value="{DynamicResource ThemeForegroundBrush}" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Panel Name="ReservedSpaceForFocus"
-                   Margin="{StaticResource InputControlsSpaceForFocusBorder}">
-               <Border
-                  Name="border"
-                  Background="{TemplateBinding Background}"
-                  BorderThickness="{DynamicResource ButtonBorderThickness}"
-                  BorderBrush="{DynamicResource ControlBorderRaisedBrush}"
-                  BoxShadow="{DynamicResource ControlBorderBoxShadow}"
-                  CornerRadius="{TemplateBinding CornerRadius}">
-                  <Grid ColumnDefinitions="*,Auto">
-                     <TextBlock
-                        Name="PlaceholderTextBlock"
-                        Grid.Column="0"
-                        Margin="{TemplateBinding Padding}"
-                        Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+  <ControlTheme x:Key="{x:Type ComboBox}" TargetType="ComboBox">
+    <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="Padding" Value="8 1 6 2" />
+    <Setter Property="MinHeight" Value="20" />
+    <Setter Property="PlaceholderForeground" Value="{DynamicResource ThemeForegroundBrush}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel Name="ReservedSpaceForFocus"
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <Border
+            Name="border"
+            Background="{TemplateBinding Background}"
+            BorderThickness="{DynamicResource ButtonBorderThickness}"
+            BorderBrush="{DynamicResource ControlBorderRaisedBrush}"
+            BoxShadow="{DynamicResource ControlBorderBoxShadow}"
+            CornerRadius="{TemplateBinding CornerRadius}">
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock
+                Name="PlaceholderTextBlock"
+                Grid.Column="0"
+                Margin="{TemplateBinding Padding}"
+                Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
 
-                        IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}"
-                        Text="{TemplateBinding PlaceholderText}" />
-                     <ContentControl
-                        Grid.Column="0"
-                        Margin="{TemplateBinding Padding}"
-                        Foreground="{TemplateBinding Foreground}"
-                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                        Content="{TemplateBinding SelectionBoxItem}"
-                        ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
-                     <ToggleButton
-                        Name="Toggle"
-                        Grid.Column="1"
-                        Theme="{StaticResource PopUpToggleButton}"
-                        Width="16"
-                        Height="16"
-                        Margin="2"
-                        Padding="3"
-                        ClickMode="Press"
-                        Focusable="False"
-                        IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}">
-                        <StackPanel VerticalAlignment="Center" Spacing="2">
-                           <StackPanel.RenderTransform>
-                              <TransformGroup>
-                                 <TranslateTransform X="1" />
-                                 <TranslateTransform Y="-1" />
-                              </TransformGroup>
-                           </StackPanel.RenderTransform>
-                           <Path Width="9"
-                                 Height="4.4"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 Data="{DynamicResource ChevronPath}"
-                                 Stretch="Uniform"
-                                 Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
+                IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}"
+                Text="{TemplateBinding PlaceholderText}" />
+              <ContentControl
+                Grid.Column="0"
+                Margin="{TemplateBinding Padding}"
+                Foreground="{TemplateBinding Foreground}"
+                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                Content="{TemplateBinding SelectionBoxItem}"
+                ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}" />
+              <ToggleButton
+                Name="Toggle"
+                Grid.Column="1"
+                Theme="{StaticResource PopUpToggleButton}"
+                Width="16"
+                Height="16"
+                Margin="2"
+                Padding="3"
+                ClickMode="Press"
+                Focusable="False"
+                IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}">
+                <StackPanel VerticalAlignment="Center" Spacing="2">
+                  <StackPanel.RenderTransform>
+                    <TransformGroup>
+                      <TranslateTransform X="1" />
+                      <TranslateTransform Y="-1" />
+                    </TransformGroup>
+                  </StackPanel.RenderTransform>
+                  <Path Width="9"
+                        Height="4.4"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{DynamicResource ChevronPath}"
+                        Stretch="Uniform"
+                        Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
 
-                           <Path Width="9"
-                                 Height="4.4"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 Data="{DynamicResource ChevronPath}"
-                                 Stretch="Uniform"
-                                 Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}">
-                              <Path.RenderTransform>
-                                 <ScaleTransform ScaleY="-1" />
-                              </Path.RenderTransform>
-                           </Path>
-                        </StackPanel>
-                     </ToggleButton>
-                  </Grid>
-               </Border>
-               <Border Name="FocusBorderElement"
-                       Margin="{StaticResource FocusBorderMargin}"
-                       BorderThickness="{StaticResource FocusBorderThickness}"
-                       CornerRadius="7" />
-               <Popup
-                  Name="PART_Popup"
-                  MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                  IsLightDismissEnabled="True"
-                  IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
-                  PlacementTarget="{TemplateBinding}"
-                  InheritsTransform="True"
-                  Placement="AnchorAndGravity"
-                  PlacementAnchor="Bottom"
-                  PlacementGravity="Bottom"
-                  HorizontalOffset="-13">
-                  <Popup.MinWidth>
-                     <MultiBinding Converter="{x:Static DevoMultiConverters.TotalWidthConverter}">
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Bounds.Width" />
-                        <Binding Source="{StaticResource PopupSideMarginWidth}" />
-                     </MultiBinding>
-                  </Popup.MinWidth>
-                  <Popup.VerticalOffset>
-                     <MultiBinding Converter="{x:Static DevoMultiConverters.SelectedIndexToPopupOffsetConverter}">
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedIndex" />
-                        <Binding Source="{StaticResource ComboBoxItemHeight}" />
-                        <Binding Source="{StaticResource InitialFirstItemDistance}" />
-                        <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
-                        <Binding Source="{StaticResource PopupTrimHeight}" />
-                     </MultiBinding>
-                  </Popup.VerticalOffset>
-                  <Border Background="{DynamicResource PopupBackgroundBrush}"
-                          BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                          BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                          CornerRadius="{DynamicResource LayoutCornerRadius}"
-                          Margin="{DynamicResource PopupMargin}"
-                          Padding="{DynamicResource PopupPadding}"
-                          BoxShadow="{DynamicResource PopupShadow}">
-                     <ScrollViewer
-                        Classes="MacOS_TransparentTrack"
-                        HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                        VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                        IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
-                        <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
-                     </ScrollViewer>
-                  </Border>
-               </Popup>
-            </Panel>
-         </ControlTemplate>
-      </Setter><!-- Tabbing focus -->
-      <Style Selector="^:focus-visible">
-         <Style Selector="^ /template/ Border#FocusBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
-         </Style>
+                  <Path Width="9"
+                        Height="4.4"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Data="{DynamicResource ChevronPath}"
+                        Stretch="Uniform"
+                        Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}">
+                    <Path.RenderTransform>
+                      <ScaleTransform ScaleY="-1" />
+                    </Path.RenderTransform>
+                  </Path>
+                </StackPanel>
+              </ToggleButton>
+            </Grid>
+          </Border>
+          <Border Name="FocusBorderElement"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  CornerRadius="7" />
+          <Popup
+            Name="PART_Popup"
+            MaxHeight="{TemplateBinding MaxDropDownHeight}"
+            IsLightDismissEnabled="True"
+            IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+            PlacementTarget="{TemplateBinding}"
+            InheritsTransform="True"
+            Placement="AnchorAndGravity"
+            PlacementAnchor="Bottom"
+            PlacementGravity="Bottom"
+            HorizontalOffset="-13">
+            <Popup.MinWidth>
+              <MultiBinding Converter="{x:Static DevoMultiConverters.TotalWidthConverter}">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Bounds.Width" />
+                <Binding Source="{StaticResource PopupSideMarginWidth}" />
+              </MultiBinding>
+            </Popup.MinWidth>
+            <Popup.VerticalOffset>
+              <MultiBinding Converter="{x:Static DevoMultiConverters.SelectedIndexToPopupOffsetConverter}">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedIndex" />
+                <Binding Source="{StaticResource ComboBoxItemHeight}" />
+                <Binding Source="{StaticResource InitialFirstItemDistance}" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
+                <Binding Source="{StaticResource PopupTrimHeight}" />
+              </MultiBinding>
+            </Popup.VerticalOffset>
+            <Border Background="{DynamicResource PopupBackgroundBrush}"
+                    BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                    BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
+                    CornerRadius="{DynamicResource LayoutCornerRadius}"
+                    Margin="{DynamicResource PopupMargin}"
+                    Padding="{DynamicResource PopupPadding}"
+                    BoxShadow="{DynamicResource PopupShadow}">
+              <ScrollViewer
+                Classes="MacOS_TransparentTrack"
+                HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
+                <ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
+              </ScrollViewer>
+            </Border>
+          </Popup>
+        </Panel>
+      </ControlTemplate>
+    </Setter><!-- Tabbing focus -->
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
       </Style>
+    </Style>
 
-      <Style Selector="^:disabled">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-         <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
-         <Style Selector="^ /template/ Border#border">
-            <Setter Property="BoxShadow" Value="{DynamicResource ComboBoxDisabledBoxShadow}" />
-         </Style>
-         <Style Selector="^ /template/ Path">
-            <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
-         </Style>
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />
+      <Style Selector="^ /template/ Border#border">
+        <Setter Property="BoxShadow" Value="{DynamicResource ComboBoxDisabledBoxShadow}" />
       </Style>
-   </ControlTheme>
+      <Style Selector="^ /template/ Path">
+        <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+      </Style>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
@@ -1,108 +1,108 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:collections="clr-namespace:Avalonia.Collections;assembly=Avalonia.Controls.DataGrid">
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:collections="clr-namespace:Avalonia.Collections;assembly=Avalonia.Controls.DataGrid">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <ResourceDictionary.ThemeDictionaries>
-      <ResourceDictionary x:Key="Dark">
-         <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource SystemBaseMediumColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="{DynamicResource SystemAltHighColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush"
-                          Color="{DynamicResource SystemListMediumColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderDraggedBackgroundBrush"
-                          Color="{DynamicResource SystemChromeMediumLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderPressedBackgroundBrush"
-                          Color="{DynamicResource SystemListMediumColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderForegroundBrush" Color="{DynamicResource SystemBaseHighColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush"
-                          Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush"
-                          Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
-         <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
-         <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
-         <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
-         <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush"
-                          Color="{DynamicResource SystemChromeMediumLowColor}" />
-      </ResourceDictionary>
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Dark">
+      <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource SystemBaseMediumColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="{DynamicResource SystemAltHighColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush"
+                       Color="{DynamicResource SystemListMediumColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderDraggedBackgroundBrush"
+                       Color="{DynamicResource SystemChromeMediumLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderPressedBackgroundBrush"
+                       Color="{DynamicResource SystemListMediumColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderForegroundBrush" Color="{DynamicResource SystemBaseHighColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush"
+                       Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush"
+                       Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
+      <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
+      <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+      <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
+      <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush"
+                       Color="{DynamicResource SystemChromeMediumLowColor}" />
+    </ResourceDictionary>
 
-      <ResourceDictionary x:Key="Default">
-         <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource SystemBaseMediumColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="{DynamicResource SystemAltHighColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush"
-                          Color="{DynamicResource SystemListMediumColor}" />
-         <SolidColorBrush x:Key="DataGridColumnHeaderDraggedBackgroundBrush"
-                          Color="{DynamicResource SystemChromeMediumLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderPressedBackgroundBrush"
-                          Color="{DynamicResource SystemListMediumColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderForegroundBrush" Color="{DynamicResource SystemBaseHighColor}" />
-         <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush"
-                          Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="{DynamicResource SystemListLowColor}" />
-         <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush"
-                          Color="{DynamicResource SystemAccentColor}" />
-         <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
-         <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
-         <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
-         <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
-         <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush"
-                          Color="{DynamicResource SystemChromeMediumLowColor}" />
-      </ResourceDictionary>
-   </ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Default">
+      <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource SystemBaseMediumColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="{DynamicResource SystemAltHighColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush"
+                       Color="{DynamicResource SystemListMediumColor}" />
+      <SolidColorBrush x:Key="DataGridColumnHeaderDraggedBackgroundBrush"
+                       Color="{DynamicResource SystemChromeMediumLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderBackgroundBrush" Color="{DynamicResource SystemChromeMediumColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderPressedBackgroundBrush"
+                       Color="{DynamicResource SystemListMediumColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderForegroundBrush" Color="{DynamicResource SystemBaseHighColor}" />
+      <SolidColorBrush x:Key="DataGridRowGroupHeaderHoveredBackgroundBrush"
+                       Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="{DynamicResource SystemListLowColor}" />
+      <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush"
+                       Color="{DynamicResource SystemAccentColor}" />
+      <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="{DynamicResource SystemBaseHighColor}" />
+      <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="{DynamicResource SystemAltMediumColor}" />
+      <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="{DynamicResource SystemErrorTextColor}" />
+      <SolidColorBrush x:Key="DataGridGridLinesBrush" Opacity="0.4" Color="{DynamicResource SystemBaseMediumLowColor}" />
+      <SolidColorBrush x:Key="DataGridDetailsPresenterBackgroundBrush"
+                       Color="{DynamicResource SystemChromeMediumLowColor}" />
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
 
-   <x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
-   <x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
-   <x:Double x:Key="DataGridSortIconMinWidth">32</x:Double>
+  <x:Double x:Key="ListAccentLowOpacity">0.6</x:Double>
+  <x:Double x:Key="ListAccentMediumOpacity">0.8</x:Double>
+  <x:Double x:Key="DataGridSortIconMinWidth">32</x:Double>
 
-   <StreamGeometry x:Key="DataGridRowGroupHeaderIconClosedPath">M515 93l930 931l-930 931l90 90l1022 -1021l-1022 -1021z</StreamGeometry>
-   <StreamGeometry x:Key="DataGridRowGroupHeaderIconOpenedPath">M109 486 19 576 1024 1581 2029 576 1939 486 1024 1401z</StreamGeometry>
+  <StreamGeometry x:Key="DataGridRowGroupHeaderIconClosedPath">M515 93l930 931l-930 931l90 90l1022 -1021l-1022 -1021z</StreamGeometry>
+  <StreamGeometry x:Key="DataGridRowGroupHeaderIconOpenedPath">M109 486 19 576 1024 1581 2029 576 1939 486 1024 1401z</StreamGeometry>
 
-   <StaticResource x:Key="DataGridRowBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
-   <StaticResource x:Key="DataGridRowSelectedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
-   <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
-   <StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
-   <StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
-   <StaticResource x:Key="DataGridCellBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
-   <StaticResource x:Key="DataGridCurrencyVisualPrimaryBrush" ResourceKey="SystemControlTransparentBrush" />
-   <StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="SystemControlTransparentBrush" />
+  <StaticResource x:Key="DataGridRowBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
+  <StaticResource x:Key="DataGridRowSelectedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+  <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+  <StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity" ResourceKey="ListAccentLowOpacity" />
+  <StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity" ResourceKey="ListAccentMediumOpacity" />
+  <StaticResource x:Key="DataGridCellBackgroundBrush" ResourceKey="SystemControlTransparentBrush" />
+  <StaticResource x:Key="DataGridCurrencyVisualPrimaryBrush" ResourceKey="SystemControlTransparentBrush" />
+  <StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="SystemControlTransparentBrush" />
 
-   <!-- CellTextBlock -->
-   <ControlTheme x:Key="DataGridCellTextBlockTheme" TargetType="TextBlock">
-      <Setter Property="Margin" Value="12,0,12,0" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-   </ControlTheme>
+  <!-- CellTextBlock -->
+  <ControlTheme x:Key="DataGridCellTextBlockTheme" TargetType="TextBlock">
+    <Setter Property="Margin" Value="12,0,12,0" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+  </ControlTheme>
 
-   <!-- CellTextBox -->
-   <ControlTheme x:Key="DataGridCellTextBoxTheme" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
-      <Style Selector="^ /template/ DataValidationErrors">
-         <Setter Property="Theme" Value="{StaticResource TooltipDataValidationErrors}" />
-      </Style>
-   </ControlTheme>
+  <!-- CellTextBox -->
+  <ControlTheme x:Key="DataGridCellTextBoxTheme" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
+    <Style Selector="^ /template/ DataValidationErrors">
+      <Setter Property="Theme" Value="{StaticResource TooltipDataValidationErrors}" />
+    </Style>
+  </ControlTheme>
 
-   <!-- Cell -->
-   <ControlTheme x:Key="{x:Type DataGridCell}" TargetType="DataGridCell">
-      <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
-      <Setter
-         Property="Foreground"
-         Value="{DynamicResourceToggler
+  <!-- Cell -->
+  <ControlTheme x:Key="{x:Type DataGridCell}" TargetType="DataGridCell">
+    <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
+    <Setter
+      Property="Foreground"
+      Value="{DynamicResourceToggler
             {AndBinding
             {WindowIsActiveBinding},
                {Binding IsSelected, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridRow}}
@@ -110,533 +110,533 @@
             DataGridForegroundSelectedBrush,
             ForegroundHighBrush
          }" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Stretch" />
-      <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-      <Setter Property="MinHeight" Value="23" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="CellBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}">
-               <Grid Name="PART_CellRoot" ColumnDefinitions="*,Auto">
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="MinHeight" Value="23" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <Grid Name="PART_CellRoot" ColumnDefinitions="*,Auto">
 
-                  <Rectangle Name="CurrencyVisual"
-                             IsVisible="False"
-                             HorizontalAlignment="Stretch"
-                             VerticalAlignment="Stretch"
-                             Fill="Transparent"
-                             IsHitTestVisible="False"
-                             Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
-                             StrokeThickness="1" />
-                  <Grid Grid.Column="0" Name="FocusVisual" IsHitTestVisible="False"
-                        IsVisible="False">
-                     <Rectangle HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Fill="Transparent"
-                                IsHitTestVisible="False"
-                                Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
-                                StrokeThickness="2" />
-                     <Rectangle Margin="2"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Fill="Transparent"
-                                IsHitTestVisible="False"
-                                Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
-                                StrokeThickness="1" />
-                  </Grid>
-
-                  <ContentPresenter Grid.Column="0" Margin="{TemplateBinding Padding}"
-                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    Content="{TemplateBinding Content}"
-                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                    Foreground="{TemplateBinding Foreground}" />
-
-                  <Rectangle Grid.Column="0" Name="InvalidVisualElement"
-                             IsVisible="False"
-                             HorizontalAlignment="Stretch"
-                             VerticalAlignment="Stretch"
-                             IsHitTestVisible="False"
-                             Stroke="{DynamicResource DataGridCellInvalidBrush}"
-                             StrokeThickness="1" />
-
-                  <Rectangle Name="PART_RightGridLine"
-                             Grid.Column="1"
-                             Width="1"
-                             VerticalAlignment="Stretch"
-                             Fill="{DynamicResource DataGridFillerColumnGridLinesBrush}" />
-               </Grid>
-            </Border>
-         </ControlTemplate>
-      </Setter>
-      <Style Selector="^:current /template/ Rectangle#CurrencyVisual">
-         <Setter Property="IsVisible" Value="True" />
-      </Style>
-      <Style Selector="^:invalid /template/ Rectangle#InvalidVisualElement">
-         <Setter Property="IsVisible" Value="True" />
-      </Style>
-   </ControlTheme>
-
-   <!-- ColumnHeader -->
-   <ControlTheme x:Key="{x:Type DataGridColumnHeader}" TargetType="DataGridColumnHeader">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundMidBrush}" />
-      <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
-      <Setter Property="Padding" Value="18,0,0,0" />
-      <Setter Property="FontSize" Value="{DynamicResource DataGridColumnHeaderFontSize}" />
-      <Setter Property="MinHeight" Value="28" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="HeaderBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}">
-               <Grid Name="PART_ColumnHeaderRoot" ColumnDefinitions="*,Auto">
-
-                  <Panel Margin="{TemplateBinding Padding}"
-                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
-                     <Grid>
-                        <Grid.ColumnDefinitions>
-                           <ColumnDefinition Width="*" />
-                           <ColumnDefinition Width="Auto" MinWidth="{DynamicResource DataGridSortIconMinWidth}" />
-                        </Grid.ColumnDefinitions>
-
-                        <ContentPresenter Name="PART_ContentPresenter"
-                                          Content="{TemplateBinding Content}"
-                                          ContentTemplate="{TemplateBinding ContentTemplate}" />
-
-                        <Path Name="SortIcon"
-                              IsVisible="False"
-                              Grid.Column="1"
-                              Width="{DynamicResource DataGridSortChevronSize}"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Fill="{DynamicResource SortIconForegroundBrush}"
-                              Stretch="Uniform" />
-                     </Grid>
-                  </Panel>
-
-                  <Rectangle Name="VerticalSeparator"
-                             Grid.Column="1"
-                             Width="1"
-                             Height="16"
-                             VerticalAlignment="Center"
-                             Fill="{TemplateBinding SeparatorBrush}"
-                             IsVisible="{TemplateBinding AreSeparatorsVisible}" />
-
-                  <Grid Name="FocusVisual" IsHitTestVisible="False"
-                        IsVisible="False">
-                     <Rectangle Name="FocusVisualPrimary"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Fill="Transparent"
-                                IsHitTestVisible="False"
-                                Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
-                                StrokeThickness="2" />
-                     <Rectangle Name="FocusVisualSecondary"
-                                Margin="2"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch"
-                                Fill="Transparent"
-                                IsHitTestVisible="False"
-                                Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
-                                StrokeThickness="1" />
-                  </Grid>
-               </Grid>
-            </Border>
-         </ControlTemplate>
-      </Setter>
-
-      <Style Selector="^:focus-visible /template/ Grid#FocusVisual">
-         <Setter Property="IsVisible" Value="True" />
-      </Style>
-
-      <Style Selector="^:pressed /template/ Grid#PART_ColumnHeaderRoot">
-         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
-      </Style>
-
-      <Style Selector="^:dragIndicator">
-         <Setter Property="Opacity" Value="0.5" />
-      </Style>
-
-      <Style Selector="^:sortascending">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-         <Setter Property="FontWeight" Value="Medium" />
-         <Style Selector="^ /template/ Path#SortIcon">
-            <Setter Property="IsVisible" Value="True" />
-            <Setter Property="Data" Value="{StaticResource ChevronPath}" />
-            <!-- <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" /> -->
-         </Style>
-      </Style>
-
-      <Style Selector="^:sortdescending">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-         <Setter Property="FontWeight" Value="Medium" />
-         <Style Selector="^ /template/ Path#SortIcon">
-            <Setter Property="IsVisible" Value="True" />
-            <Setter Property="Data" Value="{StaticResource ChevronPath}" />
-            <!-- <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" /> -->
-            <Setter Property="RenderTransform">
-               <TransformGroup>
-                  <RotateTransform Angle="180" />
-               </TransformGroup>
-            </Setter>
-         </Style>
-      </Style>
-   </ControlTheme>
-
-   <!-- Top-Left ColumnHeader -->
-   <ControlTheme x:Key="DataGridTopLeftColumnHeader" TargetType="DataGridColumnHeader"
-                 BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Grid Name="TopLeftHeaderRoot"
-                  RowDefinitions="*,*,Auto">
-               <Border Grid.RowSpan="2"
-                       BorderThickness="0,0,1,0"
-                       BorderBrush="{DynamicResource DataGridGridLinesBrush}" />
-               <Rectangle Grid.Row="0" Grid.RowSpan="2"
-                          VerticalAlignment="Bottom"
-                          StrokeThickness="1"
-                          Height="1"
-                          Fill="{DynamicResource DataGridGridLinesBrush}" />
+            <Rectangle Name="CurrencyVisual"
+                       IsVisible="False"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent"
+                       IsHitTestVisible="False"
+                       Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
+                       StrokeThickness="1" />
+            <Grid Grid.Column="0" Name="FocusVisual" IsHitTestVisible="False"
+                  IsVisible="False">
+              <Rectangle HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         Fill="Transparent"
+                         IsHitTestVisible="False"
+                         Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+                         StrokeThickness="2" />
+              <Rectangle Margin="2"
+                         HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         Fill="Transparent"
+                         IsHitTestVisible="False"
+                         Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+                         StrokeThickness="1" />
             </Grid>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
 
-   <!-- RowHeader -->
-   <ControlTheme x:Key="{x:Type DataGridRowHeader}" TargetType="DataGridRowHeader">
-      <Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
-      <Setter Property="AreSeparatorsVisible" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Grid Name="PART_Root"
-                  RowDefinitions="*,*,Auto"
-                  ColumnDefinitions="Auto,*">
-               <Border Grid.RowSpan="3"
+            <ContentPresenter Grid.Column="0" Margin="{TemplateBinding Padding}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Foreground="{TemplateBinding Foreground}" />
+
+            <Rectangle Grid.Column="0" Name="InvalidVisualElement"
+                       IsVisible="False"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       IsHitTestVisible="False"
+                       Stroke="{DynamicResource DataGridCellInvalidBrush}"
+                       StrokeThickness="1" />
+
+            <Rectangle Name="PART_RightGridLine"
+                       Grid.Column="1"
+                       Width="1"
+                       VerticalAlignment="Stretch"
+                       Fill="{DynamicResource DataGridFillerColumnGridLinesBrush}" />
+          </Grid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:current /template/ Rectangle#CurrencyVisual">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="^:invalid /template/ Rectangle#InvalidVisualElement">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+  </ControlTheme>
+
+  <!-- ColumnHeader -->
+  <ControlTheme x:Key="{x:Type DataGridColumnHeader}" TargetType="DataGridColumnHeader">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundMidBrush}" />
+    <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+    <Setter Property="Padding" Value="18,0,0,0" />
+    <Setter Property="FontSize" Value="{DynamicResource DataGridColumnHeaderFontSize}" />
+    <Setter Property="MinHeight" Value="28" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="HeaderBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <Grid Name="PART_ColumnHeaderRoot" ColumnDefinitions="*,Auto">
+
+            <Panel Margin="{TemplateBinding Padding}"
+                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+              <Grid>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="*" />
+                  <ColumnDefinition Width="Auto" MinWidth="{DynamicResource DataGridSortIconMinWidth}" />
+                </Grid.ColumnDefinitions>
+
+                <ContentPresenter Name="PART_ContentPresenter"
+                                  Content="{TemplateBinding Content}"
+                                  ContentTemplate="{TemplateBinding ContentTemplate}" />
+
+                <Path Name="SortIcon"
+                      IsVisible="False"
+                      Grid.Column="1"
+                      Width="{DynamicResource DataGridSortChevronSize}"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Fill="{DynamicResource SortIconForegroundBrush}"
+                      Stretch="Uniform" />
+              </Grid>
+            </Panel>
+
+            <Rectangle Name="VerticalSeparator"
+                       Grid.Column="1"
+                       Width="1"
+                       Height="16"
+                       VerticalAlignment="Center"
+                       Fill="{TemplateBinding SeparatorBrush}"
+                       IsVisible="{TemplateBinding AreSeparatorsVisible}" />
+
+            <Grid Name="FocusVisual" IsHitTestVisible="False"
+                  IsVisible="False">
+              <Rectangle Name="FocusVisualPrimary"
+                         HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         Fill="Transparent"
+                         IsHitTestVisible="False"
+                         Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+                         StrokeThickness="2" />
+              <Rectangle Name="FocusVisualSecondary"
+                         Margin="2"
+                         HorizontalAlignment="Stretch"
+                         VerticalAlignment="Stretch"
+                         Fill="Transparent"
+                         IsHitTestVisible="False"
+                         Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+                         StrokeThickness="1" />
+            </Grid>
+          </Grid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:focus-visible /template/ Grid#FocusVisual">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="^:pressed /template/ Grid#PART_ColumnHeaderRoot">
+      <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
+    </Style>
+
+    <Style Selector="^:dragIndicator">
+      <Setter Property="Opacity" Value="0.5" />
+    </Style>
+
+    <Style Selector="^:sortascending">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+      <Setter Property="FontWeight" Value="Medium" />
+      <Style Selector="^ /template/ Path#SortIcon">
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Data" Value="{StaticResource ChevronPath}" />
+        <!-- <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" /> -->
+      </Style>
+    </Style>
+
+    <Style Selector="^:sortdescending">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+      <Setter Property="FontWeight" Value="Medium" />
+      <Style Selector="^ /template/ Path#SortIcon">
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Data" Value="{StaticResource ChevronPath}" />
+        <!-- <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" /> -->
+        <Setter Property="RenderTransform">
+          <TransformGroup>
+            <RotateTransform Angle="180" />
+          </TransformGroup>
+        </Setter>
+      </Style>
+    </Style>
+  </ControlTheme>
+
+  <!-- Top-Left ColumnHeader -->
+  <ControlTheme x:Key="DataGridTopLeftColumnHeader" TargetType="DataGridColumnHeader"
+                BasedOn="{StaticResource {x:Type DataGridColumnHeader}}">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid Name="TopLeftHeaderRoot"
+              RowDefinitions="*,*,Auto">
+          <Border Grid.RowSpan="2"
+                  BorderThickness="0,0,1,0"
+                  BorderBrush="{DynamicResource DataGridGridLinesBrush}" />
+          <Rectangle Grid.Row="0" Grid.RowSpan="2"
+                     VerticalAlignment="Bottom"
+                     StrokeThickness="1"
+                     Height="1"
+                     Fill="{DynamicResource DataGridGridLinesBrush}" />
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <!-- RowHeader -->
+  <ControlTheme x:Key="{x:Type DataGridRowHeader}" TargetType="DataGridRowHeader">
+    <Setter Property="SeparatorBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+    <Setter Property="AreSeparatorsVisible" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid Name="PART_Root"
+              RowDefinitions="*,*,Auto"
+              ColumnDefinitions="Auto,*">
+          <Border Grid.RowSpan="3"
+                  Grid.ColumnSpan="2"
+                  BorderBrush="{TemplateBinding SeparatorBrush}"
+                  BorderThickness="0,0,1,0">
+            <Grid Background="{TemplateBinding Background}">
+              <Rectangle Name="RowInvalidVisualElement"
+                         Opacity="0"
+                         Fill="{DynamicResource DataGridRowInvalidBrush}"
+                         Stretch="Fill" />
+              <Rectangle Name="BackgroundRectangle"
+                         Fill="{DynamicResource DataGridRowBackgroundBrush}"
+                         Stretch="Fill" />
+            </Grid>
+          </Border>
+          <Rectangle Name="HorizontalSeparator"
+                     Grid.Row="2"
+                     Grid.ColumnSpan="2"
+                     Height="1"
+                     Margin="1,0,1,0"
+                     HorizontalAlignment="Stretch"
+                     Fill="{TemplateBinding SeparatorBrush}"
+                     IsVisible="{TemplateBinding AreSeparatorsVisible}" />
+
+          <ContentPresenter Grid.RowSpan="2"
+                            Grid.Column="1"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Content="{TemplateBinding Content}" />
+        </Grid>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <!-- Row -->
+  <ControlTheme x:Key="{x:Type DataGridRow}" TargetType="DataGridRow">
+    <Setter Property="Background" Value="{Binding $parent[DataGrid].RowBackground}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="RowBorder"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}">
+          <DataGridFrozenGrid Name="PART_Root"
+                              ColumnDefinitions="Auto,*"
+                              RowDefinitions="*,Auto,Auto">
+
+            <Border Name="ItemBorder"
+                    Background="{TemplateBinding Background}"
+                    Margin="8 0"
+                    CornerRadius="{DynamicResource ControlCornerRadius}"
+                    Grid.RowSpan="2"
+                    Grid.ColumnSpan="2" />
+            <Rectangle Name="InvalidVisualElement"
+                       Opacity="0"
                        Grid.ColumnSpan="2"
-                       BorderBrush="{TemplateBinding SeparatorBrush}"
-                       BorderThickness="0,0,1,0">
-                  <Grid Background="{TemplateBinding Background}">
-                     <Rectangle Name="RowInvalidVisualElement"
-                                Opacity="0"
-                                Fill="{DynamicResource DataGridRowInvalidBrush}"
-                                Stretch="Fill" />
-                     <Rectangle Name="BackgroundRectangle"
-                                Fill="{DynamicResource DataGridRowBackgroundBrush}"
-                                Stretch="Fill" />
-                  </Grid>
-               </Border>
-               <Rectangle Name="HorizontalSeparator"
-                          Grid.Row="2"
-                          Grid.ColumnSpan="2"
-                          Height="1"
-                          Margin="1,0,1,0"
-                          HorizontalAlignment="Stretch"
-                          Fill="{TemplateBinding SeparatorBrush}"
-                          IsVisible="{TemplateBinding AreSeparatorsVisible}" />
+                       Fill="{DynamicResource DataGridRowInvalidBrush}" />
 
-               <ContentPresenter Grid.RowSpan="2"
-                                 Grid.Column="1"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center"
-                                 Content="{TemplateBinding Content}" />
-            </Grid>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+            <DataGridRowHeader Name="PART_RowHeader"
+                               Grid.RowSpan="3"
+                               DataGridFrozenGrid.IsFrozen="True" />
+            <DataGridCellsPresenter Name="PART_CellsPresenter"
+                                    Grid.Column="1"
+                                    DataGridFrozenGrid.IsFrozen="True"
+                                    Margin="6 0" />
+            <DataGridDetailsPresenter Name="PART_DetailsPresenter"
+                                      Grid.Row="1"
+                                      Grid.Column="1"
+                                      Background="{DynamicResource DataGridDetailsPresenterBackgroundBrush}" />
+            <Rectangle Name="PART_BottomGridLine"
+                       Grid.Row="2"
+                       Grid.Column="1"
+                       Height="1"
+                       HorizontalAlignment="Stretch" />
 
-   <!-- Row -->
-   <ControlTheme x:Key="{x:Type DataGridRow}" TargetType="DataGridRow">
-      <Setter Property="Background" Value="{Binding $parent[DataGrid].RowBackground}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="RowBorder"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}">
-               <DataGridFrozenGrid Name="PART_Root"
-                                   ColumnDefinitions="Auto,*"
-                                   RowDefinitions="*,Auto,Auto">
+          </DataGridFrozenGrid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
 
-                  <Border Name="ItemBorder"
-                          Background="{TemplateBinding Background}"
-                          Margin="8 0"
-                          CornerRadius="{DynamicResource ControlCornerRadius}"
-                          Grid.RowSpan="2"
-                          Grid.ColumnSpan="2" />
-                  <Rectangle Name="InvalidVisualElement"
-                             Opacity="0"
-                             Grid.ColumnSpan="2"
-                             Fill="{DynamicResource DataGridRowInvalidBrush}" />
-
-                  <DataGridRowHeader Name="PART_RowHeader"
-                                     Grid.RowSpan="3"
-                                     DataGridFrozenGrid.IsFrozen="True" />
-                  <DataGridCellsPresenter Name="PART_CellsPresenter"
-                                          Grid.Column="1"
-                                          DataGridFrozenGrid.IsFrozen="True"
-                                          Margin="6 0" />
-                  <DataGridDetailsPresenter Name="PART_DetailsPresenter"
-                                            Grid.Row="1"
-                                            Grid.Column="1"
-                                            Background="{DynamicResource DataGridDetailsPresenterBackgroundBrush}" />
-                  <Rectangle Name="PART_BottomGridLine"
-                             Grid.Row="2"
-                             Grid.Column="1"
-                             Height="1"
-                             HorizontalAlignment="Stretch" />
-
-               </DataGridFrozenGrid>
-            </Border>
-         </ControlTemplate>
-      </Setter>
-
-      <Style Selector="^:nth-child(even) /template/ Border#ItemBorder">
-         <Setter Property="Background" Value="{DynamicResource DataGridItemBackgroundAlternating}" />
+    <Style Selector="^:nth-child(even) /template/ Border#ItemBorder">
+      <Setter Property="Background" Value="{DynamicResource DataGridItemBackgroundAlternating}" />
+    </Style>
+    <Style Selector="^:invalid">
+      <Style Selector="^ /template/ Rectangle#InvalidVisualElement">
+        <Setter Property="Opacity" Value="0.4" />
       </Style>
-      <Style Selector="^:invalid">
-         <Style Selector="^ /template/ Rectangle#InvalidVisualElement">
-            <Setter Property="Opacity" Value="0.4" />
-         </Style>
-      </Style>
+    </Style>
 
-      <Style Selector="^:selected /template/ Border#ItemBorder">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler DataGridItemBackgroundSelected, SelectionInInactiveWindow}" />
-      </Style>
-   </ControlTheme>
+    <Style Selector="^:selected /template/ Border#ItemBorder">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler DataGridItemBackgroundSelected, SelectionInInactiveWindow}" />
+    </Style>
+  </ControlTheme>
 
-   <!-- RowGroupExpanderButton -->
-   <ControlTheme x:Key="FluentDataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Width="12"
-                    Height="12"
-                    Background="Transparent"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center">
-               <Path Fill="{TemplateBinding Foreground}"
-                     Data="{StaticResource DataGridRowGroupHeaderIconClosedPath}"
-                     HorizontalAlignment="Right"
-                     VerticalAlignment="Center"
-                     Stretch="Uniform" />
-            </Border>
-         </ControlTemplate>
-      </Setter>
-      <Style Selector="^:checked /template/ Path">
-         <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconOpenedPath}" />
-      </Style>
-   </ControlTheme>
+  <!-- RowGroupExpanderButton -->
+  <ControlTheme x:Key="FluentDataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Width="12"
+                Height="12"
+                Background="Transparent"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+          <Path Fill="{TemplateBinding Foreground}"
+                Data="{StaticResource DataGridRowGroupHeaderIconClosedPath}"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Stretch="Uniform" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^:checked /template/ Path">
+      <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconOpenedPath}" />
+    </Style>
+  </ControlTheme>
 
-   <!-- RowGroupHeader -->
-   <ControlTheme x:Key="{x:Type DataGridRowGroupHeader}" TargetType="DataGridRowGroupHeader">
-      <Setter Property="Foreground" Value="{DynamicResource DataGridRowGroupHeaderForegroundBrush}" />
-      <Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackgroundBrush}" />
-      <Setter Property="FontSize" Value="15" />
-      <Setter Property="MinHeight" Value="32" />
-      <Setter Property="Template">
-         <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup">
-            <DataGridFrozenGrid Name="PART_Root"
-                                Background="{TemplateBinding Background}"
-                                MinHeight="{TemplateBinding MinHeight}"
-                                ColumnDefinitions="Auto,Auto,Auto,Auto,*"
-                                RowDefinitions="*,Auto">
+  <!-- RowGroupHeader -->
+  <ControlTheme x:Key="{x:Type DataGridRowGroupHeader}" TargetType="DataGridRowGroupHeader">
+    <Setter Property="Foreground" Value="{DynamicResource DataGridRowGroupHeaderForegroundBrush}" />
+    <Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackgroundBrush}" />
+    <Setter Property="FontSize" Value="15" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="Template">
+      <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup">
+        <DataGridFrozenGrid Name="PART_Root"
+                            Background="{TemplateBinding Background}"
+                            MinHeight="{TemplateBinding MinHeight}"
+                            ColumnDefinitions="Auto,Auto,Auto,Auto,*"
+                            RowDefinitions="*,Auto">
 
-               <Rectangle Name="PART_IndentSpacer"
-                          Grid.Column="1" />
-               <ToggleButton Name="PART_ExpanderButton"
-                             Grid.Column="2"
-                             Width="12"
-                             Height="12"
-                             Margin="12,0,0,0"
-                             Theme="{StaticResource FluentDataGridRowGroupExpanderButtonTheme}"
-                             BorderBrush="{TemplateBinding BorderBrush}"
-                             BorderThickness="{TemplateBinding BorderThickness}"
-                             Background="{TemplateBinding Background}"
-                             CornerRadius="{TemplateBinding CornerRadius}"
-                             IsTabStop="False"
-                             Foreground="{TemplateBinding Foreground}" />
+          <Rectangle Name="PART_IndentSpacer"
+                     Grid.Column="1" />
+          <ToggleButton Name="PART_ExpanderButton"
+                        Grid.Column="2"
+                        Width="12"
+                        Height="12"
+                        Margin="12,0,0,0"
+                        Theme="{StaticResource FluentDataGridRowGroupExpanderButtonTheme}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        IsTabStop="False"
+                        Foreground="{TemplateBinding Foreground}" />
 
-               <StackPanel Grid.Column="3"
-                           Orientation="Horizontal"
-                           VerticalAlignment="Center"
-                           Margin="12,0,0,0">
-                  <TextBlock Name="PART_PropertyNameElement"
-                             Margin="4,0,0,0"
-                             IsVisible="{TemplateBinding IsPropertyNameVisible}"
-                             Foreground="{TemplateBinding Foreground}" />
-                  <TextBlock Margin="4,0,0,0"
-                             Text="{Binding Key}"
-                             Foreground="{TemplateBinding Foreground}" />
-                  <TextBlock Name="PART_ItemCountElement"
-                             Margin="4,0,0,0"
-                             IsVisible="{TemplateBinding IsItemCountVisible}"
-                             Foreground="{TemplateBinding Foreground}" />
-               </StackPanel>
+          <StackPanel Grid.Column="3"
+                      Orientation="Horizontal"
+                      VerticalAlignment="Center"
+                      Margin="12,0,0,0">
+            <TextBlock Name="PART_PropertyNameElement"
+                       Margin="4,0,0,0"
+                       IsVisible="{TemplateBinding IsPropertyNameVisible}"
+                       Foreground="{TemplateBinding Foreground}" />
+            <TextBlock Margin="4,0,0,0"
+                       Text="{Binding Key}"
+                       Foreground="{TemplateBinding Foreground}" />
+            <TextBlock Name="PART_ItemCountElement"
+                       Margin="4,0,0,0"
+                       IsVisible="{TemplateBinding IsItemCountVisible}"
+                       Foreground="{TemplateBinding Foreground}" />
+          </StackPanel>
 
-               <Rectangle Name="CurrencyVisual"
-                          Grid.ColumnSpan="5"
-                          IsVisible="False"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch"
-                          Fill="Transparent"
-                          IsHitTestVisible="False"
-                          Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
-                          StrokeThickness="1" />
-               <Grid Name="FocusVisual"
+          <Rectangle Name="CurrencyVisual"
                      Grid.ColumnSpan="5"
                      IsVisible="False"
-                     IsHitTestVisible="False">
-                  <Rectangle HorizontalAlignment="Stretch"
-                             VerticalAlignment="Stretch"
-                             Fill="Transparent"
-                             IsHitTestVisible="False"
-                             Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
-                             StrokeThickness="2" />
-                  <Rectangle Margin="2"
-                             HorizontalAlignment="Stretch"
-                             VerticalAlignment="Stretch"
-                             Fill="Transparent"
-                             IsHitTestVisible="False"
-                             Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
-                             StrokeThickness="1" />
-               </Grid>
+                     HorizontalAlignment="Stretch"
+                     VerticalAlignment="Stretch"
+                     Fill="Transparent"
+                     IsHitTestVisible="False"
+                     Stroke="{DynamicResource DataGridCurrencyVisualPrimaryBrush}"
+                     StrokeThickness="1" />
+          <Grid Name="FocusVisual"
+                Grid.ColumnSpan="5"
+                IsVisible="False"
+                IsHitTestVisible="False">
+            <Rectangle HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent"
+                       IsHitTestVisible="False"
+                       Stroke="{DynamicResource DataGridCellFocusVisualPrimaryBrush}"
+                       StrokeThickness="2" />
+            <Rectangle Margin="2"
+                       HorizontalAlignment="Stretch"
+                       VerticalAlignment="Stretch"
+                       Fill="Transparent"
+                       IsHitTestVisible="False"
+                       Stroke="{DynamicResource DataGridCellFocusVisualSecondaryBrush}"
+                       StrokeThickness="1" />
+          </Grid>
 
-               <DataGridRowHeader Name="PART_RowHeader"
-                                  Grid.RowSpan="2"
-                                  DataGridFrozenGrid.IsFrozen="True" />
+          <DataGridRowHeader Name="PART_RowHeader"
+                             Grid.RowSpan="2"
+                             DataGridFrozenGrid.IsFrozen="True" />
 
-               <Rectangle Name="PART_BottomGridLine"
-                          Grid.Row="1"
-                          Grid.ColumnSpan="5"
-                          Height="1" />
-            </DataGridFrozenGrid>
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
+          <Rectangle Name="PART_BottomGridLine"
+                     Grid.Row="1"
+                     Grid.ColumnSpan="5"
+                     Height="1" />
+        </DataGridFrozenGrid>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 
-   <!-- DataGrid -->
-   <ControlTheme x:Key="{x:Type DataGrid}" TargetType="DataGrid">
-      <Setter Property="RowBackground" Value="Transparent" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="HeadersVisibility" Value="Column" />
-      <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
-      <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="SelectionMode" Value="Extended" />
-      <Setter Property="GridLinesVisibility" Value="None" />
-      <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
-      <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ScrollBar.AllowAutoHide" Value="False" />
-      <Setter Property="DropLocationIndicatorTemplate">
-         <Template>
-            <Rectangle Fill="{DynamicResource DataGridDropLocationIndicatorBackground}"
-                       Width="2" />
-         </Template>
-      </Setter>
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="DataGridBorder"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}">
-               <Grid ColumnDefinitions="Auto,*,Auto"
-                     RowDefinitions="Auto,*,Auto,Auto"
-                     ClipToBounds="True">
-                  <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
-                                        Theme="{StaticResource DataGridTopLeftColumnHeader}" />
-                  <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
-                                                  Grid.Column="1"
-                                                  Grid.Row="0" Grid.ColumnSpan="2" />
-                  <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
-                             Grid.Row="0" Grid.ColumnSpan="3" Grid.Column="0"
-                             VerticalAlignment="Bottom"
-                             Height="1"
-                             Fill="{DynamicResource DataGridGridLinesBrush}" />
+  <!-- DataGrid -->
+  <ControlTheme x:Key="{x:Type DataGrid}" TargetType="DataGrid">
+    <Setter Property="RowBackground" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="HeadersVisibility" Value="Column" />
+    <Setter Property="HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="SelectionMode" Value="Extended" />
+    <Setter Property="GridLinesVisibility" Value="None" />
+    <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+    <Setter Property="VerticalGridLinesBrush" Value="{DynamicResource DataGridGridLinesBrush}" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ScrollBar.AllowAutoHide" Value="False" />
+    <Setter Property="DropLocationIndicatorTemplate">
+      <Template>
+        <Rectangle Fill="{DynamicResource DataGridDropLocationIndicatorBackground}"
+                   Width="2" />
+      </Template>
+    </Setter>
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="DataGridBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <Grid ColumnDefinitions="Auto,*,Auto"
+                RowDefinitions="Auto,*,Auto,Auto"
+                ClipToBounds="True">
+            <DataGridColumnHeader Name="PART_TopLeftCornerHeader"
+                                  Theme="{StaticResource DataGridTopLeftColumnHeader}" />
+            <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
+                                            Grid.Column="1"
+                                            Grid.Row="0" Grid.ColumnSpan="2" />
+            <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
+                       Grid.Row="0" Grid.ColumnSpan="3" Grid.Column="0"
+                       VerticalAlignment="Bottom"
+                       Height="1"
+                       Fill="{DynamicResource DataGridGridLinesBrush}" />
 
-                  <DataGridRowsPresenter Name="PART_RowsPresenter"
-                                         Grid.Row="1"
-                                         Grid.Column="0"
-                                         ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
-                     <DataGridRowsPresenter.GestureRecognizers>
-                        <ScrollGestureRecognizer CanHorizontallyScroll="True"
-                                                 CanVerticallyScroll="True"
-                                                 IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_RowsPresenter}" />
-                     </DataGridRowsPresenter.GestureRecognizers>
-                  </DataGridRowsPresenter>
-                  <Border Name="PART_ScrollBarsSeparator"
-                          Grid.Row="2"
-                          Grid.Column="2"
-                          Background="{DynamicResource ScrollBarTrackBrush}"
-                          BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                          IsVisible="{TemplateBinding ScrollBar.AllowAutoHide, Converter={x:Static BoolConverters.Not}}">
-                     <Border.BorderThickness>
-                        <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
-                                 Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
-                                 ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
-                     </Border.BorderThickness>
-                  </Border>
-                  <ScrollBar Name="PART_VerticalScrollbar"
-                             Orientation="Vertical"
-                             Grid.Column="2"
-                             Grid.Row="1"
-                             Background="{DynamicResource ScrollBarTrackBrush}"
-                             BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                             BorderThickness="1"
-                             AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
-                             Width="{DynamicResource ScrollBarSize}" />
-
-                  <Grid Name="HorizontalScrollbarGrid"
-                        Grid.Column="1"
-                        Grid.Row="2"
-                        ColumnDefinitions="Auto,*">
-                     <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
-                     <ScrollBar Name="PART_HorizontalScrollbar"
-                                Grid.Column="1"
-                                Orientation="Horizontal"
-                                Background="{DynamicResource ScrollBarTrackBrush}"
-                                BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                                BorderThickness="1"
-                                AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
-                                Height="{DynamicResource ScrollBarSize}" />
-                  </Grid>
-                  <Border Name="PART_DisabledVisualElement"
-                          Grid.ColumnSpan="3" Grid.Column="0"
-                          Grid.Row="0" Grid.RowSpan="4"
-                          IsHitTestVisible="False"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch"
-                          CornerRadius="2"
-                          Background="{DynamicResource DataGridDisabledVisualElementBackground}"
-                          IsVisible="{Binding !$parent[DataGrid].IsEnabled}" />
-               </Grid>
+            <DataGridRowsPresenter Name="PART_RowsPresenter"
+                                   Grid.Row="1"
+                                   Grid.Column="0"
+                                   ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
+              <DataGridRowsPresenter.GestureRecognizers>
+                <ScrollGestureRecognizer CanHorizontallyScroll="True"
+                                         CanVerticallyScroll="True"
+                                         IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_RowsPresenter}" />
+              </DataGridRowsPresenter.GestureRecognizers>
+            </DataGridRowsPresenter>
+            <Border Name="PART_ScrollBarsSeparator"
+                    Grid.Row="2"
+                    Grid.Column="2"
+                    Background="{DynamicResource ScrollBarTrackBrush}"
+                    BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                    IsVisible="{TemplateBinding ScrollBar.AllowAutoHide, Converter={x:Static BoolConverters.Not}}">
+              <Border.BorderThickness>
+                <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
+                         Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
+                         ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
+              </Border.BorderThickness>
             </Border>
-         </ControlTemplate>
-      </Setter>
+            <ScrollBar Name="PART_VerticalScrollbar"
+                       Orientation="Vertical"
+                       Grid.Column="2"
+                       Grid.Row="1"
+                       Background="{DynamicResource ScrollBarTrackBrush}"
+                       BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                       BorderThickness="1"
+                       AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
+                       Width="{DynamicResource ScrollBarSize}" />
 
-      <Style Selector="^:empty-columns">
-         <Style Selector="^ /template/ DataGridColumnHeader#PART_TopLeftCornerHeader">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-         <Style Selector="^ /template/ DataGridColumnHeadersPresenter#PART_ColumnHeadersPresenter">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-         <Style Selector="^ /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
-            <Setter Property="IsVisible" Value="False" />
-         </Style>
-      </Style>
+            <Grid Name="HorizontalScrollbarGrid"
+                  Grid.Column="1"
+                  Grid.Row="2"
+                  ColumnDefinitions="Auto,*">
+              <Rectangle Name="PART_FrozenColumnScrollBarSpacer" />
+              <ScrollBar Name="PART_HorizontalScrollbar"
+                         Grid.Column="1"
+                         Orientation="Horizontal"
+                         Background="{DynamicResource ScrollBarTrackBrush}"
+                         BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                         BorderThickness="1"
+                         AllowAutoHide="{TemplateBinding ScrollBar.AllowAutoHide}"
+                         Height="{DynamicResource ScrollBarSize}" />
+            </Grid>
+            <Border Name="PART_DisabledVisualElement"
+                    Grid.ColumnSpan="3" Grid.Column="0"
+                    Grid.Row="0" Grid.RowSpan="4"
+                    IsHitTestVisible="False"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    CornerRadius="2"
+                    Background="{DynamicResource DataGridDisabledVisualElementBackground}"
+                    IsVisible="{Binding !$parent[DataGrid].IsEnabled}" />
+          </Grid>
+        </Border>
+      </ControlTemplate>
+    </Setter>
 
-      <Style Selector="^ /template/ DataGridRowsPresenter#PART_RowsPresenter">
-         <Setter Property="Grid.RowSpan" Value="2" />
-         <Setter Property="Grid.ColumnSpan" Value="3" />
+    <Style Selector="^:empty-columns">
+      <Style Selector="^ /template/ DataGridColumnHeader#PART_TopLeftCornerHeader">
+        <Setter Property="IsVisible" Value="False" />
       </Style>
-   </ControlTheme>
+      <Style Selector="^ /template/ DataGridColumnHeadersPresenter#PART_ColumnHeadersPresenter">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+      <Style Selector="^ /template/ Rectangle#PART_ColumnHeadersAndRowsSeparator">
+        <Setter Property="IsVisible" Value="False" />
+      </Style>
+    </Style>
+
+    <Style Selector="^ /template/ DataGridRowsPresenter#PART_RowsPresenter">
+      <Setter Property="Grid.RowSpan" Value="2" />
+      <Setter Property="Grid.ColumnSpan" Value="3" />
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -1,300 +1,300 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   x:ClassModifier="internal">
-   <Design.PreviewWith>
-      <StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:ClassModifier="internal">
+  <Design.PreviewWith>
+    <StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>
 
-      <StackPanel Width="400" Height="400" Spacing="20">
-         <EditableComboBox
-            Width="200"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Watermark="test">
-            <EditableComboBoxItem Value="test1" />
-            <EditableComboBoxItem Value="test2" />
-            <EditableComboBoxItem Value="test3" />
-         </EditableComboBox>
+    <StackPanel Width="400" Height="400" Spacing="20">
+      <EditableComboBox
+        Width="200"
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Watermark="test">
+        <EditableComboBoxItem Value="test1" />
+        <EditableComboBoxItem Value="test2" />
+        <EditableComboBoxItem Value="test3" />
+      </EditableComboBox>
 
-         <EditableComboBox
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Watermark="test">
-            <EditableComboBox.InnerLeftContent>
-               <Svg Path="M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z" />
-            </EditableComboBox.InnerLeftContent>
-            <EditableComboBox.InnerRightContent>
-               <Svg Path="M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z" />
-            </EditableComboBox.InnerRightContent>
-            <EditableComboBoxItem Value="test1" />
-            <EditableComboBoxItem Value="test2" />
-            <EditableComboBoxItem Value="test3" />
-         </EditableComboBox>
+      <EditableComboBox
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Watermark="test">
+        <EditableComboBox.InnerLeftContent>
+          <Svg Path="M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z" />
+        </EditableComboBox.InnerLeftContent>
+        <EditableComboBox.InnerRightContent>
+          <Svg Path="M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z" />
+        </EditableComboBox.InnerRightContent>
+        <EditableComboBoxItem Value="test1" />
+        <EditableComboBoxItem Value="test2" />
+        <EditableComboBoxItem Value="test3" />
+      </EditableComboBox>
 
-         <EditableComboBox
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            IsEnabled="False"
-            Watermark="test">
-            <EditableComboBoxItem Value="test" />
-         </EditableComboBox>
-      </StackPanel>
-   </Design.PreviewWith>
+      <EditableComboBox
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        IsEnabled="False"
+        Watermark="test">
+        <EditableComboBoxItem Value="test" />
+      </EditableComboBox>
+    </StackPanel>
+  </Design.PreviewWith>
 
-   <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
-   <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
-   <Thickness x:Key="EditableComboBoxItemPadding">10,3</Thickness>
-   <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
-   <!--
+  <Thickness x:Key="EditableComboBoxBorderThickness">1</Thickness>
+  <Thickness x:Key="EditableComboBoxPadding">10,5,0,5</Thickness>
+  <Thickness x:Key="EditableComboBoxItemPadding">10,3</Thickness>
+  <x:Double x:Key="EditableComboBoxMinWidth">100</x:Double>
+  <!--
         Note: On the actual current MacOs Theme, the height is 20 and dropdown items have a height of 18. 
         22/20 is here to match the rest of the styles we have in our MacOs theme instead.
         - sbergerondrouin 2025-04-24
     -->
-   <x:Double x:Key="EditableComboBoxHeight">22</x:Double>
-   <x:Double x:Key="EditableComboBoxItemsHeight">20</x:Double>
+  <x:Double x:Key="EditableComboBoxHeight">22</x:Double>
+  <x:Double x:Key="EditableComboBoxItemsHeight">20</x:Double>
 
-   <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" BasedOn="{StaticResource {x:Type EditableComboBoxItem}}">
-      <Setter Property="IsHitTestVisible" Value="True" />
-      <Setter Property="Margin" Value="4 0" />
+  <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" BasedOn="{StaticResource {x:Type EditableComboBoxItem}}">
+    <Setter Property="IsHitTestVisible" Value="True" />
+    <Setter Property="Margin" Value="4 0" />
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="Padding" Value="10 0 10 2" />
+
+    <Style Selector="^ /template/ Border#PART_Background">
       <Setter Property="CornerRadius" Value="4" />
-      <Setter Property="Padding" Value="10 0 10 2" />
+    </Style>
 
-      <Style Selector="^ /template/ Border#PART_Background">
-         <Setter Property="CornerRadius" Value="4" />
-      </Style>
+    <Style
+      Selector="^:pointerover /template/ Border#PART_Background, ^[IsSelected=True] /template/ Border#PART_Background">
+      <Setter Property="Background" Value="{DynamicResource EditableComboBoxItemHoverBackground}" />
+    </Style>
+    <Style
+      Selector="^:pointerover /template/ TextBlock#PART_Text, ^[IsSelected=True] /template/ TextBlock#PART_Text">
+      <Setter Property="Foreground" Value="#FFF" />
+    </Style>
+  </ControlTheme>
 
-      <Style
-         Selector="^:pointerover /template/ Border#PART_Background, ^[IsSelected=True] /template/ Border#PART_Background">
-         <Setter Property="Background" Value="{DynamicResource EditableComboBoxItemHoverBackground}" />
-      </Style>
-      <Style
-         Selector="^:pointerover /template/ TextBlock#PART_Text, ^[IsSelected=True] /template/ TextBlock#PART_Text">
-         <Setter Property="Foreground" Value="#FFF" />
-      </Style>
-   </ControlTheme>
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}"
+                TargetType="EditableComboBox+InnerComboBox">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="MaxDropDownHeight" Value="504" />
+    <Setter Property="Foreground"
+            Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Background"
+            Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderBrush"
+            Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="BorderThickness"
+            Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="CornerRadius"
+            Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="Padding"
+            Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="MinHeight"
+            Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerLeftContent"
+            Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="InnerRightContent"
+            Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
 
-   <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}"
-                 TargetType="EditableComboBox+InnerComboBox">
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="MaxDropDownHeight" Value="504" />
-      <Setter Property="Foreground"
-              Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Background"
-              Value="{Binding Background, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderBrush"
-              Value="{Binding BorderBrush, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="BorderThickness"
-              Value="{Binding BorderThickness, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="CornerRadius"
-              Value="{Binding CornerRadius, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="Padding"
-              Value="{Binding Padding, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="MinHeight"
-              Value="{Binding MinHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerLeftContent"
-              Value="{Binding InnerLeftContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="InnerRightContent"
-              Value="{Binding InnerRightContent, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
-      <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
-      <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-      <Setter Property="VerticalContentAlignment" Value="Center" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DataValidationErrors ClipToBounds="False">
+          <Panel ClipToBounds="False">
+            <Border
+              Name="BorderElement"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{DynamicResource TextBoxBorderBrush}"
+              BorderThickness="1 1 1 0"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              MinWidth="{TemplateBinding MinWidth}"
+              MinHeight="{TemplateBinding MinHeight}" />
 
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <DataValidationErrors ClipToBounds="False">
-               <Panel ClipToBounds="False">
-                  <Border
-                     Name="BorderElement"
-                     Background="{TemplateBinding Background}"
-                     BorderBrush="{DynamicResource TextBoxBorderBrush}"
-                     BorderThickness="1 1 1 0"
-                     CornerRadius="{TemplateBinding CornerRadius}"
-                     MinWidth="{TemplateBinding MinWidth}"
-                     MinHeight="{TemplateBinding MinHeight}" />
+            <Grid ColumnDefinitions="Auto,*,24,Auto" HorizontalAlignment="Stretch" ClipToBounds="False">
+              <ItemsControl
+                Grid.Column="0"
+                Name="PART_InnerLeftContent"
+                ItemsSource="{TemplateBinding InnerLeftContent}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="4 2 0 2" Spacing="2" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+              </ItemsControl>
 
-                  <Grid ColumnDefinitions="Auto,*,24,Auto" HorizontalAlignment="Stretch" ClipToBounds="False">
-                     <ItemsControl
-                        Grid.Column="0"
-                        Name="PART_InnerLeftContent"
-                        ItemsSource="{TemplateBinding InnerLeftContent}">
-                        <ItemsControl.ItemsPanel>
-                           <ItemsPanelTemplate>
-                              <StackPanel Orientation="Horizontal" Margin="4 2 0 2" Spacing="2" />
-                           </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                     </ItemsControl>
+              <ContentPresenter x:Name="PART_TextBoxPresenter" Grid.Column="1" />
 
-                     <ContentPresenter x:Name="PART_TextBoxPresenter" Grid.Column="1" />
+              <Border
+                Name="DropDownGlyphBackground"
+                Grid.Column="2"
+                Width="17"
+                Height="16"
+                CornerRadius="{DynamicResource ControlCornerRadius}"
+                HorizontalAlignment="Right"
+                Margin="0 0 1 0"
+                VerticalAlignment="Center">
+                <PathIcon
+                  Name="DropDownGlyph"
+                  UseLayoutRounding="False"
+                  IsHitTestVisible="False"
+                  Height="8"
+                  Width="9"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Foreground="#FFF"
+                  Data="{StaticResource ChevronPath}">
+                  <PathIcon.RenderTransform>
+                    <ScaleTransform ScaleY="-1" />
+                  </PathIcon.RenderTransform>
+                </PathIcon>
+              </Border>
 
-                     <Border
-                        Name="DropDownGlyphBackground"
-                        Grid.Column="2"
-                        Width="17"
-                        Height="16"
-                        CornerRadius="{DynamicResource ControlCornerRadius}"
-                        HorizontalAlignment="Right"
-                        Margin="0 0 1 0"
-                        VerticalAlignment="Center">
-                        <PathIcon
-                           Name="DropDownGlyph"
-                           UseLayoutRounding="False"
-                           IsHitTestVisible="False"
-                           Height="8"
-                           Width="9"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           Foreground="#FFF"
-                           Data="{StaticResource ChevronPath}">
-                           <PathIcon.RenderTransform>
-                              <ScaleTransform ScaleY="-1" />
-                           </PathIcon.RenderTransform>
-                        </PathIcon>
-                     </Border>
+              <ItemsControl
+                Grid.Column="3"
+                Name="PART_InnerRightContent"
+                ItemsSource="{TemplateBinding InnerRightContent}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" Margin="0 2 2 2" Spacing="2" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+              </ItemsControl>
 
-                     <ItemsControl
-                        Grid.Column="3"
-                        Name="PART_InnerRightContent"
-                        ItemsSource="{TemplateBinding InnerRightContent}">
-                        <ItemsControl.ItemsPanel>
-                           <ItemsPanelTemplate>
-                              <StackPanel Orientation="Horizontal" Margin="0 2 2 2" Spacing="2" />
-                           </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                     </ItemsControl>
-
-                     <Popup
-                        Name="PART_Popup"
-                        WindowManagerAddShadowHint="False"
-                        IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
-                        MinWidth="{AddBinding
+              <Popup
+                Name="PART_Popup"
+                WindowManagerAddShadowHint="False"
+                IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+                MinWidth="{AddBinding
                                     {Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}},
                                     12
                                 }"
-                        MaxWidth="{MultiplyBinding
+                MaxWidth="{MultiplyBinding
                                     {AddBinding {Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}, 12},
                                     2
                                 }"
-                        MaxHeight="{TemplateBinding MaxDropDownHeight}"
-                        Placement="AnchorAndGravity"
-                        PlacementAnchor="BottomLeft"
-                        PlacementGravity="BottomRight"
-                        HorizontalAlignment="Stretch"
-                        HorizontalOffset="-6"
-                        VerticalOffset="0"
-                        IsLightDismissEnabled="True"
-                        OverlayDismissEventPassThrough="True"
-                        InheritsTransform="True"
-                        ClipToBounds="False">
-                        <Border
-                           x:Name="PopupBorder"
-                           Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
-                           BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                           BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
-                           Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
-                           HorizontalAlignment="Stretch"
-                           BoxShadow="{DynamicResource ComboBoxBoxShadow}"
-                           Margin="1 0 1 1"
-                           CornerRadius="10">
-                           <ScrollViewer
-                              CornerRadius="10"
-                              HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                              IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
-                              <ItemsPresenter
-                                 Name="PART_ItemsPresenter"
-                                 Margin="{DynamicResource ComboBoxDropdownContentMargin}"
-                                 ItemsPanel="{TemplateBinding ItemsPanel}">
-                                 <ItemsPresenter.Styles>
-                                    <Style Selector="StackPanel">
-                                       <Setter Property="Spacing" Value="1" />
-                                    </Style>
-                                 </ItemsPresenter.Styles>
-                              </ItemsPresenter>
-                           </ScrollViewer>
-                        </Border>
-                     </Popup>
-                  </Grid>
+                MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                Placement="AnchorAndGravity"
+                PlacementAnchor="BottomLeft"
+                PlacementGravity="BottomRight"
+                HorizontalAlignment="Stretch"
+                HorizontalOffset="-6"
+                VerticalOffset="0"
+                IsLightDismissEnabled="True"
+                OverlayDismissEventPassThrough="True"
+                InheritsTransform="True"
+                ClipToBounds="False">
+                <Border
+                  x:Name="PopupBorder"
+                  Background="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"
+                  BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                  BorderThickness="{DynamicResource ComboBoxDropdownBorderThickness}"
+                  Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+                  HorizontalAlignment="Stretch"
+                  BoxShadow="{DynamicResource ComboBoxBoxShadow}"
+                  Margin="1 0 1 1"
+                  CornerRadius="10">
+                  <ScrollViewer
+                    CornerRadius="10"
+                    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                    IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
+                    <ItemsPresenter
+                      Name="PART_ItemsPresenter"
+                      Margin="{DynamicResource ComboBoxDropdownContentMargin}"
+                      ItemsPanel="{TemplateBinding ItemsPanel}">
+                      <ItemsPresenter.Styles>
+                        <Style Selector="StackPanel">
+                          <Setter Property="Spacing" Value="1" />
+                        </Style>
+                      </ItemsPresenter.Styles>
+                    </ItemsPresenter>
+                  </ScrollViewer>
+                </Border>
+              </Popup>
+            </Grid>
 
-                  <Border Name="BottomBorder"
-                          BorderThickness="0 0 0 0.6"
-                          BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
-                          BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          Margin="0.6 0  " />
-                  <Border Name="BottomBorderShadow"
-                          BorderThickness="0 0 0 0.6"
-                          BorderBrush="{TemplateBinding BorderBrush}"
-                          CornerRadius="{TemplateBinding CornerRadius}"
-                          BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                          Margin="0.6 0 0.6 -0.6 " />
-                  <Border Name="FocusBorderElement"
-                          Margin="-3"
-                          BorderThickness="4"
-                          CornerRadius="5" />
-               </Panel>
-            </DataValidationErrors>
-         </ControlTemplate>
-      </Setter>
+            <Border Name="BottomBorder"
+                    BorderThickness="0 0 0 0.6"
+                    BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
+                    BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    Margin="0.6 0  " />
+            <Border Name="BottomBorderShadow"
+                    BorderThickness="0 0 0 0.6"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    CornerRadius="{TemplateBinding CornerRadius}"
+                    BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                    Margin="0.6 0 0.6 -0.6 " />
+            <Border Name="FocusBorderElement"
+                    Margin="-3"
+                    BorderThickness="4"
+                    CornerRadius="5" />
+          </Panel>
+        </DataValidationErrors>
+      </ControlTemplate>
+    </Setter>
 
+    <Style Selector="^ /template/ Border#DropDownGlyphBackground">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundRecessedBrush}" />
+    </Style>
+
+    <!-- Error State -->
+    <Style Selector="^:error /template/ Border#Background">
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    </Style>
+
+    <!--  Focused State  -->
+    <Style Selector="^:focus-within">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderFocusBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderFocusBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">
+      <Setter Property="Opacity" Value="0.95" />
+    </Style>
+
+    <Style Selector="^:dropdownopen">
       <Style Selector="^ /template/ Border#DropDownGlyphBackground">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler ControlBackgroundAccentRaisedBrush, ControlBackgroundRecessedBrush}" />
+        <Setter Property="Opacity" Value="0.9" />
       </Style>
+    </Style>
 
-      <!-- Error State -->
-      <Style Selector="^:error /template/ Border#Background">
-         <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    <!--  Disabled State  -->
+    <Style Selector="^:disabled">
+      <Style Selector="^ /template/ Border#Background">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
       </Style>
-
-      <!--  Focused State  -->
-      <Style Selector="^:focus-within">
-         <Style Selector="^ /template/ Border#FocusBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderFocusBrush}" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderFocusBrush}" />
-         </Style>
+      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
+        <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
       </Style>
-
-      <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">
-         <Setter Property="Opacity" Value="0.95" />
+      <Style Selector="^ /template/ Border#DropDownGlyphBackground">
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundRecessedBrush}" />
       </Style>
+    </Style>
+  </ControlTheme>
 
-      <Style Selector="^:dropdownopen">
-         <Style Selector="^ /template/ Border#DropDownGlyphBackground">
-            <Setter Property="Opacity" Value="0.9" />
-         </Style>
-      </Style>
+  <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox" BasedOn="{StaticResource {x:Type EditableComboBox}}">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
+    <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="Padding" Value="4 3 2 3" />
+    <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
 
-      <!--  Disabled State  -->
-      <Style Selector="^:disabled">
-         <Style Selector="^ /template/ Border#Background">
-            <Setter Property="Background" Value="{DynamicResource ComboBoxBackgroundDisabled}" />
-            <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrushDisabled}" />
-         </Style>
-         <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-            <Setter Property="Foreground" Value="{DynamicResource ComboBoxDropDownGlyphForegroundDisabled}" />
-         </Style>
-         <Style Selector="^ /template/ Border#DropDownGlyphBackground">
-            <Setter Property="Background" Value="{DynamicResource ControlBackgroundRecessedBrush}" />
-         </Style>
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type EditableComboBox}" TargetType="EditableComboBox" BasedOn="{StaticResource {x:Type EditableComboBox}}">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
-      <Setter Property="CaretBrush" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="Padding" Value="4 3 2 3" />
-      <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
-      <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
-
-      <Setter Property="ClipToBounds" Value="False" />
-   </ControlTheme>
+    <Setter Property="ClipToBounds" Value="False" />
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/GridSplitter.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/GridSplitter.axaml
@@ -59,7 +59,7 @@
       <Setter Property="Width" Value="{x:Static sys:Double.NaN}" />
       <Setter Property="Height" Value="1" />
     </Style>
-    
+
     <!-- Tabbing focus -->
     <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Rectangle#VisualLineMarker">
@@ -68,7 +68,7 @@
       <Style Selector="^[ResizeDirection=Columns] /template/ Rectangle#VisualLineMarker">
         <Setter Property="Width" Value="7" />
       </Style>
-     <Style Selector="^[ResizeDirection=Rows] /template/ Rectangle#VisualLineMarker">
+      <Style Selector="^[ResizeDirection=Rows] /template/ Rectangle#VisualLineMarker">
         <Setter Property="Height" Value="3.5" />
       </Style>
     </Style>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
@@ -2,339 +2,339 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=System.Runtime">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <DockPanel Height="200">
-         <Menu DockPanel.Dock="Top" VerticalAlignment="Top"
-               Classes="MacOS_Theme_MenuItemIconOnly MacOS_Theme_MenuLabelBelowIcon">
-            <MenuItem Header="Add">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-               <MenuItem Header="User" />
-               <MenuItem Header="Group" />
-            </MenuItem>
-            <MenuItem Header="-" />
-            <MenuItem Header="Test">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-            </MenuItem>
-            <MenuItem Header="Disabled" IsEnabled="False">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-            </MenuItem>
-         </Menu>
-         <Menu DockPanel.Dock="Bottom" VerticalAlignment="Bottom"
-               Classes="MacOS_Theme_MenuOpensAbove MacOS_Theme_MenuLabelBelowIcon">
-            <MenuItem Header="_Standard">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-               <MenuItem Header="_Standard" />
-               <MenuItem Header="_Standard" />
-            </MenuItem>
-            <MenuItem Header="-" />
-            <MenuItem Header="Focus session" IsSelected="True">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-            </MenuItem>
-            <MenuItem Header="Copy username and password" IsSelected="True">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-            </MenuItem>
-            <MenuItem Header="Disabled" IsEnabled="False">
-               <MenuItem.Icon>
-                  <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
-               </MenuItem.Icon>
-               <MenuItem Header="_Standard" />
-            </MenuItem>
-         </Menu>
-         <Border Background="Gainsboro" />
-      </DockPanel>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <DockPanel Height="200">
+      <Menu DockPanel.Dock="Top" VerticalAlignment="Top"
+            Classes="MacOS_Theme_MenuItemIconOnly MacOS_Theme_MenuLabelBelowIcon">
+        <MenuItem Header="Add">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+          <MenuItem Header="User" />
+          <MenuItem Header="Group" />
+        </MenuItem>
+        <MenuItem Header="-" />
+        <MenuItem Header="Test">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Disabled" IsEnabled="False">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+      </Menu>
+      <Menu DockPanel.Dock="Bottom" VerticalAlignment="Bottom"
+            Classes="MacOS_Theme_MenuOpensAbove MacOS_Theme_MenuLabelBelowIcon">
+        <MenuItem Header="_Standard">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+          <MenuItem Header="_Standard" />
+          <MenuItem Header="_Standard" />
+        </MenuItem>
+        <MenuItem Header="-" />
+        <MenuItem Header="Focus session" IsSelected="True">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Copy username and password" IsSelected="True">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Disabled" IsEnabled="False">
+          <MenuItem.Icon>
+            <Svg Path="/Accents/Assets/TestIconForDesignPreview.svg" />
+          </MenuItem.Icon>
+          <MenuItem Header="_Standard" />
+        </MenuItem>
+      </Menu>
+      <Border Background="Gainsboro" />
+    </DockPanel>
+  </Design.PreviewWith>
 
-   <!-- TODO: Consider refactoring with separate ControlThemes for the different Menu types 
+  <!-- TODO: Consider refactoring with separate ControlThemes for the different Menu types 
        (instead of multiple individual variations on the property level) -->
-   <ControlTheme x:Key="FluentTopLevelMenuItem" TargetType="MenuItem">
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="FontSize">
-         <Setter.Value>
-            <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                          ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-               <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-               <Binding Source="{StaticResource MenuHeaderFontSizeSmall}" />
-               <Binding Source="{StaticResource ControlFontSize}" />
-            </MultiBinding>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="Padding">
-         <Setter.Value>
-            <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                          ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-               <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-               <Binding Source="{StaticResource MenuToolBarItemPadding}" />
-               <Binding Source="{StaticResource MenuItemPadding}" />
-            </MultiBinding>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Foreground" Value="{DynamicResource MenuItemForegroundBrush}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Name="PART_LayoutRoot"
-                    Padding="{TemplateBinding Padding}"
-                    Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    VerticalAlignment="Top">
-               <Panel>
-                  <Border Name="MenuItemActiveBackground"
+  <ControlTheme x:Key="FluentTopLevelMenuItem" TargetType="MenuItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="FontSize">
+      <Setter.Value>
+        <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+          <Binding Source="{StaticResource MenuHeaderFontSizeSmall}" />
+          <Binding Source="{StaticResource ControlFontSize}" />
+        </MultiBinding>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Padding">
+      <Setter.Value>
+        <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+          <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+          <Binding Source="{StaticResource MenuToolBarItemPadding}" />
+          <Binding Source="{StaticResource MenuItemPadding}" />
+        </MultiBinding>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MenuItemForegroundBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_LayoutRoot"
+                Padding="{TemplateBinding Padding}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                VerticalAlignment="Top">
+          <Panel>
+            <Border Name="MenuItemActiveBackground"
+                    Background="Transparent"
+                    CornerRadius="{StaticResource SelectionCornerRadius}"
+                    Margin="{DynamicResource MenuItemActiveBackgroundMargin}">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                              ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                  <Binding Source="{x:False}" />
+                  <Binding Source="{x:True}" />
+                </MultiBinding>
+              </Border.IsVisible>
+            </Border>
+            <StackPanel>
+              <StackPanel.Orientation>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                              ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                  <Binding Source="{x:Static Orientation.Vertical}" />
+                  <Binding Source="{x:Static Orientation.Horizontal}" />
+                </MultiBinding>
+              </StackPanel.Orientation>
+              <Border Name="FlexiblePaddingIconBorder"
+                      HorizontalAlignment="Center"
+                      Background="Transparent">
+                <Border.Padding>
+                  <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                    <Binding Source="{StaticResource MenuToolBarItemIconPadding}" />
+                    <Binding Source="{StaticResource MenuItemIconPadding}" />
+                  </MultiBinding>
+                </Border.Padding>
+                <Panel>
+                  <Border Name="ToolBarItemActiveBackground"
                           Background="Transparent"
                           CornerRadius="{StaticResource SelectionCornerRadius}"
-                          Margin="{DynamicResource MenuItemActiveBackgroundMargin}">
-                     <Border.IsVisible>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                           <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                           <Binding Source="{x:False}" />
-                           <Binding Source="{x:True}" />
-                        </MultiBinding>
-                     </Border.IsVisible>
+                          Margin="{DynamicResource MenuToolBarItemActiveBackgroundMargin}">
+                    <Border.IsVisible>
+                      <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                    ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                        <Binding Source="{x:True}" />
+                        <Binding Source="{x:False}" />
+                      </MultiBinding>
+                    </Border.IsVisible>
                   </Border>
-                  <StackPanel>
-                     <StackPanel.Orientation>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                           <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                           <Binding Source="{x:Static Orientation.Vertical}" />
-                           <Binding Source="{x:Static Orientation.Horizontal}" />
-                        </MultiBinding>
-                     </StackPanel.Orientation>
-                     <Border Name="FlexiblePaddingIconBorder"
-                             HorizontalAlignment="Center"
-                             Background="Transparent">
-                        <Border.Padding>
-                           <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                         ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                              <Binding Source="{StaticResource MenuToolBarItemIconPadding}" />
-                              <Binding Source="{StaticResource MenuItemIconPadding}" />
-                           </MultiBinding>
-                        </Border.Padding>
-                        <Panel>
-                           <Border Name="ToolBarItemActiveBackground"
-                                   Background="Transparent"
-                                   CornerRadius="{StaticResource SelectionCornerRadius}"
-                                   Margin="{DynamicResource MenuToolBarItemActiveBackgroundMargin}">
-                              <Border.IsVisible>
-                                 <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                               ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                                    <Binding Source="{x:True}" />
-                                    <Binding Source="{x:False}" />
-                                 </MultiBinding>
-                              </Border.IsVisible>
-                           </Border>
-                           <StackPanel
-                              Orientation="Horizontal"
-                              VerticalAlignment="Center"
+                  <StackPanel
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    ToolTip.Tip="{TemplateBinding Header}">
+                    <ToolTip.ServiceEnabled>
+                      <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                    ConverterParameter="MacOS_Theme_MenuItemIconOnly">
+                        <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                        <Binding Source="{x:True}" />
+                        <Binding Source="{x:False}" />
+                      </MultiBinding>
+                    </ToolTip.ServiceEnabled>
+                    <ContentPresenter Name="PART_IconPresenter"
+                                      Content="{TemplateBinding Icon}" />
+                    <Panel Name="PART_ChevronPanel">
+                      <Border Name="PART_ChevronBorder" Margin="3 0 0 0 ">
+                        <Path Name="PART_ChevronPath"
+                              Data="{StaticResource ChevronPath}"
+                              Width="{StaticResource TreeViewItemChevronSize}"
+                              Height="{StaticResource TreeViewItemChevronSize}"
+                              Fill="{TemplateBinding Foreground}"
+                              Stretch="Uniform"
                               HorizontalAlignment="Center"
-                              ToolTip.Tip="{TemplateBinding Header}">
-                              <ToolTip.ServiceEnabled>
-                                 <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                               ConverterParameter="MacOS_Theme_MenuItemIconOnly">
-                                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                                    <Binding Source="{x:True}" />
-                                    <Binding Source="{x:False}" />
-                                 </MultiBinding>
-                              </ToolTip.ServiceEnabled>
-                              <ContentPresenter Name="PART_IconPresenter"
-                                                Content="{TemplateBinding Icon}" />
-                              <Panel Name="PART_ChevronPanel">
-                                 <Border Name="PART_ChevronBorder" Margin="3 0 0 0 ">
-                                    <Path Name="PART_ChevronPath"
-                                          Data="{StaticResource ChevronPath}"
-                                          Width="{StaticResource TreeViewItemChevronSize}"
-                                          Height="{StaticResource TreeViewItemChevronSize}"
-                                          Fill="{TemplateBinding Foreground}"
-                                          Stretch="Uniform"
-                                          HorizontalAlignment="Center"
-                                          VerticalAlignment="Center">
-                                       <Path.RenderTransform>
-                                          <TransformGroup>
-                                             <RotateTransform Angle="180" />
-                                          </TransformGroup>
-                                       </Path.RenderTransform>
-                                       <Path.IsVisible>
-                                          <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                                        ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                                             <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                                             <Binding Source="{x:True}" />
-                                             <Binding Source="{x:False}" />
-                                          </MultiBinding>
-                                       </Path.IsVisible>
-                                    </Path>
-                                 </Border>
-                              </Panel>
-                           </StackPanel>
-                        </Panel>
-                     </Border>
-                     <ContentPresenter Name="PART_HeaderPresenter"
-                                       Content="{TemplateBinding Header}"
-                                       ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                       MinWidth="{TemplateBinding MinWidth}"
-                                       MaxWidth="{TemplateBinding MaxWidth}"
-                                       VerticalAlignment="Center"
-                                       HorizontalAlignment="Center"
-                                       TextWrapping="Wrap"
-                                       HorizontalContentAlignment="Center"
-                                       TextAlignment="Center"
-                                       RecognizesAccessKey="True"
-                                       Classes="TopLevelMenuItem">
-                        <ContentPresenter.IsVisible>
-                           <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                         ConverterParameter="MacOS_Theme_MenuItemIconOnly">
+                              VerticalAlignment="Center">
+                          <Path.RenderTransform>
+                            <TransformGroup>
+                              <RotateTransform Angle="180" />
+                            </TransformGroup>
+                          </Path.RenderTransform>
+                          <Path.IsVisible>
+                            <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                          ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
                               <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                              <Binding Source="{x:False}" />
                               <Binding Source="{x:True}" />
-                           </MultiBinding>
-                        </ContentPresenter.IsVisible>
-                     </ContentPresenter>
-
+                              <Binding Source="{x:False}" />
+                            </MultiBinding>
+                          </Path.IsVisible>
+                        </Path>
+                      </Border>
+                    </Panel>
                   </StackPanel>
-                  <Popup Name="PART_Popup"
-                         WindowManagerAddShadowHint="False"
-                         MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
-                         IsLightDismissEnabled="True"
-                         IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
-                         Placement="BottomEdgeAlignedLeft"
-                         HorizontalOffset="{DynamicResource MenuPopupHorizontalOffset}"
-                         OverlayInputPassThroughElement="{Binding $parent[Menu]}">
-                     <Popup.VerticalOffset>
-                        <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
-                                      ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
-                           <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
-                           <Binding Source="{StaticResource MenuToolBarPopupVerticalOffset}" />
-                           <Binding Source="{StaticResource MenuPopupVerticalOffset}" />
-                        </MultiBinding>
-                     </Popup.VerticalOffset>
-                     <Border Margin="{StaticResource PopupMargin} "
-                             Background="{DynamicResource PopupBackgroundBrush}"
-                             BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                             BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                             Padding="{DynamicResource MenuFlyoutPadding}"
-                             MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                             MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
-                             HorizontalAlignment="Stretch"
-                             BoxShadow="{DynamicResource PopupShadow}"
-                             CornerRadius="{DynamicResource LayoutCornerRadius}">
-                        <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
-                           <ItemsPresenter Name="PART_ItemsPresenter"
-                                           ItemsPanel="{TemplateBinding ItemsPanel}"
-                                           Margin="{DynamicResource MenuFlyoutScrollerMargin}"
-                                           Grid.IsSharedSizeScope="True" />
-                        </ScrollViewer>
-                     </Border>
-                  </Popup>
-               </Panel>
-            </Border>
-         </ControlTemplate>
-      </Setter>
+                </Panel>
+              </Border>
+              <ContentPresenter Name="PART_HeaderPresenter"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                MinWidth="{TemplateBinding MinWidth}"
+                                MaxWidth="{TemplateBinding MaxWidth}"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                TextWrapping="Wrap"
+                                HorizontalContentAlignment="Center"
+                                TextAlignment="Center"
+                                RecognizesAccessKey="True"
+                                Classes="TopLevelMenuItem">
+                <ContentPresenter.IsVisible>
+                  <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                ConverterParameter="MacOS_Theme_MenuItemIconOnly">
+                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                    <Binding Source="{x:False}" />
+                    <Binding Source="{x:True}" />
+                  </MultiBinding>
+                </ContentPresenter.IsVisible>
+              </ContentPresenter>
 
-      <!-- Not working -> handled in Styles.axaml -->
-      <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg"> -->
-      <!--   <Setter Property="Css" Value=".st0 {fill : #9500C3; }" /> -->
-      <!-- </Style> -->
-      <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter:empty">
-         <Setter Property="IsVisible" Value="False" />
-         <Setter Property="Width" Value="0" />
-         <Setter Property="Height" Value="0" />
-      </Style>
+            </StackPanel>
+            <Popup Name="PART_Popup"
+                   WindowManagerAddShadowHint="False"
+                   MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
+                   IsLightDismissEnabled="True"
+                   IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
+                   Placement="BottomEdgeAlignedLeft"
+                   HorizontalOffset="{DynamicResource MenuPopupHorizontalOffset}"
+                   OverlayInputPassThroughElement="{Binding $parent[Menu]}">
+              <Popup.VerticalOffset>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                              ConverterParameter="MacOS_Theme_MenuLabelBelowIcon">
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Menu}" Path="Classes" />
+                  <Binding Source="{StaticResource MenuToolBarPopupVerticalOffset}" />
+                  <Binding Source="{StaticResource MenuPopupVerticalOffset}" />
+                </MultiBinding>
+              </Popup.VerticalOffset>
+              <Border Margin="{StaticResource PopupMargin} "
+                      Background="{DynamicResource PopupBackgroundBrush}"
+                      BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                      BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
+                      Padding="{DynamicResource MenuFlyoutPadding}"
+                      MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
+                      MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+                      HorizontalAlignment="Stretch"
+                      BoxShadow="{DynamicResource PopupShadow}"
+                      CornerRadius="{DynamicResource LayoutCornerRadius}">
+                <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
+                  <ItemsPresenter Name="PART_ItemsPresenter"
+                                  ItemsPanel="{TemplateBinding ItemsPanel}"
+                                  Margin="{DynamicResource MenuFlyoutScrollerMargin}"
+                                  Grid.IsSharedSizeScope="True" />
+                </ScrollViewer>
+              </Border>
+            </Popup>
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
 
-      <Style Selector="^:separator">
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Separator
-                  Height="{x:Static sys:Double.NaN}"
-                  Width="{DynamicResource MenuFlyoutSeparatorThemeHeight}"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Stretch"
-                  Margin="4 1 4 1" />
-            </ControlTemplate>
-         </Setter>
-      </Style>
+    <!-- Not working -> handled in Styles.axaml -->
+    <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg"> -->
+    <!--   <Setter Property="Css" Value=".st0 {fill : #9500C3; }" /> -->
+    <!-- </Style> -->
+    <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter:empty">
+      <Setter Property="IsVisible" Value="False" />
+      <Setter Property="Width" Value="0" />
+      <Setter Property="Height" Value="0" />
+    </Style>
 
-      <Style Selector="^:open, ^:pointerover, ^:focus-visible">
-         <Style Selector="^ /template/ Border#MenuItemActiveBackground">
-            <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:pressed">
-         <Style Selector="^ /template/ Border#MenuItemActiveBackground">
-            <Setter Property="Background" Value="{DynamicResource LayoutBackgroundHighBrush}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:open, ^:pointerover, ^:focus-visible">
-         <Style Selector="^ /template/ Border#ToolBarItemActiveBackground">
-            <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:pressed">
-         <Style Selector="^ /template/ Border#ToolBarItemActiveBackground">
-            <Setter Property="Background" Value="{DynamicResource LayoutBackgroundHighBrush}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:empty /template/ Border#ToolBarItemActiveBackground">
-         <Setter Property="Margin" Value="-13 -4" />
-      </Style>
-
-      <Style Selector="^:empty /template/ Panel#PART_ChevronPanel">
-         <Setter Property="IsVisible" Value="False" />
-      </Style>
-
-      <Style Selector="^:disabled">
-         <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
-            <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
-         </Style>
-         <Style Selector="^ /template/ Path#PART_ChevronPath">
-            <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
-         </Style>
-         <!-- Not working -> handled in Styles.axaml -->
-         <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg:disabled"> -->
-         <!--   <Setter Property="Css" Value=".st0 {fill : #dddddd; }" /> -->
-         <!-- </Style> -->
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type Menu}" TargetType="Menu">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="ItemContainerTheme" Value="{StaticResource FluentTopLevelMenuItem}" />
-      <Setter Property="Padding" Value="{DynamicResource MenuBarPadding}" />
+    <Style Selector="^:separator">
       <Setter Property="Template">
-         <ControlTemplate>
-            <Border Background="{TemplateBinding Background}"
-                    BorderBrush="{TemplateBinding BorderBrush}"
-                    BorderThickness="{TemplateBinding BorderThickness}"
-                    CornerRadius="{TemplateBinding CornerRadius}"
-                    HorizontalAlignment="Stretch"
-                    Padding="{TemplateBinding Padding}">
-               <ItemsPresenter Name="PART_ItemsPresenter"
-                               ItemsPanel="{TemplateBinding ItemsPanel}"
-                               VerticalAlignment="Stretch"
-                               KeyboardNavigation.TabNavigation="Continue" />
-            </Border>
-         </ControlTemplate>
+        <ControlTemplate>
+          <Separator
+            Height="{x:Static sys:Double.NaN}"
+            Width="{DynamicResource MenuFlyoutSeparatorThemeHeight}"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Stretch"
+            Margin="4 1 4 1" />
+        </ControlTemplate>
       </Setter>
-   </ControlTheme>
+    </Style>
+
+    <Style Selector="^:open, ^:pointerover, ^:focus-visible">
+      <Style Selector="^ /template/ Border#MenuItemActiveBackground">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ Border#MenuItemActiveBackground">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundHighBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:open, ^:pointerover, ^:focus-visible">
+      <Style Selector="^ /template/ Border#ToolBarItemActiveBackground">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ Border#ToolBarItemActiveBackground">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundHighBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:empty /template/ Border#ToolBarItemActiveBackground">
+      <Setter Property="Margin" Value="-13 -4" />
+    </Style>
+
+    <Style Selector="^:empty /template/ Panel#PART_ChevronPanel">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="^:disabled">
+      <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Path#PART_ChevronPath">
+        <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+      </Style>
+      <!-- Not working -> handled in Styles.axaml -->
+      <!-- <Style Selector="^ /template/ ContentPresenter#PART_IconPresenter Svg:disabled"> -->
+      <!--   <Setter Property="Css" Value=".st0 {fill : #dddddd; }" /> -->
+      <!-- </Style> -->
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type Menu}" TargetType="Menu">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="ItemContainerTheme" Value="{StaticResource FluentTopLevelMenuItem}" />
+    <Setter Property="Padding" Value="{DynamicResource MenuBarPadding}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                HorizontalAlignment="Stretch"
+                Padding="{TemplateBinding Padding}">
+          <ItemsPresenter Name="PART_ItemsPresenter"
+                          ItemsPanel="{TemplateBinding ItemsPanel}"
+                          VerticalAlignment="Stretch"
+                          KeyboardNavigation.TabNavigation="Continue" />
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/NumericUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/NumericUpDown.axaml
@@ -64,37 +64,37 @@
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Template">
       <ControlTemplate>
-          <DataValidationErrors ClipToBounds="False">
-            <ButtonSpinner Name="PART_Spinner"
-                           ClipToBounds="False"
-                           Background="{TemplateBinding Background}"
-                           BorderThickness="{TemplateBinding BorderThickness}"
-                           BorderBrush="{TemplateBinding BorderBrush}"
-                           CornerRadius="{TemplateBinding CornerRadius}"
-                           IsTabStop="False"
-                           Padding="0"
-                           MinWidth="0"
-                           HorizontalContentAlignment="Stretch"
-                           VerticalContentAlignment="Stretch"
-                           AllowSpin="{TemplateBinding AllowSpin}"
-                           ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
-                           ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
-              <TextBox Name="PART_TextBox"
-                       ClipToBounds="False"
-                       Watermark="{TemplateBinding Watermark}"
-                       IsReadOnly="{TemplateBinding IsReadOnly}"
-                       IsEnabled="{TemplateBinding IsEnabled}"
-                       VerticalAlignment="Center"
-                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                       Text="{TemplateBinding Text}"
-                       TextAlignment="{TemplateBinding TextAlignment}"
-                       AcceptsReturn="False"
-                       TextWrapping="NoWrap"
-                       InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
-                       InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
-            </ButtonSpinner>
-          </DataValidationErrors>
+        <DataValidationErrors ClipToBounds="False">
+          <ButtonSpinner Name="PART_Spinner"
+                         ClipToBounds="False"
+                         Background="{TemplateBinding Background}"
+                         BorderThickness="{TemplateBinding BorderThickness}"
+                         BorderBrush="{TemplateBinding BorderBrush}"
+                         CornerRadius="{TemplateBinding CornerRadius}"
+                         IsTabStop="False"
+                         Padding="0"
+                         MinWidth="0"
+                         HorizontalContentAlignment="Stretch"
+                         VerticalContentAlignment="Stretch"
+                         AllowSpin="{TemplateBinding AllowSpin}"
+                         ShowButtonSpinner="{TemplateBinding ShowButtonSpinner}"
+                         ButtonSpinnerLocation="{TemplateBinding ButtonSpinnerLocation}">
+            <TextBox Name="PART_TextBox"
+                     ClipToBounds="False"
+                     Watermark="{TemplateBinding Watermark}"
+                     IsReadOnly="{TemplateBinding IsReadOnly}"
+                     IsEnabled="{TemplateBinding IsEnabled}"
+                     VerticalAlignment="Center"
+                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                     Text="{TemplateBinding Text}"
+                     TextAlignment="{TemplateBinding TextAlignment}"
+                     AcceptsReturn="False"
+                     TextWrapping="NoWrap"
+                     InnerLeftContent="{Binding InnerLeftContent, RelativeSource={RelativeSource TemplatedParent}}"
+                     InnerRightContent="{Binding InnerRightContent, RelativeSource={RelativeSource TemplatedParent}}" />
+          </ButtonSpinner>
+        </DataValidationErrors>
       </ControlTemplate>
     </Setter>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ScrollBar.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ScrollBar.axaml
@@ -1,229 +1,229 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <Border Padding="20">
-         <StackPanel>
-            <ScrollViewer Width="200" Height="200" HorizontalScrollBarVisibility="Auto">
-               <Image Width="800" Height="600"
-                      Source="avares://SampleApp/Assets/SampleImage.jpg" />
-            </ScrollViewer>
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <StackPanel>
+        <ScrollViewer Width="200" Height="200" HorizontalScrollBarVisibility="Auto">
+          <Image Width="800" Height="600"
+                 Source="avares://SampleApp/Assets/SampleImage.jpg" />
+        </ScrollViewer>
 
-            <StackPanel Orientation="Horizontal" Spacing="20">
-               <StackPanel Spacing="20">
-                  <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100" />
-                  <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100"
-                             IsEnabled="False" />
-                  <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100" />
-                  <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100"
-                             IsEnabled="False" />
-               </StackPanel>
-               <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="100" />
-               <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="100"
-                          IsEnabled="False" />
-               <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="100" />
-               <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="100"
-                          IsEnabled="False" />
-            </StackPanel>
-         </StackPanel>
-      </Border>
-   </Design.PreviewWith>
+        <StackPanel Orientation="Horizontal" Spacing="20">
+          <StackPanel Spacing="20">
+            <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100" />
+            <ScrollBar Orientation="Horizontal" AllowAutoHide="False" VerticalAlignment="Center" Width="100"
+                       IsEnabled="False" />
+            <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100" />
+            <ScrollBar Orientation="Horizontal" AllowAutoHide="True" VerticalAlignment="Center" Width="100"
+                       IsEnabled="False" />
+          </StackPanel>
+          <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="100" />
+          <ScrollBar Orientation="Vertical" AllowAutoHide="False" HorizontalAlignment="Center" Height="100"
+                     IsEnabled="False" />
+          <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="100" />
+          <ScrollBar Orientation="Vertical" AllowAutoHide="True" HorizontalAlignment="Center" Height="100"
+                     IsEnabled="False" />
+        </StackPanel>
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="ScrollBarThumbTheme" TargetType="Thumb">
-      <Setter Property="Background" Value="{DynamicResource ScrollBarThumbBrush}" />
+  <ControlTheme x:Key="ScrollBarThumbTheme" TargetType="Thumb">
+    <Setter Property="Background" Value="{DynamicResource ScrollBarThumbBrush}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate>
+          <Border Background="{TemplateBinding Background }"
+                  CornerRadius="{DynamicResource ControlCornerRadius}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Transitions">
+      <Transitions>
+        <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.1" />
+        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.1" />
+      </Transitions>
+    </Setter>
+
+    <Style Selector="^:disabled  /template/ Border">
+      <Setter Property="Background" Value="{DynamicResource ScrollBarDisabledThumbBrush}" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="ScrollBarPageButtonTheme" TargetType="RepeatButton">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="VerticalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="Opacity" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}" />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type ScrollBar}" TargetType="ScrollBar">
+    <Setter Property="MinWidth" Value="{DynamicResource ScrollBarSize}" />
+    <Setter Property="MinHeight" Value="{DynamicResource ScrollBarSize}" />
+
+    <Style Selector="^:vertical">
       <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate>
-               <Border Background="{TemplateBinding Background }"
-                       CornerRadius="{DynamicResource ControlCornerRadius}" />
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="Transitions">
-         <Transitions>
-            <CornerRadiusTransition Property="CornerRadius" Duration="0:0:0.1" />
-            <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.1" />
-         </Transitions>
-      </Setter>
-
-      <Style Selector="^:disabled  /template/ Border">
-         <Setter Property="Background" Value="{DynamicResource ScrollBarDisabledThumbBrush}" />
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="ScrollBarPageButtonTheme" TargetType="RepeatButton">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="VerticalAlignment" Value="Stretch" />
-      <Setter Property="HorizontalAlignment" Value="Stretch" />
-      <Setter Property="Opacity" Value="0" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border Background="{TemplateBinding Background}" />
-         </ControlTemplate>
-      </Setter>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type ScrollBar}" TargetType="ScrollBar">
-      <Setter Property="MinWidth" Value="{DynamicResource ScrollBarSize}" />
-      <Setter Property="MinHeight" Value="{DynamicResource ScrollBarSize}" />
-
-      <Style Selector="^:vertical">
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Panel Name="Root">
-                  <Border Name="VerticalRoot">
-                     <Grid RowDefinitions="Auto,*,Auto">
-                        <Border Name="TrackBorder"
-                                Grid.Row="0"
-                                Grid.RowSpan="3"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness,
+        <ControlTemplate>
+          <Panel Name="Root">
+            <Border Name="VerticalRoot">
+              <Grid RowDefinitions="Auto,*,Auto">
+                <Border Name="TrackBorder"
+                        Grid.Row="0"
+                        Grid.RowSpan="3"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness,
                            Converter={x:Static  DevoConverters.ThicknessToSelectiveThicknessConverter},
                            ConverterParameter={StaticResource ScrollBarTrackVerticalBorderFactors}}"
-                                Opacity="0">
-                           <Border.Transitions>
-                              <Transitions>
-                                 <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
-                              </Transitions>
-                           </Border.Transitions>
-                        </Border>
+                        Opacity="0">
+                  <Border.Transitions>
+                    <Transitions>
+                      <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
+                    </Transitions>
+                  </Border.Transitions>
+                </Border>
 
-                        <Track Grid.Row="1"
-                               Minimum="{TemplateBinding Minimum}"
-                               Maximum="{TemplateBinding Maximum}"
-                               Value="{TemplateBinding Value, Mode=TwoWay}"
-                               DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                               ViewportSize="{TemplateBinding ViewportSize}"
-                               Orientation="{TemplateBinding Orientation}"
-                               IsDirectionReversed="True"
-                               Margin="0 1">
-                           <Track.DecreaseButton>
-                              <RepeatButton Name="PART_PageUpButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource ScrollBarPageButtonTheme}"
-                                            Focusable="False" />
-                           </Track.DecreaseButton>
-                           <Track.IncreaseButton>
-                              <RepeatButton Name="PART_PageDownButton"
-                                            Classes="largeIncrease"
-                                            Theme="{StaticResource ScrollBarPageButtonTheme}"
-                                            Focusable="False" />
-                           </Track.IncreaseButton>
-                           <Thumb Theme="{StaticResource ScrollBarThumbTheme}"
-                                  Width="{DynamicResource ScrollBarThumbWidth}"
-                                  MinHeight="{DynamicResource ScrollBarMinLength}"
-                                  Opacity="0.6">
-                              <Thumb.Transitions>
-                                 <Transitions>
-                                    <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
-                                 </Transitions>
-                              </Thumb.Transitions>
-                           </Thumb>
-                        </Track>
+                <Track Grid.Row="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}"
+                       IsDirectionReversed="True"
+                       Margin="0 1">
+                  <Track.DecreaseButton>
+                    <RepeatButton Name="PART_PageUpButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource ScrollBarPageButtonTheme}"
+                                  Focusable="False" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton Name="PART_PageDownButton"
+                                  Classes="largeIncrease"
+                                  Theme="{StaticResource ScrollBarPageButtonTheme}"
+                                  Focusable="False" />
+                  </Track.IncreaseButton>
+                  <Thumb Theme="{StaticResource ScrollBarThumbTheme}"
+                         Width="{DynamicResource ScrollBarThumbWidth}"
+                         MinHeight="{DynamicResource ScrollBarMinLength}"
+                         Opacity="0.6">
+                    <Thumb.Transitions>
+                      <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
+                      </Transitions>
+                    </Thumb.Transitions>
+                  </Thumb>
+                </Track>
 
-                     </Grid>
-                  </Border>
-               </Panel>
-            </ControlTemplate>
-         </Setter>
-      </Style>
+              </Grid>
+            </Border>
+          </Panel>
+        </ControlTemplate>
+      </Setter>
+    </Style>
 
-      <Style Selector="^:horizontal">
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Panel Name="Root">
-                  <Border Name="HorizontalRoot">
-                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <Border
-                           Name="TrackBorder"
-                           Grid.Column="0"
-                           Grid.ColumnSpan="3"
-                           Background="{TemplateBinding Background}"
-                           BorderBrush="{TemplateBinding BorderBrush}"
-                           BorderThickness="{TemplateBinding BorderThickness,
+    <Style Selector="^:horizontal">
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Panel Name="Root">
+            <Border Name="HorizontalRoot">
+              <Grid ColumnDefinitions="Auto,*,Auto">
+                <Border
+                  Name="TrackBorder"
+                  Grid.Column="0"
+                  Grid.ColumnSpan="3"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness,
                            Converter={x:Static  DevoConverters.ThicknessToSelectiveThicknessConverter},
                            ConverterParameter={StaticResource ScrollBarTrackHorizontalBorderFactors}}"
-                           Opacity="0">
-                           <Border.Transitions>
-                              <Transitions>
-                                 <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
-                              </Transitions>
-                           </Border.Transitions>
-                        </Border>
-                        <Track Grid.Column="1"
-                               Minimum="{TemplateBinding Minimum}"
-                               Maximum="{TemplateBinding Maximum}"
-                               Value="{TemplateBinding Value, Mode=TwoWay}"
-                               DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                               ViewportSize="{TemplateBinding ViewportSize}"
-                               Orientation="{TemplateBinding Orientation}"
-                               Margin="1 0">
-                           <Track.DecreaseButton>
-                              <RepeatButton
-                                 Name="PART_PageUpButton"
-                                 Classes="largeIncrease"
-                                 Theme="{StaticResource ScrollBarPageButtonTheme}"
-                                 Focusable="False" />
-                           </Track.DecreaseButton>
-                           <Track.IncreaseButton>
-                              <RepeatButton
-                                 Name="PART_PageDownButton"
-                                 Classes="largeIncrease"
-                                 Theme="{StaticResource ScrollBarPageButtonTheme}"
-                                 Focusable="False" />
-                           </Track.IncreaseButton>
-                           <Thumb Theme="{StaticResource ScrollBarThumbTheme}"
-                                  Height="{DynamicResource ScrollBarThumbWidth}"
-                                  MinWidth="{DynamicResource ScrollBarMinLength}"
-                                  Opacity="0.33">
-                              <Thumb.Transitions>
-                                 <Transitions>
-                                    <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
-                                 </Transitions>
-                              </Thumb.Transitions>
-                           </Thumb>
-                        </Track>
+                  Opacity="0">
+                  <Border.Transitions>
+                    <Transitions>
+                      <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
+                    </Transitions>
+                  </Border.Transitions>
+                </Border>
+                <Track Grid.Column="1"
+                       Minimum="{TemplateBinding Minimum}"
+                       Maximum="{TemplateBinding Maximum}"
+                       Value="{TemplateBinding Value, Mode=TwoWay}"
+                       DeferThumbDrag="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                       ViewportSize="{TemplateBinding ViewportSize}"
+                       Orientation="{TemplateBinding Orientation}"
+                       Margin="1 0">
+                  <Track.DecreaseButton>
+                    <RepeatButton
+                      Name="PART_PageUpButton"
+                      Classes="largeIncrease"
+                      Theme="{StaticResource ScrollBarPageButtonTheme}"
+                      Focusable="False" />
+                  </Track.DecreaseButton>
+                  <Track.IncreaseButton>
+                    <RepeatButton
+                      Name="PART_PageDownButton"
+                      Classes="largeIncrease"
+                      Theme="{StaticResource ScrollBarPageButtonTheme}"
+                      Focusable="False" />
+                  </Track.IncreaseButton>
+                  <Thumb Theme="{StaticResource ScrollBarThumbTheme}"
+                         Height="{DynamicResource ScrollBarThumbWidth}"
+                         MinWidth="{DynamicResource ScrollBarMinLength}"
+                         Opacity="0.33">
+                    <Thumb.Transitions>
+                      <Transitions>
+                        <DoubleTransition Property="Opacity" Duration="0:0:0.4" />
+                      </Transitions>
+                    </Thumb.Transitions>
+                  </Thumb>
+                </Track>
 
-                     </Grid>
-                  </Border>
-               </Panel>
-            </ControlTemplate>
-         </Setter>
-      </Style>
+              </Grid>
+            </Border>
+          </Panel>
+        </ControlTemplate>
+      </Setter>
+    </Style>
 
-      <Style Selector="^:pointerover /template/ Panel#Root Thumb">
-         <Setter Property="Opacity" Value="1" />
-      </Style>
+    <Style Selector="^:pointerover /template/ Panel#Root Thumb">
+      <Setter Property="Opacity" Value="1" />
+    </Style>
 
-      <Style Selector="^[IsExpanded=True]">
-         <Setter Property="ZIndex" Value="1" />
-         <Style Selector="^ /template/ Border#TrackBorder">
-            <Setter Property="Opacity" Value="0.9" />
-         </Style>
-         <Style Selector="^ /template/ Border#VerticalRoot Thumb">
-            <Setter Property="Width" Value="{DynamicResource ScrollBarExpandedThumbWidth}" />
-         </Style>
-         <Style Selector="^ /template/ Border#HorizontalRoot Thumb">
-            <Setter Property="Height" Value="{DynamicResource ScrollBarExpandedThumbWidth}" />
-         </Style>
-         <Style Selector="^[AllowAutoHide=False]">
-            <Style Selector="^ /template/ Border#TrackBorder">
-               <Setter Property="Opacity" Value="1" />
-            </Style>
-            <Style Selector="^ /template/ Border#VerticalRoot Thumb">
-               <Setter Property="Width" Value="{DynamicResource ScrollBarExpandedStaticThumbWidth}" />
-            </Style>
-            <Style Selector="^ /template/ Border#HorizontalRoot Thumb">
-               <Setter Property="Height" Value="{DynamicResource ScrollBarExpandedStaticThumbWidth}" />
-            </Style>
-         </Style>
+    <Style Selector="^[IsExpanded=True]">
+      <Setter Property="ZIndex" Value="1" />
+      <Style Selector="^ /template/ Border#TrackBorder">
+        <Setter Property="Opacity" Value="0.9" />
       </Style>
-   </ControlTheme>
+      <Style Selector="^ /template/ Border#VerticalRoot Thumb">
+        <Setter Property="Width" Value="{DynamicResource ScrollBarExpandedThumbWidth}" />
+      </Style>
+      <Style Selector="^ /template/ Border#HorizontalRoot Thumb">
+        <Setter Property="Height" Value="{DynamicResource ScrollBarExpandedThumbWidth}" />
+      </Style>
+      <Style Selector="^[AllowAutoHide=False]">
+        <Style Selector="^ /template/ Border#TrackBorder">
+          <Setter Property="Opacity" Value="1" />
+        </Style>
+        <Style Selector="^ /template/ Border#VerticalRoot Thumb">
+          <Setter Property="Width" Value="{DynamicResource ScrollBarExpandedStaticThumbWidth}" />
+        </Style>
+        <Style Selector="^ /template/ Border#HorizontalRoot Thumb">
+          <Setter Property="Height" Value="{DynamicResource ScrollBarExpandedStaticThumbWidth}" />
+        </Style>
+      </Style>
+    </Style>
+  </ControlTheme>
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ScrollViewer.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ScrollViewer.axaml
@@ -1,117 +1,117 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <ScrollViewer Width="200" Height="200"
-                    HorizontalScrollBarVisibility="Auto">
-         <StackPanel Spacing="20" Width="210" Background="White">
-            <TextBlock>Item 1</TextBlock>
-            <TextBlock>Item 2</TextBlock>
-            <TextBlock>Item 3</TextBlock>
-            <TextBlock>Item 4</TextBlock>
-            <TextBlock>Item 5</TextBlock>
-            <TextBlock>Item 6</TextBlock>
-            <TextBlock>Item 7</TextBlock>
-            <TextBlock>Item 8</TextBlock>
-            <TextBlock>Item 9</TextBlock>
-         </StackPanel>
-      </ScrollViewer>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <ScrollViewer Width="200" Height="200"
+                  HorizontalScrollBarVisibility="Auto">
+      <StackPanel Spacing="20" Width="210" Background="White">
+        <TextBlock>Item 1</TextBlock>
+        <TextBlock>Item 2</TextBlock>
+        <TextBlock>Item 3</TextBlock>
+        <TextBlock>Item 4</TextBlock>
+        <TextBlock>Item 5</TextBlock>
+        <TextBlock>Item 6</TextBlock>
+        <TextBlock>Item 7</TextBlock>
+        <TextBlock>Item 8</TextBlock>
+        <TextBlock>Item 9</TextBlock>
+      </StackPanel>
+    </ScrollViewer>
+  </Design.PreviewWith>
 
-   <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
-      <Setter Property="Background" Value="Transparent" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
-               <ScrollContentPresenter Name="PART_ContentPresenter"
-                                       Grid.Row="0" Grid.RowSpan="2"
-                                       Grid.Column="0" Grid.ColumnSpan="2"
-                                       Background="{TemplateBinding Background}"
-                                       HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
-                                       VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
-                                       HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
-                                       VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
-                                       Padding="{TemplateBinding Padding}"
-                                       ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
-                  <ScrollContentPresenter.GestureRecognizers>
-                     <ScrollGestureRecognizer
-                        CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
-                        CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
-                        IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}" />
-                  </ScrollContentPresenter.GestureRecognizers>
-               </ScrollContentPresenter>
-               <ScrollBar Name="PART_HorizontalScrollBar"
-                          Grid.Row="1"
-                          Grid.Column="0" Grid.ColumnSpan="2"
-                          Orientation="Horizontal"
-                          Background="{DynamicResource ScrollBarTrackBrush}"
-                          BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                          BorderThickness="1" />
-               <ScrollBar Name="PART_VerticalScrollBar"
-                          Grid.Row="0" Grid.RowSpan="2"
-                          Grid.Column="1"
-                          Orientation="Vertical"
-                          Background="{DynamicResource ScrollBarTrackBrush}"
-                          BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                          BorderThickness="1" />
-               <Border Name="PART_ScrollBarsSeparator"
-                       Grid.Row="1"
-                       Grid.Column="1"
-                       Background="{DynamicResource ScrollBarTrackBrush}"
-                       BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
-                       Opacity="0">
-                  <Border.BorderThickness>
-                     <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
-                              Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
-                              ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
-                  </Border.BorderThickness>
-                  <Border.Transitions>
-                     <Transitions>
-                        <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
-                     </Transitions>
-                  </Border.Transitions>
-               </Border>
-            </Grid>
-         </ControlTemplate>
-      </Setter>
+  <ControlTheme x:Key="{x:Type ScrollViewer}" TargetType="ScrollViewer">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
+          <ScrollContentPresenter Name="PART_ContentPresenter"
+                                  Grid.Row="0" Grid.RowSpan="2"
+                                  Grid.Column="0" Grid.ColumnSpan="2"
+                                  Background="{TemplateBinding Background}"
+                                  HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                  VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
+                                  HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                  VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
+                                  Padding="{TemplateBinding Padding}"
+                                  ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
+            <ScrollContentPresenter.GestureRecognizers>
+              <ScrollGestureRecognizer
+                CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
+                IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}" />
+            </ScrollContentPresenter.GestureRecognizers>
+          </ScrollContentPresenter>
+          <ScrollBar Name="PART_HorizontalScrollBar"
+                     Grid.Row="1"
+                     Grid.Column="0" Grid.ColumnSpan="2"
+                     Orientation="Horizontal"
+                     Background="{DynamicResource ScrollBarTrackBrush}"
+                     BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                     BorderThickness="1" />
+          <ScrollBar Name="PART_VerticalScrollBar"
+                     Grid.Row="0" Grid.RowSpan="2"
+                     Grid.Column="1"
+                     Orientation="Vertical"
+                     Background="{DynamicResource ScrollBarTrackBrush}"
+                     BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                     BorderThickness="1" />
+          <Border Name="PART_ScrollBarsSeparator"
+                  Grid.Row="1"
+                  Grid.Column="1"
+                  Background="{DynamicResource ScrollBarTrackBrush}"
+                  BorderBrush="{DynamicResource ScrollBarTrackBorderBrush}"
+                  Opacity="0">
+            <Border.BorderThickness>
+              <Binding Source="{StaticResource ScrollBarTrackBorderThickness}"
+                       Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
+                       ConverterParameter="{StaticResource ScrollBarSeparatorBorderFactors}" />
+            </Border.BorderThickness>
+            <Border.Transitions>
+              <Transitions>
+                <DoubleTransition Property="Opacity" Duration="0:0:0.1" />
+              </Transitions>
+            </Border.Transitions>
+          </Border>
+        </Grid>
+      </ControlTemplate>
+    </Setter>
 
 
-      <Style Selector="^.MacOS_TransparentTrack[AllowAutoHide=True]">
-         <Style
-            Selector="^ /template/ Border#PART_ScrollBarsSeparator">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style
-            Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
-         <Style
-            Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
-            <Setter Property="Background" Value="Transparent" />
-            <Setter Property="BorderThickness" Value="0" />
-         </Style>
+    <Style Selector="^.MacOS_TransparentTrack[AllowAutoHide=True]">
+      <Style
+        Selector="^ /template/ Border#PART_ScrollBarsSeparator">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-      <Style Selector="^[AllowAutoHide=False]">
-         <Style Selector="^ /template/ Border#PART_ScrollBarsSeparator">
-            <Setter Property="Opacity" Value="1" />
-         </Style>
-         <Style Selector="^ /template/ ScrollContentPresenter#PART_ContentPresenter">
-            <Setter Property="Grid.RowSpan" Value="1" />
-            <Setter Property="Grid.ColumnSpan" Value="1" />
-         </Style>
-         <Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
-            <Setter Property="Grid.RowSpan" Value="1" />
-         </Style>
-         <Style Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
-            <Setter Property="Grid.ColumnSpan" Value="1" />
-         </Style>
+      <Style
+        Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
       </Style>
-   </ControlTheme>
+      <Style
+        Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+      </Style>
+    </Style>
+    <Style Selector="^[AllowAutoHide=False]">
+      <Style Selector="^ /template/ Border#PART_ScrollBarsSeparator">
+        <Setter Property="Opacity" Value="1" />
+      </Style>
+      <Style Selector="^ /template/ ScrollContentPresenter#PART_ContentPresenter">
+        <Setter Property="Grid.RowSpan" Value="1" />
+        <Setter Property="Grid.ColumnSpan" Value="1" />
+      </Style>
+      <Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
+        <Setter Property="Grid.RowSpan" Value="1" />
+      </Style>
+      <Style Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
+        <Setter Property="Grid.ColumnSpan" Value="1" />
+      </Style>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -1,151 +1,151 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <ThemeVariantScope RequestedThemeVariant="Dark">
-         <Border Background="#212121">
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
-               <Border Width="500">
-                  <TabControl TabStripPlacement="Left" Margin="5">
-                     <TabItem Header="Tab 1">
-                        <TextBlock Text="Vertical tab view" />
-                     </TabItem>
-                     <TabItem Header="Tab 2">
-                        <TextBlock Text="Content 2" />
-                     </TabItem>
-                     <TabItem Header="Tab3" IsEnabled="False" />
-                  </TabControl>
-               </Border>
-               <Border Width="500">
-                  <TabControl TabStripPlacement="Top" Margin="5">
-                     <TabItem Header="General">
-                        <TextBlock Text="Horizontal tab view" />
-                     </TabItem>
-                     <TabItem Header="Settings">
-                        <TextBlock Text="Content 2" />
-                     </TabItem>
-                     <TabItem Header="Disabled Tab" IsEnabled="False" />
-                     <TabItem Header="Advanced">
-                        <TextBlock Text="Content 3" />
-                     </TabItem>
-                  </TabControl>
-               </Border>
-            </StackPanel>
-         </Border>
-      </ThemeVariantScope>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <ThemeVariantScope RequestedThemeVariant="Dark">
+      <Border Background="#212121">
+        <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
+          <Border Width="500">
+            <TabControl TabStripPlacement="Left" Margin="5">
+              <TabItem Header="Tab 1">
+                <TextBlock Text="Vertical tab view" />
+              </TabItem>
+              <TabItem Header="Tab 2">
+                <TextBlock Text="Content 2" />
+              </TabItem>
+              <TabItem Header="Tab3" IsEnabled="False" />
+            </TabControl>
+          </Border>
+          <Border Width="500">
+            <TabControl TabStripPlacement="Top" Margin="5">
+              <TabItem Header="General">
+                <TextBlock Text="Horizontal tab view" />
+              </TabItem>
+              <TabItem Header="Settings">
+                <TextBlock Text="Content 2" />
+              </TabItem>
+              <TabItem Header="Disabled Tab" IsEnabled="False" />
+              <TabItem Header="Advanced">
+                <TextBlock Text="Content 3" />
+              </TabItem>
+            </TabControl>
+          </Border>
+        </StackPanel>
+      </Border>
+    </ThemeVariantScope>
+  </Design.PreviewWith>
 
-   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
+  <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
 
-   <ControlTheme x:Key="{x:Type TabControl}" TargetType="TabControl">
-      <!-- <Setter Property="Margin" Value="5" /> -->
-      <Setter Property="Padding" Value="10" />
-      <Setter Property="Background" Value="Transparent" />
+  <ControlTheme x:Key="{x:Type TabControl}" TargetType="TabControl">
+    <!-- <Setter Property="Margin" Value="5" /> -->
+    <Setter Property="Padding" Value="10" />
+    <Setter Property="Background" Value="Transparent" />
 
-      <Style Selector="^[TabStripPlacement=Top]">
-         <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderLowBrush}" />
-         <Setter Property="BorderThickness" Value="{DynamicResource BorderThickness}" />
-         <Setter Property="CornerRadius" Value="{DynamicResource LayoutCornerRadius}" />
-         <Setter Property="ClipToBounds" Value="False" />
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Border Background="{TemplateBinding Background}"
-                       ClipToBounds="False"
-                       HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                       VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                  <DockPanel ClipToBounds="False">
-                     <Border Name="TabstripPanel"
-                             ClipToBounds="False"
-                             UseLayoutRounding="False"
-                             DockPanel.Dock="{TemplateBinding TabStripPlacement}">
-                        <Border.Margin>
-                           <Binding Source="{StaticResource InputControlsSpaceForFocusBorder}"
-                                    Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
-                                    ConverterParameter="{StaticResource TabControlSpaceForFocusFactors}" />
-                        </Border.Margin>
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        ClipToBounds="False"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
-                     </Border>
-                     <ContentPresenter Name="PART_SelectedContentHost"
-                                       BorderBrush="{TemplateBinding BorderBrush}"
-                                       BorderThickness="{TemplateBinding BorderThickness}"
-                                       CornerRadius="{TemplateBinding CornerRadius}"
-                                       Margin="{TemplateBinding Padding}"
-                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Content="{TemplateBinding SelectedContent}"
-                                       ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
-                  </DockPanel>
-               </Border>
-            </ControlTemplate>
-         </Setter>
-         <Setter Property="Padding" Value="10 -10 10 10" />
-         <Style Selector="^/template/ Border#TabstripPanel">
-            <Setter Property="Background" Value="{DynamicResource TabControlBackgroundBrush}" />
-            <Setter Property="HorizontalAlignment" Value="Center" />
-            <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
-            <Setter Property="BorderThickness" Value="0 1 0 0.6" />
-            <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-            <Setter Property="Padding" Value="0" />
-            <Setter Property="ZIndex" Value="1" />
-         </Style>
-         <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter">
-            <Setter Property="Margin" Value="0" />
-         </Style>
-         <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-            <Setter Property="Margin" Value="-4 0 0 0" />
-         </Style>
-         <Style Selector="^/template/ ContentPresenter#PART_SelectedContentHost">
-            <Setter Property="Padding" Value="20" />
-            <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
-            <Setter Property="VerticalAlignment" Value="Stretch" />
-         </Style>
+    <Style Selector="^[TabStripPlacement=Top]">
+      <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderLowBrush}" />
+      <Setter Property="BorderThickness" Value="{DynamicResource BorderThickness}" />
+      <Setter Property="CornerRadius" Value="{DynamicResource LayoutCornerRadius}" />
+      <Setter Property="ClipToBounds" Value="False" />
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border Background="{TemplateBinding Background}"
+                  ClipToBounds="False"
+                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                  VerticalAlignment="{TemplateBinding VerticalAlignment}">
+            <DockPanel ClipToBounds="False">
+              <Border Name="TabstripPanel"
+                      ClipToBounds="False"
+                      UseLayoutRounding="False"
+                      DockPanel.Dock="{TemplateBinding TabStripPlacement}">
+                <Border.Margin>
+                  <Binding Source="{StaticResource InputControlsSpaceForFocusBorder}"
+                           Converter="{x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}"
+                           ConverterParameter="{StaticResource TabControlSpaceForFocusFactors}" />
+                </Border.Margin>
+                <ItemsPresenter Name="PART_ItemsPresenter"
+                                ClipToBounds="False"
+                                ItemsPanel="{TemplateBinding ItemsPanel}" />
+              </Border>
+              <ContentPresenter Name="PART_SelectedContentHost"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding SelectedContent}"
+                                ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+            </DockPanel>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+      <Setter Property="Padding" Value="10 -10 10 10" />
+      <Style Selector="^/template/ Border#TabstripPanel">
+        <Setter Property="Background" Value="{DynamicResource TabControlBackgroundBrush}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
+        <Setter Property="BorderThickness" Value="0 1 0 0.6" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="ZIndex" Value="1" />
+      </Style>
+      <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter">
+        <Setter Property="Margin" Value="0" />
+      </Style>
+      <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+        <Setter Property="Margin" Value="-4 0 0 0" />
+      </Style>
+      <Style Selector="^/template/ ContentPresenter#PART_SelectedContentHost">
+        <Setter Property="Padding" Value="20" />
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Left], ^[TabStripPlacement=Right]">
+      <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
+      <Setter Property="BorderThickness" Value="{DynamicResource BorderThickness}" />
+      <Setter Property="CornerRadius" Value="0" />
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Border Name="RootElement"
+                  ClipToBounds="False"
+                  BorderBrush="{TemplateBinding BorderBrush}"
+                  BorderThickness="{TemplateBinding BorderThickness}"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  Background="{TemplateBinding Background}"
+                  HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                  VerticalAlignment="{TemplateBinding VerticalAlignment}">
+            <DockPanel ClipToBounds="False">
+              <Border Name="TabstripPanel"
+                      ClipToBounds="False"
+                      DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                      Background="{DynamicResource TabStripVerticalBackgroundBrush}"
+                      Padding="5 10">
+                <ItemsPresenter Name="PART_ItemsPresenter"
+                                ClipToBounds="False"
+                                ItemsPanel="{TemplateBinding ItemsPanel}" />
+              </Border>
+              <ContentPresenter Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding SelectedContent}"
+                                ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+            </DockPanel>
+          </Border>
+        </ControlTemplate>
+      </Setter>
+      <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+        <Setter Property="Orientation" Value="Vertical" />
       </Style>
 
-      <Style Selector="^[TabStripPlacement=Left], ^[TabStripPlacement=Right]">
-         <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
-         <Setter Property="BorderThickness" Value="{DynamicResource BorderThickness}" />
-         <Setter Property="CornerRadius" Value="0" />
-         <Setter Property="Template">
-            <ControlTemplate>
-               <Border Name="RootElement"
-                       ClipToBounds="False"
-                       BorderBrush="{TemplateBinding BorderBrush}"
-                       BorderThickness="{TemplateBinding BorderThickness}"
-                       CornerRadius="{TemplateBinding CornerRadius}"
-                       Background="{TemplateBinding Background}"
-                       HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                       VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                  <DockPanel ClipToBounds="False">
-                     <Border Name="TabstripPanel"
-                             ClipToBounds="False"
-                             DockPanel.Dock="{TemplateBinding TabStripPlacement}"
-                             Background="{DynamicResource TabStripVerticalBackgroundBrush}"
-                             Padding="5 10">
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        ClipToBounds="False"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
-                     </Border>
-                     <ContentPresenter Name="PART_SelectedContentHost"
-                                       Margin="{TemplateBinding Padding}"
-                                       HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                       VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                       Content="{TemplateBinding SelectedContent}"
-                                       ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
-                  </DockPanel>
-               </Border>
-            </ControlTemplate>
-         </Setter>
-         <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-            <Setter Property="Orientation" Value="Vertical" />
-         </Style>
+    </Style>
 
-      </Style>
-
-   </ControlTheme>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
@@ -129,14 +129,14 @@
           </Panel>
         </ControlTemplate>
       </Setter>
-          
+
       <!-- Tabbing focus -->
       <Style Selector="^:focus-visible">
         <Style Selector="^ /template/ Border#FocusBorderElement">
           <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
         </Style>
       </Style>
-      
+
       <Style Selector="^:nth-child(1) /template/ TextBlock#TabDivider">
         <Setter Property="Foreground" Value="Transparent" />
       </Style>
@@ -163,28 +163,28 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   CornerRadius="7">
-          <ContentPresenter Name="PART_ContentPresenter"
-                            Padding="{TemplateBinding Padding}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Content="{TemplateBinding Header}"
-                            ContentTemplate="{TemplateBinding HeaderTemplate}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            RecognizesAccessKey="True" />
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Padding="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Background="{TemplateBinding Background}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              CornerRadius="{TemplateBinding CornerRadius}"
+                              RecognizesAccessKey="True" />
           </Border>
         </ControlTemplate>
       </Setter>
-      
+
       <!-- Tabbing focus -->
       <Style Selector="^:focus-visible">
         <Style Selector="^ /template/ Border#FocusBorderElement">
           <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
         </Style>
       </Style>
-      
+
       <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundMidBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -1,306 +1,306 @@
 <ResourceDictionary
-   xmlns="https://github.com/avaloniaui"
-   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-   xmlns:converters="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Converters">
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:converters="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Converters">
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <ThemeVariantScope RequestedThemeVariant="Light">
-         <Border Background="{DynamicResource BackgroundBrush}">
-            <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
-               <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
-                  <TextBlock>Name:</TextBlock>
-                  <TextBox Watermark="Enter your name">Anna</TextBox>
-                  <TextBlock>Password:</TextBlock>
-                  <TextBox PasswordChar="*" Watermark="Enter your password" />
-                  <TextBlock>Notes:</TextBlock>
-                  <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
-                     Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
-                  </TextBox>
-                  <TextBox InnerLeftContent="http://" />
-                  <TextBox InnerRightContent=".com" />
-                  <TextBox
-                     InnerLeftContent="http://"
-                     InnerRightContent=".com" />
-                  <TextBox Classes="clearButton">With 'Clear' button</TextBox>
-                  <TextBox Watermark="Enter your name" IsEnabled="False" />
-                  <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
-                  <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-                  <TextBlock>Custom Height:</TextBlock>
-                  <StackPanel Orientation="Horizontal" Spacing="5">
-                     <TextBox Watermark="Type here" Height="30" Width="250" VerticalContentAlignment="Center" />
-                     <Button Content="..." Height="30" Width="30" />
-                  </StackPanel>
-               </StackPanel>
-            </Border>
-         </Border>
-      </ThemeVariantScope>
-   </Design.PreviewWith>
+  <Design.PreviewWith>
+    <ThemeVariantScope RequestedThemeVariant="Light">
+      <Border Background="{DynamicResource BackgroundBrush}">
+        <Border Background="{DynamicResource LayoutBackgroundLowBrush}">
+          <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
+            <TextBlock>Name:</TextBlock>
+            <TextBox Watermark="Enter your name">Anna</TextBox>
+            <TextBlock>Password:</TextBlock>
+            <TextBox PasswordChar="*" Watermark="Enter your password" />
+            <TextBlock>Notes:</TextBlock>
+            <TextBox Height="100" AcceptsReturn="True" TextWrapping="Wrap">
+              Note: explicitly styling TextBlock causes massive problems, because there are so many dynamically created TextBlocks in controls' ContentPresenters (i.e. they only get created if the content provided is a simple string, and therefore they are not a part of the logical tree and do not receive the local template styling anymore if there is a general TextBlock rule, and cannot easily overwritten then - except with hard-coded styles rather than template bindings ...
+            </TextBox>
+            <TextBox InnerLeftContent="http://" />
+            <TextBox InnerRightContent=".com" />
+            <TextBox
+              InnerLeftContent="http://"
+              InnerRightContent=".com" />
+            <TextBox Classes="clearButton">With 'Clear' button</TextBox>
+            <TextBox Watermark="Enter your name" IsEnabled="False" />
+            <TextBox PasswordChar="•" Classes="revealPasswordButton">Reveal Password</TextBox>
+            <TextBox PasswordChar="•" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
+            <TextBlock>Custom Height:</TextBlock>
+            <StackPanel Orientation="Horizontal" Spacing="5">
+              <TextBox Watermark="Type here" Height="30" Width="250" VerticalContentAlignment="Center" />
+              <Button Content="..." Height="30" Width="30" />
+            </StackPanel>
+          </StackPanel>
+        </Border>
+      </Border>
+    </ThemeVariantScope>
+  </Design.PreviewWith>
 
-   <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
-   </MenuFlyout>
-   <MenuFlyout x:Key="HorizontalTextBoxContextFlyout"
-               FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
-               ItemContainerTheme="{StaticResource HorizontalMenuItem}">
-      <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
-                IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
-                IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
-      <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
-                IsEnabled="{Binding $parent[TextBox].CanPaste}" />
-   </MenuFlyout>
+  <MenuFlyout x:Key="DefaultTextBoxContextFlyout">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" InputGesture="{x:Static TextBox.CutGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" InputGesture="{x:Static TextBox.CopyGesture}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" InputGesture="{x:Static TextBox.PasteGesture}" />
+  </MenuFlyout>
+  <MenuFlyout x:Key="HorizontalTextBoxContextFlyout"
+              FlyoutPresenterTheme="{StaticResource HorizontalMenuFlyoutPresenter}"
+              ItemContainerTheme="{StaticResource HorizontalMenuItem}">
+    <MenuItem Header="{DynamicResource StringTextFlyoutCutText}" Command="{Binding $parent[TextBox].Cut}"
+              IsEnabled="{Binding $parent[TextBox].CanCut}" IsVisible="{Binding $parent[TextBox].CanCut}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutCopyText}" Command="{Binding $parent[TextBox].Copy}"
+              IsEnabled="{Binding $parent[TextBox].CanCopy}" IsVisible="{Binding $parent[TextBox].CanCopy}" />
+    <MenuItem Header="{DynamicResource StringTextFlyoutPasteText}" Command="{Binding $parent[TextBox].Paste}"
+              IsEnabled="{Binding $parent[TextBox].CanPaste}" />
+  </MenuFlyout>
 
-   <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
-      <Setter Property="Focusable" Value="False" />
-      <Setter Property="Padding" Value="0" />
-      <Setter Property="Width" Value="13" />
-      <Setter Property="Height" Value="13" />
-      <Setter Property="Margin" Value="0 0 5 0" />
-      <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}" />
-      <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate TargetType="Button">
-               <ContentPresenter Name="PART_ContentPresenter"
-                                 Background="{TemplateBinding Background}"
-                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                 Content="{TemplateBinding Content}"
-                                 Padding="{TemplateBinding Padding}" />
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
+  <ControlTheme x:Key="FluentTextBoxButton" TargetType="Button">
+    <Setter Property="Focusable" Value="False" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Width" Value="13" />
+    <Setter Property="Height" Value="13" />
+    <Setter Property="Margin" Value="0 0 5 0" />
+    <Setter Property="TextElement.Foreground" Value="{DynamicResource TextControlButtonForeground}" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="Button">
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            Content="{TemplateBinding Content}"
+                            Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
 
-      <Style Selector="^:disabled /template/ ContentPresenter">
-         <Setter Property="Opacity" Value="0" />
-      </Style>
-   </ControlTheme>
+    <Style Selector="^:disabled /template/ ContentPresenter">
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+  </ControlTheme>
 
-   <ControlTheme x:Key="FluentTextBoxToggleButton"
-                 TargetType="ToggleButton"
-                 BasedOn="{StaticResource FluentTextBoxButton}">
-      <Setter Property="Template">
-         <Setter.Value>
-            <ControlTemplate TargetType="ToggleButton">
-               <ContentPresenter Name="PART_ContentPresenter"
-                                 Background="{TemplateBinding Background}"
-                                 Content="{TemplateBinding Content}"
-                                 Padding="{TemplateBinding Padding}" />
-            </ControlTemplate>
-         </Setter.Value>
-      </Setter>
-   </ControlTheme>
+  <ControlTheme x:Key="FluentTextBoxToggleButton"
+                TargetType="ToggleButton"
+                BasedOn="{StaticResource FluentTextBoxButton}">
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="ToggleButton">
+          <ContentPresenter Name="PART_ContentPresenter"
+                            Background="{TemplateBinding Background}"
+                            Content="{TemplateBinding Content}"
+                            Padding="{TemplateBinding Padding}" />
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </ControlTheme>
 
-   <ControlTheme x:Key="{x:Type TextBox}" TargetType="TextBox">
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
-      <Setter Property="BorderThickness" Value="0.6" />
-      <Setter Property="CaretBrush" Value="{DynamicResource SystemAccentColor}" />
-      <Setter Property="FontSize">
-         <Setter.Value>
-            <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
-               <Binding RelativeSource="{RelativeSource Self}" Path="PasswordChar" />
-               <Binding RelativeSource="{RelativeSource Self}" Path="RevealPassword" />
-               <Binding Source="{StaticResource ControlFontSize}" />
-               <Binding Source="{StaticResource PasswordHiddenFontSize}" />
-            </MultiBinding>
-         </Setter.Value>
-      </Setter>
-      <Setter Property="SelectionBrush" Value="{DynamicResource TextBoxSelectionHighlightBrush}" />
-      <!-- <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" /> TODO: make this a style? Class: rounded true/false -->
-      <Setter Property="CornerRadius" Value="0" />
-      <Setter Property="MinHeight" Value="19" />
-      <Setter Property="MinWidth" Value="19" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="ClipToBounds" Value="False" />
-      <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
-      <Setter Property="ContextFlyout"
-              Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
-      <Setter Property="ScrollViewer.AllowAutoHide" Value="False" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Panel Name="ReservedSpaceForFocus"
-                   Margin="{StaticResource InputControlsSpaceForFocusBorder}">
-               <DataValidationErrors ClipToBounds="False">
-                  <Panel ClipToBounds="False">
-                     <Border Name="PART_BorderElement"
-                             Height="{TemplateBinding Height}"
-                             BorderThickness="{TemplateBinding BorderThickness}"
-                             BorderBrush="{TemplateBinding BorderBrush}"
-                             Background="{TemplateBinding Background}"
-                             CornerRadius="{TemplateBinding CornerRadius}"
-                             Padding="2 0 2 0 ">
-                        <Grid ColumnDefinitions="Auto,*,Auto">
-                           <ContentPresenter Name="PrefixContent"
-                                             Grid.Column="0"
-                                             Content="{TemplateBinding InnerLeftContent}"
-                                             Padding="3 2 3 1"
-                                             VerticalAlignment="Center">
-                              <ContentPresenter.IsVisible>
-                                 <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                                          Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                              </ContentPresenter.IsVisible>
-                           </ContentPresenter>
-                           <DockPanel Name="PART_InnerDockPanel"
-                                      Grid.Column="1"
-                                      Margin="2 2 3 1 ">
-                              <ScrollViewer Name="PART_ScrollViewer"
-                                            Margin="0 0 -4 0"
-                                            HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                                            VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
-                                            IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
-                                            AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                                            BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
-                                 <Panel>
-                                    <TextBlock Name="PART_Watermark"
-                                               Foreground="{DynamicResource ForegroundLowBrush}"
-                                               FontSize="{DynamicResource ControlFontSize}"
-                                               Text="{TemplateBinding Watermark}"
-                                               TextAlignment="{TemplateBinding TextAlignment}"
-                                               TextWrapping="{TemplateBinding TextWrapping}"
-                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                               VerticalAlignment="Center">
-                                       <TextBlock.IsVisible>
-                                          <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                             <Binding ElementName="PART_TextPresenter" Path="PreeditText"
-                                                      Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                                             <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
-                                                      Converter="{x:Static StringConverters.IsNullOrEmpty}" />
-                                          </MultiBinding>
-                                       </TextBlock.IsVisible>
-                                    </TextBlock>
-                                    <TextPresenter Name="PART_TextPresenter"
-                                                   Text="{TemplateBinding Text, Mode=TwoWay}"
-                                                   CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
-                                                   CaretIndex="{TemplateBinding CaretIndex}"
-                                                   SelectionStart="{TemplateBinding SelectionStart}"
-                                                   SelectionEnd="{TemplateBinding SelectionEnd}"
-                                                   TextAlignment="{TemplateBinding TextAlignment}"
-                                                   TextWrapping="{TemplateBinding TextWrapping}"
-                                                   LineHeight="{TemplateBinding LineHeight}"
-                                                   LetterSpacing="{TemplateBinding LetterSpacing}"
-                                                   RevealPassword="{TemplateBinding RevealPassword}"
-                                                   SelectionBrush="{TemplateBinding SelectionBrush}"
-                                                   SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
-                                                   CaretBrush="{TemplateBinding CaretBrush}"
-                                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                   VerticalAlignment="Center">
-                                       <TextPresenter.PasswordChar>
-                                          <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
-                                                   Converter="{x:Static converters:MacOSConverters.CharToMacOsPasswordCharConverter}" />
-                                       </TextPresenter.PasswordChar>
-                                    </TextPresenter>
-                                 </Panel>
-                                 <ScrollViewer.Styles>
-                                    <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
-                                       <Setter Property="Cursor" Value="IBeam" />
-                                    </Style>
-                                 </ScrollViewer.Styles>
-                              </ScrollViewer>
-                           </DockPanel>
-                           <ContentPresenter Name="SuffixContent"
-                                             Grid.Column="2"
-                                             Padding="3 2 3 1"
-                                             Content="{TemplateBinding InnerRightContent}"
-                                             VerticalAlignment="Center">
-                              <ContentPresenter.IsVisible>
-                                 <Binding RelativeSource="{RelativeSource Self}" Path="Content"
-                                          Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
-                              </ContentPresenter.IsVisible>
-                           </ContentPresenter>
-                        </Grid>
-                     </Border>
-                     <Border Name="BottomBorder"
-                             BorderThickness="0 0 0 0.6"
-                             BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
-                             BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                             CornerRadius="{TemplateBinding CornerRadius}"
-                             Margin="0.6 0  " />
-                     <Border Name="BottomBorderShadow"
-                             BorderThickness="0 0 0 0.6"
-                             BorderBrush="{TemplateBinding BorderBrush}"
-                             CornerRadius="{TemplateBinding CornerRadius}"
-                             BoxShadow="{DynamicResource TextBoxBorderShadows}"
-                             Margin="0.6 0 0.6 -0.6 " />
-                     <Border Name="FocusBorderElement"
-                             Margin="{StaticResource FocusBorderMargin}"
-                             BorderThickness="{StaticResource FocusBorderThickness}"
-                             CornerRadius="2" />
-                  </Panel>
-
-               </DataValidationErrors>
+  <ControlTheme x:Key="{x:Type TextBox}" TargetType="TextBox">
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
+    <Setter Property="BorderThickness" Value="0.6" />
+    <Setter Property="CaretBrush" Value="{DynamicResource SystemAccentColor}" />
+    <Setter Property="FontSize">
+      <Setter.Value>
+        <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
+          <Binding RelativeSource="{RelativeSource Self}" Path="PasswordChar" />
+          <Binding RelativeSource="{RelativeSource Self}" Path="RevealPassword" />
+          <Binding Source="{StaticResource ControlFontSize}" />
+          <Binding Source="{StaticResource PasswordHiddenFontSize}" />
+        </MultiBinding>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="SelectionBrush" Value="{DynamicResource TextBoxSelectionHighlightBrush}" />
+    <!-- <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" /> TODO: make this a style? Class: rounded true/false -->
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="MinHeight" Value="19" />
+    <Setter Property="MinWidth" Value="19" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ClipToBounds" Value="False" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ContextFlyout"
+            Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
+    <Setter Property="ScrollViewer.AllowAutoHide" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel Name="ReservedSpaceForFocus"
+               Margin="{StaticResource InputControlsSpaceForFocusBorder}">
+          <DataValidationErrors ClipToBounds="False">
+            <Panel ClipToBounds="False">
+              <Border Name="PART_BorderElement"
+                      Height="{TemplateBinding Height}"
+                      BorderThickness="{TemplateBinding BorderThickness}"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      Background="{TemplateBinding Background}"
+                      CornerRadius="{TemplateBinding CornerRadius}"
+                      Padding="2 0 2 0 ">
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                  <ContentPresenter Name="PrefixContent"
+                                    Grid.Column="0"
+                                    Content="{TemplateBinding InnerLeftContent}"
+                                    Padding="3 2 3 1"
+                                    VerticalAlignment="Center">
+                    <ContentPresenter.IsVisible>
+                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                    </ContentPresenter.IsVisible>
+                  </ContentPresenter>
+                  <DockPanel Name="PART_InnerDockPanel"
+                             Grid.Column="1"
+                             Margin="2 2 3 1 ">
+                    <ScrollViewer Name="PART_ScrollViewer"
+                                  Margin="0 0 -4 0"
+                                  HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                                  VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                                  IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                                  AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                                  BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                      <Panel>
+                        <TextBlock Name="PART_Watermark"
+                                   Foreground="{DynamicResource ForegroundLowBrush}"
+                                   FontSize="{DynamicResource ControlFontSize}"
+                                   Text="{TemplateBinding Watermark}"
+                                   TextAlignment="{TemplateBinding TextAlignment}"
+                                   TextWrapping="{TemplateBinding TextWrapping}"
+                                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                   VerticalAlignment="Center">
+                          <TextBlock.IsVisible>
+                            <MultiBinding Converter="{x:Static BoolConverters.And}">
+                              <Binding ElementName="PART_TextPresenter" Path="PreeditText"
+                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                              <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Text"
+                                       Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                            </MultiBinding>
+                          </TextBlock.IsVisible>
+                        </TextBlock>
+                        <TextPresenter Name="PART_TextPresenter"
+                                       Text="{TemplateBinding Text, Mode=TwoWay}"
+                                       CaretBlinkInterval="{TemplateBinding CaretBlinkInterval}"
+                                       CaretIndex="{TemplateBinding CaretIndex}"
+                                       SelectionStart="{TemplateBinding SelectionStart}"
+                                       SelectionEnd="{TemplateBinding SelectionEnd}"
+                                       TextAlignment="{TemplateBinding TextAlignment}"
+                                       TextWrapping="{TemplateBinding TextWrapping}"
+                                       LineHeight="{TemplateBinding LineHeight}"
+                                       LetterSpacing="{TemplateBinding LetterSpacing}"
+                                       RevealPassword="{TemplateBinding RevealPassword}"
+                                       SelectionBrush="{TemplateBinding SelectionBrush}"
+                                       SelectionForegroundBrush="{TemplateBinding SelectionForegroundBrush}"
+                                       CaretBrush="{TemplateBinding CaretBrush}"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="Center">
+                          <TextPresenter.PasswordChar>
+                            <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="PasswordChar"
+                                     Converter="{x:Static converters:MacOSConverters.CharToMacOsPasswordCharConverter}" />
+                          </TextPresenter.PasswordChar>
+                        </TextPresenter>
+                      </Panel>
+                      <ScrollViewer.Styles>
+                        <Style Selector="ScrollContentPresenter#PART_ContentPresenter">
+                          <Setter Property="Cursor" Value="IBeam" />
+                        </Style>
+                      </ScrollViewer.Styles>
+                    </ScrollViewer>
+                  </DockPanel>
+                  <ContentPresenter Name="SuffixContent"
+                                    Grid.Column="2"
+                                    Padding="3 2 3 1"
+                                    Content="{TemplateBinding InnerRightContent}"
+                                    VerticalAlignment="Center">
+                    <ContentPresenter.IsVisible>
+                      <Binding RelativeSource="{RelativeSource Self}" Path="Content"
+                               Converter="{x:Static StringConverters.IsNotNullOrEmpty}" />
+                    </ContentPresenter.IsVisible>
+                  </ContentPresenter>
+                </Grid>
+              </Border>
+              <Border Name="BottomBorder"
+                      BorderThickness="0 0 0 0.6"
+                      BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
+                      BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                      CornerRadius="{TemplateBinding CornerRadius}"
+                      Margin="0.6 0  " />
+              <Border Name="BottomBorderShadow"
+                      BorderThickness="0 0 0 0.6"
+                      BorderBrush="{TemplateBinding BorderBrush}"
+                      CornerRadius="{TemplateBinding CornerRadius}"
+                      BoxShadow="{DynamicResource TextBoxBorderShadows}"
+                      Margin="0.6 0 0.6 -0.6 " />
+              <Border Name="FocusBorderElement"
+                      Margin="{StaticResource FocusBorderMargin}"
+                      BorderThickness="{StaticResource FocusBorderThickness}"
+                      CornerRadius="2" />
             </Panel>
-         </ControlTemplate>
+
+          </DataValidationErrors>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <!-- Disabled State -->
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+
+      <Style Selector="^ /template/ Border#InnerBorderElement">
+        <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundDisabledHighBrush}" />
+      </Style>
+    </Style>
+
+    <!-- Focused State -->
+    <Style Selector="^:focus">
+      <Style Selector="^ /template/ Border#FocusBorderElement">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
+      </Style>
+      <Style Selector="^ /template/ Border#BottomBorder">
+        <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:error /template/ Border#PART_BorderElement">
+      <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
+      <Setter Property="InnerRightContent">
+        <Template>
+          <ToggleButton Name="PasswordRevealButton"
+                        Theme="{StaticResource FluentTextBoxToggleButton}"
+                        IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
+                        ClipToBounds="True">
+            <Panel>
+              <PathIcon Data="{StaticResource PasswordRevealPath}"
+                        Height="9" Width="12"
+                        IsVisible="{Binding !$parent[ToggleButton].IsChecked}" />
+              <PathIcon Data="{StaticResource PasswordHidePath}"
+                        Height="12" Width="12"
+                        IsVisible="{Binding $parent[ToggleButton].IsChecked}" />
+            </Panel>
+          </ToggleButton>
+        </Template>
       </Setter>
+    </Style>
 
-      <!-- Disabled State -->
-      <Style Selector="^:disabled">
-         <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+    <Style Selector="^[AcceptsReturn=True] /template/ TextPresenter#PART_TextPresenter">
+      <Setter Property="VerticalAlignment" Value="Top" />
+    </Style>
 
-         <Style Selector="^ /template/ Border#InnerBorderElement">
-            <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundDisabledHighBrush}" />
-         </Style>
-      </Style>
-
-      <!-- Focused State -->
-      <Style Selector="^:focus">
-         <Style Selector="^ /template/ Border#FocusBorderElement">
-            <Setter Property="BorderBrush" Value="{DynamicResource FocusBorderBrush}" />
-         </Style>
-         <Style Selector="^ /template/ Border#BottomBorder">
-            <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
-         </Style>
-      </Style>
-
-      <Style Selector="^:error /template/ Border#PART_BorderElement">
-         <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />
-      </Style>
-
-      <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
-         <Setter Property="InnerRightContent">
-            <Template>
-               <ToggleButton Name="PasswordRevealButton"
-                             Theme="{StaticResource FluentTextBoxToggleButton}"
-                             IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}"
-                             ClipToBounds="True">
-                  <Panel>
-                     <PathIcon Data="{StaticResource PasswordRevealPath}"
-                               Height="9" Width="12"
-                               IsVisible="{Binding !$parent[ToggleButton].IsChecked}" />
-                     <PathIcon Data="{StaticResource PasswordHidePath}"
-                               Height="12" Width="12"
-                               IsVisible="{Binding $parent[ToggleButton].IsChecked}" />
-                  </Panel>
-               </ToggleButton>
-            </Template>
-         </Setter>
-      </Style>
-
-      <Style Selector="^[AcceptsReturn=True] /template/ TextPresenter#PART_TextPresenter">
-         <Setter Property="VerticalAlignment" Value="Top" />
-      </Style>
-
-      <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">
-         <Setter Property="InnerRightContent">
-            <Template>
-               <Button Theme="{StaticResource FluentTextBoxButton}"
-                       Command="{Binding $parent[TextBox].Clear}"
-                       ClipToBounds="True"
-                       Background="{DynamicResource TextBoxClearButtonBackgroundBrush}"
-                       CornerRadius="7">
-                  <PathIcon Data="{StaticResource XShapePath}" Height="5" Width="5"
-                            Foreground="{DynamicResource ControlForegroundAccentHighBrush}" />
-               </Button>
-            </Template>
-         </Setter>
-      </Style>
-   </ControlTheme>
+    <Style Selector="^.clearButton[AcceptsReturn=False][IsReadOnly=False]:focus:not(TextBox:empty)">
+      <Setter Property="InnerRightContent">
+        <Template>
+          <Button Theme="{StaticResource FluentTextBoxButton}"
+                  Command="{Binding $parent[TextBox].Clear}"
+                  ClipToBounds="True"
+                  Background="{DynamicResource TextBoxClearButtonBackgroundBrush}"
+                  CornerRadius="7">
+            <PathIcon Data="{StaticResource XShapePath}" Height="5" Width="5"
+                      Foreground="{DynamicResource ControlForegroundAccentHighBrush}" />
+          </Button>
+        </Template>
+      </Setter>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TreeViewItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TreeViewItem.axaml
@@ -2,156 +2,156 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:converters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls">
 
-   <ResourceDictionary.MergedDictionaries>
-      <ResourceInclude Source="/Accents/ThemeResources.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 
-   <Design.PreviewWith>
-      <Border Padding="20" MinWidth="300">
-         <TreeView>
-            <TreeViewItem Header="MacOS UI elements" IsExpanded="True" IsSelected="True">
-               <TreeViewItem Header="Button" IsExpanded="True">
-                  <TreeViewItem Header="Button comparison" />
-                  <TreeViewItem Header="default button" />
-                  <TreeViewItem Header="CheckBox">
-                     <TreeViewItem Header="CheckBox.psd" />
-                  </TreeViewItem>
-               </TreeViewItem>
-               <TreeViewItem Header="Level 2.2" IsEnabled="False" />
+  <Design.PreviewWith>
+    <Border Padding="20" MinWidth="300">
+      <TreeView>
+        <TreeViewItem Header="MacOS UI elements" IsExpanded="True" IsSelected="True">
+          <TreeViewItem Header="Button" IsExpanded="True">
+            <TreeViewItem Header="Button comparison" />
+            <TreeViewItem Header="default button" />
+            <TreeViewItem Header="CheckBox">
+              <TreeViewItem Header="CheckBox.psd" />
             </TreeViewItem>
-         </TreeView>
-      </Border>
-   </Design.PreviewWith>
+          </TreeViewItem>
+          <TreeViewItem Header="Level 2.2" IsEnabled="False" />
+        </TreeViewItem>
+      </TreeView>
+    </Border>
+  </Design.PreviewWith>
 
-   <converters:MarginMultiplierConverter Indent="{StaticResource TreeViewItemIndent}" Left="True" x:Key="TreeViewItemLeftMarginConverter" />
+  <converters:MarginMultiplierConverter Indent="{StaticResource TreeViewItemIndent}" Left="True" x:Key="TreeViewItemLeftMarginConverter" />
 
-   <ControlTheme x:Key="FluentTreeViewExpandCollapseChevron" TargetType="ToggleButton">
-      <Setter Property="Margin" Value="0" />
+  <ControlTheme x:Key="FluentTreeViewExpandCollapseChevron" TargetType="ToggleButton">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Width" Value="{StaticResource TreeViewItemChevronSize}" />
+    <Setter Property="Height" Value="{StaticResource TreeViewItemChevronSize}" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundMidBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Background="Transparent"
+          Width="{TemplateBinding Width}"
+          Height="{TemplateBinding Height}"
+          HorizontalAlignment="Center"
+          VerticalAlignment="Center">
+          <Path
+            Name="ChevronPath"
+            Data="{StaticResource ChevronPath}"
+            Fill="{TemplateBinding Foreground}"
+            Stretch="Uniform"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center">
+            <Path.RenderTransform>
+              <TransformGroup>
+                <RotateTransform Angle="90" />
+              </TransformGroup>
+            </Path.RenderTransform>
+          </Path>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:checked /template/ Path#ChevronPath">
+      <Setter Property="RenderTransform">
+        <RotateTransform Angle="180" />
+      </Setter>
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type TreeViewItem}" TargetType="TreeViewItem">
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrush}" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
+    <Setter Property="MinHeight" Value="22" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <StackPanel>
+          <Border
+            Name="PART_LayoutRoot"
+            Classes="TreeViewItemLayoutRoot"
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            CornerRadius="{TemplateBinding CornerRadius}"
+            MinHeight="{TemplateBinding MinHeight}"
+            TemplatedControl.IsTemplateFocusTarget="True">
+            <Grid
+              Name="PART_Header"
+              ColumnDefinitions="Auto, *"
+              Margin="{TemplateBinding Level, Mode=OneWay, Converter={StaticResource TreeViewItemLeftMarginConverter}}">
+              <Panel Name="PART_ExpandCollapseChevronContainer" Margin="{StaticResource TreeViewItemChevronMargin}">
+                <ToggleButton
+                  Name="PART_ExpandCollapseChevron"
+                  Theme="{StaticResource FluentTreeViewExpandCollapseChevron}"
+                  Focusable="False"
+                  IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}" />
+              </Panel>
+              <ContentPresenter
+                Name="PART_HeaderPresenter"
+                Grid.Column="1"
+                Focusable="False"
+                Background="Transparent"
+                Content="{TemplateBinding Header}"
+                ContentTemplate="{TemplateBinding HeaderTemplate}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                Margin="{TemplateBinding Padding}" />
+            </Grid>
+          </Border>
+          <ItemsPresenter
+            Name="PART_ItemsPresenter"
+            IsVisible="{TemplateBinding IsExpanded}"
+            ItemsPanel="{TemplateBinding ItemsPanel}" />
+        </StackPanel>
+      </ControlTemplate>
+    </Setter>
+
+    <!--  Disabled state  -->
+    <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource TreeViewItemBackgroundDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushDisabled}" />
+    </Style>
+    <Style Selector="^:disabled /template/ ContentPresenter#PART_HeaderPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForegroundDisabled}" />
+    </Style>
+
+    <!--  Selected state = tabbing focus -->
+    <!-- TODO: the tabbing _behaviour_ is not quite right - the selected item doesn't get unselected and you can't tab to all items -->
+    <Style Selector="^:selected /template/ Border#PART_LayoutRoot, ^:focus-visible /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="{WindowActiveResourceToggler TreeViewItemBackgroundSelected, SelectionInInactiveWindow}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushSelected}" />
+    </Style>
+    <Style Selector="^:selected /template/ ContentPresenter#PART_HeaderPresenter, ^:focus-visible /template/ ContentPresenter#PART_HeaderPresenter">
+      <Setter Property="Foreground" Value="{WindowActiveResourceToggler TreeViewItemForegroundSelected, ForegroundHighBrush}" />
+    </Style>
+    <Style Selector="^:selected /template/ ToggleButton#PART_ExpandCollapseChevron, ^:focus-visible /template/ ToggleButton#PART_ExpandCollapseChevron">
+      <Setter Property="Foreground" Value="{WindowActiveResourceToggler TreeViewItemForegroundSelected, ForegroundHighBrush}" />
+    </Style>
+
+    <!--  Disabled Selected state  -->
+    <Style Selector="^:disabled:selected /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource TreeViewItemBackgroundSelectedDisabled}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushSelectedDisabled}" />
+    </Style>
+    <Style Selector="^:disabled:selected /template/ Border#PART_LayoutRoot > ContentPresenter#PART_HeaderPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForegroundSelectedDisabled}" />
+    </Style>
+
+    <Style Selector="^:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
       <Setter Property="Width" Value="{StaticResource TreeViewItemChevronSize}" />
-      <Setter Property="Height" Value="{StaticResource TreeViewItemChevronSize}" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundMidBrush}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <Border
-               Background="Transparent"
-               Width="{TemplateBinding Width}"
-               Height="{TemplateBinding Height}"
-               HorizontalAlignment="Center"
-               VerticalAlignment="Center">
-               <Path
-                  Name="ChevronPath"
-                  Data="{StaticResource ChevronPath}"
-                  Fill="{TemplateBinding Foreground}"
-                  Stretch="Uniform"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Center">
-                  <Path.RenderTransform>
-                     <TransformGroup>
-                        <RotateTransform Angle="90" />
-                     </TransformGroup>
-                  </Path.RenderTransform>
-               </Path>
-            </Border>
-         </ControlTemplate>
-      </Setter>
-
-      <Style Selector="^:checked /template/ Path#ChevronPath">
-         <Setter Property="RenderTransform">
-            <RotateTransform Angle="180" />
-         </Setter>
-      </Style>
-   </ControlTheme>
-
-   <ControlTheme x:Key="{x:Type TreeViewItem}" TargetType="TreeViewItem">
-      <Setter Property="Padding" Value="0" />
-      <Setter Property="Background" Value="{DynamicResource TreeViewItemBackground}" />
-      <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrush}" />
-      <Setter Property="BorderThickness" Value="0" />
-      <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-      <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
-      <Setter Property="MinHeight" Value="22" />
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-      <Setter Property="VerticalAlignment" Value="Center" />
-      <Setter Property="FocusAdorner" Value="{x:Null}" />
-      <Setter Property="Template">
-         <ControlTemplate>
-            <StackPanel>
-               <Border
-                  Name="PART_LayoutRoot"
-                  Classes="TreeViewItemLayoutRoot"
-                  Background="{TemplateBinding Background}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="{TemplateBinding CornerRadius}"
-                  MinHeight="{TemplateBinding MinHeight}"
-                  TemplatedControl.IsTemplateFocusTarget="True">
-                  <Grid
-                     Name="PART_Header"
-                     ColumnDefinitions="Auto, *"
-                     Margin="{TemplateBinding Level, Mode=OneWay, Converter={StaticResource TreeViewItemLeftMarginConverter}}">
-                     <Panel Name="PART_ExpandCollapseChevronContainer" Margin="{StaticResource TreeViewItemChevronMargin}">
-                        <ToggleButton
-                           Name="PART_ExpandCollapseChevron"
-                           Theme="{StaticResource FluentTreeViewExpandCollapseChevron}"
-                           Focusable="False"
-                           IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}" />
-                     </Panel>
-                     <ContentPresenter
-                        Name="PART_HeaderPresenter"
-                        Grid.Column="1"
-                        Focusable="False"
-                        Background="Transparent"
-                        Content="{TemplateBinding Header}"
-                        ContentTemplate="{TemplateBinding HeaderTemplate}"
-                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        Margin="{TemplateBinding Padding}" />
-                  </Grid>
-               </Border>
-               <ItemsPresenter
-                  Name="PART_ItemsPresenter"
-                  IsVisible="{TemplateBinding IsExpanded}"
-                  ItemsPanel="{TemplateBinding ItemsPanel}" />
-            </StackPanel>
-         </ControlTemplate>
-      </Setter>
-
-      <!--  Disabled state  -->
-      <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
-         <Setter Property="Background" Value="{DynamicResource TreeViewItemBackgroundDisabled}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushDisabled}" />
-      </Style>
-      <Style Selector="^:disabled /template/ ContentPresenter#PART_HeaderPresenter">
-         <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForegroundDisabled}" />
-      </Style>
-
-      <!--  Selected state = tabbing focus -->
-      <!-- TODO: the tabbing _behaviour_ is not quite right - the selected item doesn't get unselected and you can't tab to all items -->
-      <Style Selector="^:selected /template/ Border#PART_LayoutRoot, ^:focus-visible /template/ Border#PART_LayoutRoot">
-         <Setter Property="Background" Value="{WindowActiveResourceToggler TreeViewItemBackgroundSelected, SelectionInInactiveWindow}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushSelected}" />
-      </Style>
-      <Style Selector="^:selected /template/ ContentPresenter#PART_HeaderPresenter, ^:focus-visible /template/ ContentPresenter#PART_HeaderPresenter">
-         <Setter Property="Foreground" Value="{WindowActiveResourceToggler TreeViewItemForegroundSelected, ForegroundHighBrush}" />
-      </Style>
-      <Style Selector="^:selected /template/ ToggleButton#PART_ExpandCollapseChevron, ^:focus-visible /template/ ToggleButton#PART_ExpandCollapseChevron">
-         <Setter Property="Foreground" Value="{WindowActiveResourceToggler TreeViewItemForegroundSelected, ForegroundHighBrush}" />
-      </Style>
-
-      <!--  Disabled Selected state  -->
-      <Style Selector="^:disabled:selected /template/ Border#PART_LayoutRoot">
-         <Setter Property="Background" Value="{DynamicResource TreeViewItemBackgroundSelectedDisabled}" />
-         <Setter Property="BorderBrush" Value="{DynamicResource TreeViewItemBorderBrushSelectedDisabled}" />
-      </Style>
-      <Style Selector="^:disabled:selected /template/ Border#PART_LayoutRoot > ContentPresenter#PART_HeaderPresenter">
-         <Setter Property="Foreground" Value="{DynamicResource TreeViewItemForegroundSelectedDisabled}" />
-      </Style>
-
-      <Style Selector="^:empty /template/ ToggleButton#PART_ExpandCollapseChevron">
-         <Setter Property="IsVisible" Value="False" />
-      </Style>
-      <Style Selector="^:empty /template/ Panel#PART_ExpandCollapseChevronContainer">
-         <Setter Property="Width" Value="{StaticResource TreeViewItemChevronSize}" />
-      </Style>
-   </ControlTheme>
+    </Style>
+  </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
@@ -1,31 +1,31 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-   <ResourceDictionary.MergedDictionaries>
-      <MergeResourceInclude Source="Button.axaml" />
-      <MergeResourceInclude Source="ButtonSpinner.axaml" />
-      <MergeResourceInclude Source="CheckBox.axaml" />
-      <MergeResourceInclude Source="ComboBox.axaml" />
-      <MergeResourceInclude Source="ComboBoxItem.axaml" />
-      <MergeResourceInclude Source="ContextMenu.axaml" />
-      <MergeResourceInclude Source="DataGrid.axaml" />
-      <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
-      <MergeResourceInclude Source="EditableComboBox.axaml" />
-      <MergeResourceInclude Source="GridSplitter.axaml" />
-      <MergeResourceInclude Source="Menu.axaml" />
-      <MergeResourceInclude Source="MenuFlyoutPresenter.axaml" />
-      <MergeResourceInclude Source="MenuItem.axaml" />
-      <MergeResourceInclude Source="NumericUpDown.axaml" />
-      <MergeResourceInclude Source="ScrollBar.axaml" />
-      <MergeResourceInclude Source="ScrollViewer.axaml" />
-      <MergeResourceInclude Source="Separator.axaml" />
-      <MergeResourceInclude Source="TabControl.axaml" />
-      <MergeResourceInclude Source="TabItem.axaml" />
-      <MergeResourceInclude Source="TextBox.axaml" />
-      <MergeResourceInclude Source="ToggleSwitch.axaml" />
-      <MergeResourceInclude Source="ToolTip.axaml" />
-      <MergeResourceInclude Source="TreeView.axaml" />
-      <MergeResourceInclude Source="TreeViewItem.axaml" />
-      <MergeResourceInclude Source="Window.axaml" />
-   </ResourceDictionary.MergedDictionaries>
+  <ResourceDictionary.MergedDictionaries>
+    <MergeResourceInclude Source="Button.axaml" />
+    <MergeResourceInclude Source="ButtonSpinner.axaml" />
+    <MergeResourceInclude Source="CheckBox.axaml" />
+    <MergeResourceInclude Source="ComboBox.axaml" />
+    <MergeResourceInclude Source="ComboBoxItem.axaml" />
+    <MergeResourceInclude Source="ContextMenu.axaml" />
+    <MergeResourceInclude Source="DataGrid.axaml" />
+    <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
+    <MergeResourceInclude Source="EditableComboBox.axaml" />
+    <MergeResourceInclude Source="GridSplitter.axaml" />
+    <MergeResourceInclude Source="Menu.axaml" />
+    <MergeResourceInclude Source="MenuFlyoutPresenter.axaml" />
+    <MergeResourceInclude Source="MenuItem.axaml" />
+    <MergeResourceInclude Source="NumericUpDown.axaml" />
+    <MergeResourceInclude Source="ScrollBar.axaml" />
+    <MergeResourceInclude Source="ScrollViewer.axaml" />
+    <MergeResourceInclude Source="Separator.axaml" />
+    <MergeResourceInclude Source="TabControl.axaml" />
+    <MergeResourceInclude Source="TabItem.axaml" />
+    <MergeResourceInclude Source="TextBox.axaml" />
+    <MergeResourceInclude Source="ToggleSwitch.axaml" />
+    <MergeResourceInclude Source="ToolTip.axaml" />
+    <MergeResourceInclude Source="TreeView.axaml" />
+    <MergeResourceInclude Source="TreeViewItem.axaml" />
+    <MergeResourceInclude Source="Window.axaml" />
+  </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Converters/CharToMacOsPasswordCharConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Converters/CharToMacOsPasswordCharConverter.cs
@@ -5,14 +5,14 @@ using Avalonia.Data.Converters;
 
 public class CharToMacOsPasswordCharConverter : IValueConverter
 {
-    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        const char blackCircleSymbol = '\u25CF';
-        const char emptyCharacter = '\0';
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    const char blackCircleSymbol = '\u25CF';
+    const char emptyCharacter = '\0';
 
-        return value is char and not emptyCharacter ? blackCircleSymbol : emptyCharacter;
-    }
+    return value is char and not emptyCharacter ? blackCircleSymbol : emptyCharacter;
+  }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotImplementedException();
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
 }

--- a/src/Devolutions.AvaloniaTheme.MacOS/Converters/MacOSConverters.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Converters/MacOSConverters.cs
@@ -1,6 +1,6 @@
 namespace Devolutions.AvaloniaTheme.MacOS.Converters;
 
-public static partial class MacOSConverters
+public static class MacOSConverters
 {
-    public static readonly CharToMacOsPasswordCharConverter CharToMacOsPasswordCharConverter = new();
+  public static readonly CharToMacOsPasswordCharConverter CharToMacOsPasswordCharConverter = new();
 }

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
-   <PropertyGroup>
-      <Version>1.0.0.0</Version>
-      <Company>Devolutions</Company>
-      <Description>Devolutions Avalonia macOS Theme</Description>
-      <PackageId>Devolutions.AvaloniaTheme.MacOS</PackageId>
-      <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <TargetFramework>net9.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
-      <Nullable>enable</Nullable>
-   </PropertyGroup>
-   <ItemGroup>
-      <PackageReference Include="Avalonia" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)" />
-      <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
-      <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)" />
-   </ItemGroup>
-   <ItemGroup>
-      <AvaloniaResource Include="Accents/Assets/**" />
-   </ItemGroup>
-   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-      <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
-   </ItemGroup>
+  <PropertyGroup>
+    <Version>1.0.0.0</Version>
+    <Company>Devolutions</Company>
+    <Description>Devolutions Avalonia macOS Theme</Description>
+    <PackageId>Devolutions.AvaloniaTheme.MacOS</PackageId>
+    <PackageProjectUrl>https://github.com/Devolutions/avalonia-extensions</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)"/>
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)"/>
+    <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.5.28,)"/>
+  </ItemGroup>
+  <ItemGroup>
+    <AvaloniaResource Include="Accents/Assets/**"/>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
+  </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/MacOSTheme.axaml
@@ -1,25 +1,25 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-   <!-- Using Fluent Theme as a fallback for anything not defined in MacOS theme
+  <!-- Using Fluent Theme as a fallback for anything not defined in MacOS theme
        NOTE: the Simple Theme does not give access to System colours 
        See https://github.com/AvaloniaUI/Avalonia/pull/11097 for how it's getting the colours (if we ever want to make this independent of Fluent) -->
-   <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
+  <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.axaml" />
 
-   <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
+  <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
 
-   <Styles.Resources>
-      <ResourceDictionary>
-         <ResourceDictionary.MergedDictionaries>
-            <MergeResourceInclude Source="/Accents/Icons.axaml" />
-            <MergeResourceInclude Source="/Controls/_index.axaml" />
-            <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
-            <!-- TODO: Theme variants not handled consistently yet - use Shared / Light / Dark for everything (cp. Semi.Avalonia for good example) -->
-            <MergeResourceInclude Source="/Accents/Shared/ToggleSwitch.axaml" />
-            <MergeResourceInclude Source="/Accents/Light/ToggleSwitch.axaml" />
-         </ResourceDictionary.MergedDictionaries>
-      </ResourceDictionary>
-   </Styles.Resources>
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="/Accents/Icons.axaml" />
+        <MergeResourceInclude Source="/Controls/_index.axaml" />
+        <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
+        <!-- TODO: Theme variants not handled consistently yet - use Shared / Light / Dark for everything (cp. Semi.Avalonia for good example) -->
+        <MergeResourceInclude Source="/Accents/Shared/ToggleSwitch.axaml" />
+        <MergeResourceInclude Source="/Accents/Light/ToggleSwitch.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
 
-   <!-- Themed Controls -->
-   <StyleInclude Source="/Accents/Styles.axaml" />
+  <!-- Themed Controls -->
+  <StyleInclude Source="/Accents/Styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/README.md
+++ b/src/Devolutions.AvaloniaTheme.MacOS/README.md
@@ -7,19 +7,21 @@ Custom Avalonia Themes developed by [Devolutions](https://devolutions.net/)
 [![NuGet Version](https://img.shields.io/nuget/vpre/Devolutions.AvaloniaTheme.MacOS)](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.MacOS)
 ![NuGet Downloads](https://img.shields.io/nuget/dt/Devolutions.AvaloniaTheme.MacOS)
 
-
 ## MacOS Theme [Work in Progress]
-(Inspired by [@MikeCodesDotNET's earlier draft](https://github.com/AvaloniaUI/Avalonia/issues/14880#issuecomment-1985425341))
+
+(Inspired
+by [@MikeCodesDotNET's earlier draft](https://github.com/AvaloniaUI/Avalonia/issues/14880#issuecomment-1985425341))
 
 ![image](https://github.com/user-attachments/assets/33d9a103-936f-4db3-b5cc-520a5ccdaf60)
 
-
-This theme is currently based on [Avalonia.Themes.Fluent](https://github.com/AvaloniaUI/Avalonia/tree/759facea182b7771ce07baf173c52529f4871004/src/Avalonia.Themes.Fluent), 
-both as a fallback for any controls not covered yet and as starting point for our (somewhat simplified) 
+This theme is currently based
+on [Avalonia.Themes.Fluent](https://github.com/AvaloniaUI/Avalonia/tree/759facea182b7771ce07baf173c52529f4871004/src/Avalonia.Themes.Fluent),
+both as a fallback for any controls not covered yet and as starting point for our (somewhat simplified)
 style definitions targeting AppKit macOS look.
 
-While we are prioritizing controls for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/) initially,
-the goal is to create a theme that helps all of the Avalonia community to bring a native look to their macOS apps. 
+While we are prioritizing controls
+for [Devolutions Remote Desktop Manager](https://devolutions.net/remote-desktop-manager/) initially,
+the goal is to create a theme that helps all of the Avalonia community to bring a native look to their macOS apps.
 
 - [Installation](#installation)
 - [Styled Controls](#styled-controls)
@@ -39,7 +41,7 @@ the goal is to create a theme that helps all of the Avalonia community to bring 
       - [ButtonSpinner](#buttonspinner)
     - [ScrollViewer](#scrollviewer)
       - [ScrollBar](#scrollbar)
-    - [Separator](#separator) 
+    - [Separator](#separator)
     - [TabControl](#tabcontrol)
       - [TabItem](#tabitem)
     - [TextBox](#textbox)
@@ -52,19 +54,24 @@ the goal is to create a theme that helps all of the Avalonia community to bring 
     - small improvements & fixes, some code cleanup
   - 🔮 Next on the road map ...
     - AutoCompleteBox
-    
-
 
 ## Installation
-Install the Devolutions.AvaloniaTheme.MacOS package via [NuGet](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.MacOS):
+
+Install the Devolutions.AvaloniaTheme.MacOS package
+via [NuGet](https://www.nuget.org/packages/Devolutions.AvaloniaTheme.MacOS):
+
 ``` bash
 Install-Package Devolutions.AvaloniaTheme.MacOS
 ```
+
 or .NET
+
 ```bash
 dotnet add package Devolutions.AvaloniaTheme.MacOS
 ```
+
 In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<SimpleTheme />`) with the macOS theme:
+
 ``` xaml
 <Application ...>
   <Application.Styles>


### PR DESCRIPTION
- Adjust indents to 2 everywhere
- Apply the new formatting and code style rules introduced in #157 everywhere to be more in line with company standards and from now on avoid bloated diffs where little code changes are obscured by lots of auto-formatting changes
- In the .cs files I reverted a few changes where I wasn't 100% sure if they're ok, because I didn't want to waste too much time on this with testing ... - I just want the bulk of the code to be compliant
- Also reverted auto-formatting of some alphabetic field sorting, where it separated clearly related variables (maybe we should remove that rule and favour logical structuring ...)