### PR TITLE
[MacOS] Fix tabs

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -61,6 +61,8 @@
       <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.10" />
       <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.20" />
 
+      <SolidColorBrush x:Key="TabItemSelectedPressedBrush" Color="#f0f0f0" />
+      
       <BoxShadows x:Key="TextBoxBorderShadows">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
       <BoxShadows x:Key="ControlBorderBoxShadow">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
       <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26000000, 0 0 0 0.5 #08000000</BoxShadows>
@@ -149,7 +151,7 @@
 
       <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
       <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
-      <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.09" />
+      <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.05" />
 
       <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
       <SolidColorBrush x:Key="LayoutBorderMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
@@ -169,6 +171,8 @@
       <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.14" />
       <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
 
+      <SolidColorBrush x:Key="TabItemSelectedPressedBrush" Color="#666666" />
+      
       <BoxShadows x:Key="TextBoxBorderShadows">0 1 1 0 #4dffffff</BoxShadows>
       <BoxShadows x:Key="ControlBorderBoxShadow">0 0 Transparent</BoxShadows>
       <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 0.5 2.5 0 #26ffffff, 0 0 0 0.5 #08ffffff</BoxShadows>
@@ -344,7 +348,7 @@
   </VisualBrush>
 
   <!-- TabControl & TabItem Resources -->
-  <Thickness x:Key="TabItemPadding">8 2</Thickness>
+  <Thickness x:Key="TabItemPadding">16 2</Thickness>
   <SolidColorBrush x:Key="TabControlBackgroundBrush" Color="{DynamicResource TabControlBackgroundColor}" />
 
   <!-- CheckBox Resources -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -257,7 +257,7 @@
   <Thickness x:Key="BorderThickness">1</Thickness>
 
   <Thickness x:Key="InputControlsSpaceForFocusBorder">1.5</Thickness>
-  <Thickness x:Key="TabControlSpaceForFocusFactors">3</Thickness>
+  <Thickness x:Key="TabControlSpaceForFocusFactors">2 2 2 0</Thickness>
 
   <x:Double x:Key="DefaultFontSize">13</x:Double>
   <x:Double x:Key="ControlFontSize">13</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -42,7 +42,6 @@
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
 
   <ControlTheme x:Key="{x:Type TabControl}" TargetType="TabControl">
-    <!-- <Setter Property="Margin" Value="5" /> -->
     <Setter Property="Padding" Value="10" />
     <Setter Property="Background" Value="Transparent" />
 
@@ -51,6 +50,7 @@
       <Setter Property="BorderThickness" Value="{DynamicResource BorderThickness}" />
       <Setter Property="CornerRadius" Value="{DynamicResource LayoutCornerRadius}" />
       <Setter Property="ClipToBounds" Value="False" />
+      <Setter Property="Padding" Value="10 -10 10 10" />
       <Setter Property="Template">
         <ControlTemplate>
           <Border Background="{TemplateBinding Background}"
@@ -61,6 +61,13 @@
               <Border Name="TabstripPanel"
                       ClipToBounds="False"
                       UseLayoutRounding="False"
+                      Background="{DynamicResource TabControlBackgroundBrush}"
+                      HorizontalAlignment="Center"
+                      BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+                      BorderThickness="0.5 1 0.5 0.6"
+                      CornerRadius="{DynamicResource ControlCornerRadius}"
+                      Padding="0"
+                      ZIndex="1"
                       DockPanel.Dock="{TemplateBinding TabStripPlacement}">
                 <Border.Margin>
                   <Binding Source="{StaticResource InputControlsSpaceForFocusBorder}"
@@ -84,21 +91,11 @@
           </Border>
         </ControlTemplate>
       </Setter>
-      <Setter Property="Padding" Value="10 -10 10 10" />
-      <Style Selector="^/template/ Border#TabstripPanel">
-        <Setter Property="Background" Value="{DynamicResource TabControlBackgroundBrush}" />
-        <Setter Property="HorizontalAlignment" Value="Center" />
-        <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
-        <Setter Property="BorderThickness" Value="0 1 0 0.6" />
-        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="ZIndex" Value="1" />
-      </Style>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter">
         <Setter Property="Margin" Value="0" />
       </Style>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-        <Setter Property="Margin" Value="-4 0 0 0" />
+        <Setter Property="Margin" Value="0 0 0 0" />
       </Style>
       <Style Selector="^/template/ ContentPresenter#PART_SelectedContentHost">
         <Setter Property="Padding" Value="20" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
@@ -7,7 +7,7 @@
 
   <Design.PreviewWith>
     <ThemeVariantScope RequestedThemeVariant="Dark">
-      <Border Background="#212121">
+      <Border Background="{DynamicResource BackgroundBrush}">
         <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
           <Border Width="500">
             <TabControl TabStripPlacement="Left" Margin="5">
@@ -66,12 +66,9 @@
     </ThemeVariantScope>
   </Design.PreviewWith>
 
-  <!-- Shifting the divider right up to the left neighbour -->
+  <!-- Shifting the tab to the left to cover the divider of its left neighbour -->
   <Thickness x:Key="TabItemDividerMargin">-2, 0, 0, 0</Thickness>
-  <!-- Shifting the 'selected' border to the right to hide the divider -->
-  <Thickness x:Key="TabItemSelectedMargin">1, 0, -1, 0</Thickness>
-  <!-- = ButtonDefaultPadding + 1px horizontal offset to keep the text position stable as the margin shifts -->
-  <Thickness x:Key="TabItemSelectedOffsetPadding">7, 2, 9, 2</Thickness>
+
 
   <ControlTheme x:Key="{x:Type TabItem}" TargetType="TabItem">
     <Setter Property="Background" Value="Transparent" />
@@ -81,8 +78,8 @@
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
-    <Setter Property="Margin" Value="0" />
-    <Setter Property="Padding" Value="{DynamicResource TabItemPadding}" />
+    <Setter Property="Margin" Value="{DynamicResource TabItemDividerMargin}" />
+    <Setter Property="Padding" Value="{DynamicResource TabItemPadding} " />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ClipToBounds" Value="False" />
 
@@ -94,34 +91,23 @@
       <Setter Property="Template">
         <ControlTemplate>
           <Panel>
-            <StackPanel Orientation="Horizontal">
-              <!-- POTENTIALLY FRAGILE HACK (TODO: test with different user font size settings ...?)
-                 The TextBlock as divider works better than Rectangle, because the pipe character is anti-aliased.
-                 A better option might be to track the selected tab in code-behind and attach a property addressing the 
-                 tab to the right of it somehow ... Or check DataGrid ColumnHeader - that works fine with Rectangle TODO: ??? -->
-              <TextBlock Name="TabDivider"
-                         Foreground="{DynamicResource ForegroundLowBrush}"
-                         VerticalAlignment="Center"
-                         Margin="{DynamicResource TabItemDividerMargin}">
-                |
-              </TextBlock>
-              <!-- <Rectangle Name="TabDivider" -->
-              <!--            Height="14" -->
-              <!--            Width="1" -->
-              <!--            Fill="{DynamicResource ForegroundLowBrush}" -->
-              <!--            VerticalAlignment="Center" /> -->
-              <ContentPresenter Name="PART_ContentPresenter"
-                                Padding="{TemplateBinding Padding}"
-                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Background="{TemplateBinding Background}"
-                                BorderBrush="{TemplateBinding BorderBrush}"
-                                BorderThickness="{TemplateBinding BorderThickness}"
-                                Content="{TemplateBinding Header}"
-                                ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                CornerRadius="{TemplateBinding CornerRadius}"
-                                RecognizesAccessKey="True" />
-            </StackPanel>
+            <Border Name="TabDivider"
+                    Height="12"
+                    VerticalAlignment="Center"
+                    Background="Transparent"
+                    BorderThickness=" 0 0  1 0"
+                    BorderBrush="{DynamicResource ForegroundLowBrush}" />
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Padding="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Background="{TemplateBinding Background}"
+                              BorderBrush="{TemplateBinding BorderBrush}"
+                              BorderThickness="{TemplateBinding BorderThickness}"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              CornerRadius="{TemplateBinding CornerRadius}"
+                              RecognizesAccessKey="True" />
             <Border Name="FocusBorderElement"
                     Margin="-1 -3 -3 -3"
                     BorderThickness="{StaticResource FocusBorderThickness}"
@@ -137,11 +123,11 @@
         </Style>
       </Style>
 
-      <Style Selector="^:nth-child(1) /template/ TextBlock#TabDivider">
-        <Setter Property="Foreground" Value="Transparent" />
+      <Style Selector="^:nth-last-child(1) /template/ Border#TabDivider">
+        <Setter Property="BorderBrush" Value="Transparent" />
       </Style>
-      <Style Selector="^:selected /template/ TextBlock#TabDivider">
-        <Setter Property="Foreground" Value="Transparent" />
+      <Style Selector="^:selected /template/ Border#TabDivider">
+        <Setter Property="BorderBrush" Value="Transparent" />
       </Style>
       <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
@@ -149,9 +135,8 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ForegroundLowBrush}" />
         <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
       </Style>
-      <Style Selector="^:selected:not(:nth-last-child(1)) /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Margin" Value="{DynamicResource TabItemSelectedMargin}" />
-        <Setter Property="Padding" Value="{DynamicResource TabItemSelectedOffsetPadding}" />
+      <Style Selector="^:selected:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource TabItemSelectedPressedBrush}" />
       </Style>
     </Style>
 


### PR DESCRIPTION
#154 introduced a slightly more visible little line next to selected tabs, and #155 broke the vertical alignment of the tabstrip to the tab body.

This fixes both, but also removes the previous fragile implementation of the divider lines as pipe characters, replacing them with a border and moving each tab's divider line to the _right_ which allows the next tab's selection border to completely hide the divider (since tabs further to the right are above the previous ones on the z-axis)

Also corrected the body colour for dark mode.

Added a `:selected:pressed` state, but kept the dark mode colour deliberately more subtle than native MacOS, since Avalonia doesn't distinguish between '_already selected & then pressed_' which is supposed to flash a clear "hey, I'm already selected!' colour, and '_pressed & becoming selected_' which looks really jarring when the colour difference between the two states is too big.