### PR TITLE
Workaround for Markup Extensions with variable amount of parameters

### DIFF
--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/AddBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/AddBinding.cs
@@ -5,9 +5,16 @@ using Converters;
 
 public class AddBinding : AbstractMultipleValueBinding<double>
 {
-  public AddBinding(object a, object b) : base(a, b) { }
+    // @formatter:off
+    public AddBinding(object b1, object b2) : base(b1, b2) { }
+    public AddBinding(object b1, object b2, object b3) : base(b1, b2, b3) { }
+    public AddBinding(object b1, object b2, object b3, object b4) : base(b1, b2, b3, b4) { }
+    public AddBinding(object b1, object b2, object b3, object b4, object b5) : base(b1, b2, b3, b4, b5) { }
+    public AddBinding(object b1, object b2, object b3, object b4, object b5, object b6) : base(b1, b2, b3, b4, b5, b6) { }
+    public AddBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7) : base(b1, b2, b3, b4, b5, b6, b7) { }
+    public AddBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8) : base(b1, b2, b3, b4, b5, b6, b7, b8) { }
+    public AddBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8, object b9) : base(b1, b2, b3, b4, b5, b6, b7, b8, b9) { }
+    // @formatter:on
 
-  public AddBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
-
-  protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Add;
+    protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Add;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/AndBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/AndBinding.cs
@@ -4,9 +4,16 @@ using Avalonia.Data.Converters;
 
 public class AndBinding : AbstractMultipleValueBinding<bool>
 {
-  public AndBinding(object a, object b) : base(a, b) { }
+    // @formatter:off
+    public AndBinding(object b1, object b2) : base(b1, b2) { }
+    public AndBinding(object b1, object b2, object b3) : base(b1, b2, b3) { }
+    public AndBinding(object b1, object b2, object b3, object b4) : base(b1, b2, b3, b4) { }
+    public AndBinding(object b1, object b2, object b3, object b4, object b5) : base(b1, b2, b3, b4, b5) { }
+    public AndBinding(object b1, object b2, object b3, object b4, object b5, object b6) : base(b1, b2, b3, b4, b5, b6) { }
+    public AndBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7) : base(b1, b2, b3, b4, b5, b6, b7) { }
+    public AndBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8) : base(b1, b2, b3, b4, b5, b6, b7, b8) { }
+    public AndBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8, object b9) : base(b1, b2, b3, b4, b5, b6, b7, b8, b9) { }
+    // @formatter:on
 
-  public AndBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
-
-  protected override IMultiValueConverter MultiValueConverter => BoolConverters.And;
+    protected override IMultiValueConverter MultiValueConverter => BoolConverters.And;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/MultiplyBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/MultiplyBinding.cs
@@ -5,9 +5,16 @@ using Converters;
 
 public class MultiplyBinding : AbstractMultipleValueBinding<double>
 {
-  public MultiplyBinding(object a, object b) : base(a, b) { }
+    // @formatter:off
+    public MultiplyBinding(object b1, object b2) : base(b1, b2) { }
+    public MultiplyBinding(object b1, object b2, object b3) : base(b1, b2, b3) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4) : base(b1, b2, b3, b4) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4, object b5) : base(b1, b2, b3, b4, b5) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4, object b5, object b6) : base(b1, b2, b3, b4, b5, b6) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7) : base(b1, b2, b3, b4, b5, b6, b7) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8) : base(b1, b2, b3, b4, b5, b6, b7, b8) { }
+    public MultiplyBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8, object b9) : base(b1, b2, b3, b4, b5, b6, b7, b8, b9) { }
+    // @formatter:on
 
-  public MultiplyBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
-
-  protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Multiply;
+    protected override IMultiValueConverter MultiValueConverter => DevoDoubleConverters.Multiply;
 }

--- a/src/Devolutions.AvaloniaControls/MarkupExtensions/OrBinding.cs
+++ b/src/Devolutions.AvaloniaControls/MarkupExtensions/OrBinding.cs
@@ -4,9 +4,16 @@ using Avalonia.Data.Converters;
 
 public class OrBinding : AbstractMultipleValueBinding<bool>
 {
-  public OrBinding(object a, object b) : base(a, b) { }
+    // @formatter:off
+    public OrBinding(object b1, object b2) : base(b1, b2) { }
+    public OrBinding(object b1, object b2, object b3) : base(b1, b2, b3) { }
+    public OrBinding(object b1, object b2, object b3, object b4) : base(b1, b2, b3, b4) { }
+    public OrBinding(object b1, object b2, object b3, object b4, object b5) : base(b1, b2, b3, b4, b5) { }
+    public OrBinding(object b1, object b2, object b3, object b4, object b5, object b6) : base(b1, b2, b3, b4, b5, b6) { }
+    public OrBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7) : base(b1, b2, b3, b4, b5, b6, b7) { }
+    public OrBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8) : base(b1, b2, b3, b4, b5, b6, b7, b8) { }
+    public OrBinding(object b1, object b2, object b3, object b4, object b5, object b6, object b7, object b8, object b9) : base(b1, b2, b3, b4, b5, b6, b7, b8, b9) { }
+    // @formatter:on
 
-  public OrBinding(object a, object b, params object[] extraBindings) : base(a, b, extraBindings) { }
-
-  protected override IMultiValueConverter MultiValueConverter => BoolConverters.Or;
+    protected override IMultiValueConverter MultiValueConverter => BoolConverters.Or;
 }


### PR DESCRIPTION
Sadly, variadic constructors (variable parameter numbers with the `params` keyword) don't seem well-supported in axaml.

We'll work-around this by exposing 9 constructors with flat parameter numbers, and these markup extensions can be embedded inside one another, so this will cover all possible use-cases, but is less convenient than if variadic were properly supported :(