### PR TITLE
[MacOS & DevExpress] Add/tweak styling for DataGrid grouped row header & gridlines

### DIFF
--- a/samples/SampleApp/DemoPages/DataGridGroupedDemo.axaml
+++ b/samples/SampleApp/DemoPages/DataGridGroupedDemo.axaml
@@ -12,20 +12,67 @@
     <vm:DataGridGroupedViewModel />
   </Design.DataContext>
 
-  <DataGrid Margin="20" ItemsSource="{Binding Items}"
-            GridLinesVisibility="None">
-    <DataGrid.Columns>
-      <DataGridTemplateColumn Header="">
-        <DataGridTemplateColumn.CellTemplate>
-          <DataTemplate>
-            <Svg Path="/Assets/Computer.svg" Width="20" Height="20" Css=".st0 {fill: #3B86EA}" />
-          </DataTemplate>
-        </DataGridTemplateColumn.CellTemplate>
-      </DataGridTemplateColumn>
-      <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" x:DataType="local:DataGridItem" />
-      <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" />
-      <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" />
-      <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" />
-    </DataGrid.Columns>
-  </DataGrid>
+  <StackPanel Spacing="20"
+              Margin="20">
+    <DataGrid ItemsSource="{Binding Items}"
+              Height="280"
+              GridLinesVisibility="None">
+
+      <DataGrid.Styles>
+        <Style Selector="DataGridRowGroupHeader">
+          <Setter Property="IsPropertyNameVisible" Value="True" />
+          <Setter Property="IsItemCountVisible" Value="True" />
+        </Style>
+      </DataGrid.Styles>
+
+      <DataGrid.Columns>
+        <DataGridTemplateColumn Header="">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate>
+              <Svg Path="/Assets/Computer.svg" Width="20" Height="20" Css=".st0 {fill: #3B86EA}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" />
+      </DataGrid.Columns>
+    </DataGrid>
+    <TextBlock>
+      Display of the property by which items are grouped (here 'Type') and the number of items in the group can be enabled with:
+    </TextBlock>
+    <TextBlock Classes="code"
+               HorizontalAlignment="Left"
+               Margin="5 -5 0 0 "
+               Padding="5 8 6 8">
+      <TextBlock.Inlines>
+        <Run Text=" &lt;Style Selector=&quot;DataGridRowGroupHeader&quot;&gt;&#x0a;" />
+        <Run Text="  &lt;Setter Property=&quot;IsPropertyNameVisible&quot; Value=&quot;True&quot; /&gt;&#x0a;" />
+        <Run Text="  &lt;Setter Property=&quot;IsItemCountVisible&quot; Value=&quot;True&quot; /&gt;&#x0a;" />
+        <Run Text="&lt;/Style&gt;" />
+      </TextBlock.Inlines>
+    </TextBlock>
+
+    <DataGrid ItemsSource="{Binding Items}"
+              Height="280"
+              GridLinesVisibility="All">
+      <DataGrid.Columns>
+        <DataGridTemplateColumn Header="">
+          <DataGridTemplateColumn.CellTemplate>
+            <DataTemplate>
+              <Svg Path="/Assets/Computer.svg" Width="20" Height="20" Css=".st0 {fill: #3B86EA}" />
+            </DataTemplate>
+          </DataGridTemplateColumn.CellTemplate>
+        </DataGridTemplateColumn>
+        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" />
+      </DataGrid.Columns>
+    </DataGrid>
+
+    <TextBlock>
+      Display of Gridlines can be enabled with the property <TextBlock Classes="code" Text="GridLinesVisibility=&quot;All&quot;" /> (Default under DevExpress)
+    </TextBlock>
+
+  </StackPanel>
 </UserControl>

--- a/samples/SampleApp/ViewModels/DataGridGroupedViewModel.cs
+++ b/samples/SampleApp/ViewModels/DataGridGroupedViewModel.cs
@@ -11,13 +11,13 @@ public class DataGridGroupedViewModel : ObservableObject
   {
     List<DataGridItem> items =
     [
-      new("computer", "PDQ-VM", "PDQ-VM$", "6/26/2023"),
-      new("user", "AD TEST Guy2", "ADGuysam", "5/2/2023"),
-      new("user", "krbtgt", "krbtgt", "11/10/2021"),
-      new("computer", "WIN11-VM-BT", "WIN11-VM-BT$", "11/12/2021"),
-      new("computer", "RDS6", "RDS6$", "30/03/2021"),
-      new("computer", "MSSQL1", "MSSQL1$", "14/10/2024"),
-      new("computer", "ITMANGER-DRIVE", "ITMANGER-DRIVE$", "13/10/2021")
+      new("Computer", "PDQ-VM", "PDQ-VM$", "6/26/2023"),
+      new("User", "AD TEST Guy2", "ADGuysam", "5/2/2023"),
+      new("User", "krbtgt", "krbtgt", "11/10/2021"),
+      new("Computer", "WIN11-VM-BT", "WIN11-VM-BT$", "11/12/2021"),
+      new("Computer", "RDS6", "RDS6$", "30/03/2021"),
+      new("Computer", "MSSQL1", "MSSQL1$", "14/10/2024"),
+      new("Computer", "ITMANGER-DRIVE", "ITMANGER-DRIVE$", "13/10/2021")
     ];
     this.Items = new DataGridCollectionView(items);
     this.Items.GroupDescriptions.Add(new DataGridPathGroupDescription("ItemType"));

--- a/src/Devolutions.AvaloniaControls/Converters/DevoMultiConverters.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/DevoMultiConverters.cs
@@ -3,6 +3,7 @@ namespace Devolutions.AvaloniaControls.Converters;
 public static class DevoMultiConverters
 {
   public static readonly BooleanToChoiceConverter BooleanToChoiceConverter = new();
+  public static readonly OptionsToChoiceConverter OptionsToChoiceConverter = new();
   public static readonly ClassToChoiceConverter ClassToChoiceConverter = new();
   public static readonly IsExplicitlyTrueConverter IsExplicitlyTrueConverter = new();
   public static readonly IsUnsetConverter IsUnsetConverter = new();

--- a/src/Devolutions.AvaloniaControls/Converters/OptionsToChoiceConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/OptionsToChoiceConverter.cs
@@ -1,0 +1,35 @@
+namespace Devolutions.AvaloniaControls.Converters;
+
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+/// <summary>
+///   Allows to provide different choices for each of the given options.
+/// </summary>
+/// <param name="values[0]">The input that the choice depends on (e.g. 'Horizontal').</param>
+/// <param name="values[1..]">The choices (AvaloniaProperty values).</param>
+/// <param name="parameter">
+///   A string containing two or more options that determine the choice, separated by commas (e.g.
+///   'None,Horizontal,Vertical,All').
+/// </param>
+/// <returns>An AvaloniaProperty value.</returns>
+/// <remarks>
+///   Given choices are mapped to the list of possible options - if there are less choices than options, the last choice is
+///   used as default.
+/// </remarks>
+public class OptionsToChoiceConverter : IMultiValueConverter
+{
+  public object Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+  {
+    string option = values[0]?.ToString() ?? string.Empty;
+    string[] options = (parameter as string)?.Split(',') ?? [];
+    int optionsIndex = Array.IndexOf(options, option);
+
+    object? selectedChoice = optionsIndex + 1 < values.Count ? values[optionsIndex + 1] : values[^1];
+    return selectedChoice ?? AvaloniaProperty.UnsetValue;
+  }
+
+  public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
+}

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -107,6 +107,7 @@
   <SolidColorBrush x:Key="BorderBrush" Color="{DynamicResource BorderColor}" />
 
   <SolidColorBrush x:Key="ForegroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.90" />
+  <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />
   <SolidColorBrush x:Key="ForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.55" />
 
   <SolidColorBrush x:Key="SystemControlErrorTextForegroundBrush" Color="{DynamicResource ErrorTextColor}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/DataGrid.axaml
@@ -352,7 +352,7 @@
   </ControlTheme>
 
   <!-- RowGroupExpanderButton -->
-  <ControlTheme x:Key="FluentDataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
+  <ControlTheme x:Key="DataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
     <Setter Property="Template">
       <ControlTemplate>
         <Border Width="12"
@@ -403,7 +403,7 @@
                           Width="12"
                           Height="12"
                           Margin="12,0,0,0"
-                          Theme="{StaticResource FluentDataGridRowGroupExpanderButtonTheme}"
+                          Theme="{StaticResource DataGridRowGroupExpanderButtonTheme}"
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           Background="{TemplateBinding Background}"
@@ -411,22 +411,24 @@
                           IsTabStop="False"
                           Foreground="{TemplateBinding Foreground}" />
 
-            <StackPanel Grid.Column="3"
-                        Orientation="Horizontal"
-                        VerticalAlignment="Center"
-                        Margin="12,0,0,0">
+            <DockPanel Grid.Column="3"
+                       Grid.ColumnSpan="2"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Stretch"
+                       Margin="12,0">
               <TextBlock Name="PART_PropertyNameElement"
+                         DockPanel.Dock="Left"
                          Margin="4,0,0,0"
                          IsVisible="{TemplateBinding IsPropertyNameVisible}"
+                         Foreground="{DynamicResource ForegroundMidBrush}" />
+              <TextBlock Name="PART_ItemCountElement"
+                         DockPanel.Dock="Right"
+                         IsVisible="{TemplateBinding IsItemCountVisible}"
                          Foreground="{TemplateBinding Foreground}" />
               <TextBlock Margin="4,0,0,0"
                          Text="{Binding Key}"
                          Foreground="{TemplateBinding Foreground}" />
-              <TextBlock Name="PART_ItemCountElement"
-                         Margin="4,0,0,0"
-                         IsVisible="{TemplateBinding IsItemCountVisible}"
-                         Foreground="{TemplateBinding Foreground}" />
-            </StackPanel>
+            </DockPanel>
 
             <Rectangle Name="CurrencyVisual"
                        Grid.ColumnSpan="5"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -257,6 +257,7 @@
   <CornerRadius x:Key="LayoutCornerRadius">5</CornerRadius>
   <CornerRadius x:Key="ControlCornerRadius">5</CornerRadius>
   <CornerRadius x:Key="SelectionCornerRadius">4</CornerRadius>
+  <CornerRadius x:Key="ZeroCornerRadius">0</CornerRadius>
 
   <Thickness x:Key="BorderThickness">1</Thickness>
 
@@ -388,7 +389,12 @@
   <SolidColorBrush x:Key="DataGridCellBorderSelectedBrush" Color="{DynamicResource AccentForegroundColor}" Opacity="0.8" />
   <x:Double x:Key="DataGridColumnHeaderFontSize">11</x:Double>
   <x:Double x:Key="DataGridSortChevronSize">7</x:Double>
-  <Thickness x:Key="DataGridRowMargin">6 0</Thickness>
+  <Thickness x:Key="DataGridRowPadding">6 0</Thickness>
+  <Thickness x:Key="DataGridRowMargin">8 0</Thickness>
+  <Thickness x:Key="DataGridGroupHeaderBorderThickness">1</Thickness>
+  <Thickness x:Key="DataGridGroupHeaderBorderThicknessGridLinesVisible">0 1</Thickness>
+  <Thickness x:Key="DataGridGroupHeaderMargin">8 2</Thickness>
+  <Thickness x:Key="DataGridGroupHeaderMarginGridLinesVisible">0 1</Thickness>
 
   <!-- Menu & MenuItem Resources -->
   <SolidColorBrush x:Key="MenuFlyoutPresenterBackground" Color="{DynamicResource PopupBackgroundColor}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
@@ -374,10 +374,25 @@
 
             <Border Name="ItemBorder"
                     Background="{TemplateBinding Background}"
-                    Margin="8 0"
-                    CornerRadius="{DynamicResource ControlCornerRadius}"
                     Grid.RowSpan="2"
-                    Grid.ColumnSpan="2" />
+                    Grid.ColumnSpan="2">
+              <Border.Margin>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
+                              ConverterParameter="None,All,Horizontal,Vertical">
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+                  <Binding Source="{StaticResource DataGridRowMargin}" />
+                  <Binding Source="{StaticResource DataGridGroupHeaderMarginGridLinesVisible}" />
+                </MultiBinding>
+              </Border.Margin>
+              <Border.CornerRadius>
+                <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
+                              ConverterParameter="None,All,Horizontal,Vertical">
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+                  <Binding Source="{StaticResource ControlCornerRadius}" />
+                  <Binding Source="{StaticResource ZeroCornerRadius}" />
+                </MultiBinding>
+              </Border.CornerRadius>
+            </Border>
             <Rectangle Name="InvalidVisualElement"
                        Opacity="0"
                        Grid.ColumnSpan="2"
@@ -389,7 +404,7 @@
             <DataGridCellsPresenter Name="PART_CellsPresenter"
                                     Grid.Column="1"
                                     DataGridFrozenGrid.IsFrozen="True"
-                                    Margin="{DynamicResource DataGridRowMargin}" />
+                                    Margin="{DynamicResource DataGridRowPadding}" />
             <DataGridDetailsPresenter Name="PART_DetailsPresenter"
                                       Grid.Row="1"
                                       Grid.Column="1"
@@ -420,7 +435,7 @@
   </ControlTheme>
 
   <!-- RowGroupExpanderButton -->
-  <ControlTheme x:Key="FluentDataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
+  <ControlTheme x:Key="DataGridRowGroupExpanderButtonTheme" TargetType="ToggleButton">
     <Setter Property="Template">
       <ControlTemplate>
         <Border Width="12"
@@ -429,31 +444,63 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
           <Path Fill="{TemplateBinding Foreground}"
-                Data="{StaticResource DataGridRowGroupHeaderIconClosedPath}"
+                Data="{StaticResource ChevronPath}"
+                Width="9"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
-                Stretch="Uniform" />
+                Stretch="Uniform">
+            <Path.RenderTransform>
+              <RotateTransform Angle="90" />
+            </Path.RenderTransform>
+          </Path>
         </Border>
       </ControlTemplate>
     </Setter>
     <Style Selector="^:checked /template/ Path">
-      <Setter Property="Data" Value="{StaticResource DataGridRowGroupHeaderIconOpenedPath}" />
+      <Setter Property="RenderTransform">
+        <RotateTransform Angle="180" />
+      </Setter>
     </Style>
   </ControlTheme>
 
   <!-- RowGroupHeader -->
   <ControlTheme x:Key="{x:Type DataGridRowGroupHeader}" TargetType="DataGridRowGroupHeader">
-    <Setter Property="Foreground" Value="{DynamicResource DataGridRowGroupHeaderForegroundBrush}" />
-    <Setter Property="Background" Value="{DynamicResource DataGridRowGroupHeaderBackgroundBrush}" />
-    <Setter Property="FontSize" Value="15" />
-    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="Foreground" Value="{Binding $parent[DataGrid].Foreground}" />
+    <Setter Property="Background" Value="{DynamicResource DataGridGroupHeaderBackgroundBrush}" />
+    <Setter Property="MinHeight" Value="26" />
     <Setter Property="Template">
       <ControlTemplate x:DataType="collections:DataGridCollectionViewGroup">
-        <DataGridFrozenGrid Name="PART_Root"
-                            Background="{TemplateBinding Background}"
-                            MinHeight="{TemplateBinding MinHeight}"
-                            ColumnDefinitions="Auto,Auto,Auto,Auto,*"
-                            RowDefinitions="*,Auto">
+        <Border BorderBrush="{Binding $parent[DataGrid].BorderBrush}">
+          <Border.BorderThickness>
+            <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
+                          ConverterParameter="None,All,Horizontal,Vertical">
+              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+              <Binding Source="{StaticResource DataGridGroupHeaderBorderThickness}" />
+              <Binding Source="{StaticResource DataGridGroupHeaderBorderThicknessGridLinesVisible}" />
+            </MultiBinding>
+          </Border.BorderThickness>
+          <Border.Margin>
+            <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
+                          ConverterParameter="None,All,Horizontal,Vertical">
+              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+              <Binding Source="{StaticResource DataGridGroupHeaderMargin}" />
+              <Binding Source="{StaticResource DataGridGroupHeaderMarginGridLinesVisible}" />
+            </MultiBinding>
+          </Border.Margin>
+          <Border.CornerRadius>
+            <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
+                          ConverterParameter="None,All,Horizontal,Vertical">
+              <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+              <Binding Source="{StaticResource ControlCornerRadius}" />
+              <Binding Source="{StaticResource ZeroCornerRadius}" />
+            </MultiBinding>
+          </Border.CornerRadius>
+
+          <DataGridFrozenGrid Name="PART_Root"
+                              Background="{TemplateBinding Background}"
+                              MinHeight="{TemplateBinding MinHeight}"
+                              ColumnDefinitions="Auto,Auto,Auto,Auto,*"
+                              RowDefinitions="*,Auto">
 
           <Rectangle Name="PART_IndentSpacer"
                      Grid.Column="1" />
@@ -462,7 +509,7 @@
                         Width="12"
                         Height="12"
                         Margin="12,0,0,0"
-                        Theme="{StaticResource FluentDataGridRowGroupExpanderButtonTheme}"
+                        Theme="{StaticResource DataGridRowGroupExpanderButtonTheme}"
                         BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="{TemplateBinding BorderThickness}"
                         Background="{TemplateBinding Background}"
@@ -470,22 +517,24 @@
                         IsTabStop="False"
                         Foreground="{TemplateBinding Foreground}" />
 
-          <StackPanel Grid.Column="3"
-                      Orientation="Horizontal"
-                      VerticalAlignment="Center"
-                      Margin="12,0,0,0">
+          <DockPanel Grid.Column="3"
+                     Grid.ColumnSpan="2"
+                     VerticalAlignment="Center"
+                     HorizontalAlignment="Stretch"
+                     Margin="12,0">
             <TextBlock Name="PART_PropertyNameElement"
+                       DockPanel.Dock="Left"
                        Margin="4,0,0,0"
                        IsVisible="{TemplateBinding IsPropertyNameVisible}"
+                       Foreground="{DynamicResource ForegroundMidBrush}" />
+            <TextBlock Name="PART_ItemCountElement"
+                       DockPanel.Dock="Right"
+                       IsVisible="{TemplateBinding IsItemCountVisible}"
                        Foreground="{TemplateBinding Foreground}" />
             <TextBlock Margin="4,0,0,0"
                        Text="{Binding Key}"
                        Foreground="{TemplateBinding Foreground}" />
-            <TextBlock Name="PART_ItemCountElement"
-                       Margin="4,0,0,0"
-                       IsVisible="{TemplateBinding IsItemCountVisible}"
-                       Foreground="{TemplateBinding Foreground}" />
-          </StackPanel>
+          </DockPanel>
 
           <Rectangle Name="CurrencyVisual"
                      Grid.ColumnSpan="5"
@@ -524,6 +573,7 @@
                      Grid.ColumnSpan="5"
                      Height="1" />
         </DataGridFrozenGrid>
+        </Border>
       </ControlTemplate>
     </Setter>
   </ControlTheme>
@@ -568,7 +618,7 @@
             <DataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
                                             Grid.Column="1"
                                             Grid.Row="0" Grid.ColumnSpan="2"
-                                            Margin="{DynamicResource DataGridRowMargin}" />
+                                            Margin="{DynamicResource DataGridRowPadding}" />
             <Rectangle Name="PART_ColumnHeadersAndRowsSeparator"
                        Grid.Row="0" Grid.ColumnSpan="3" Grid.Column="0"
                        VerticalAlignment="Bottom"


### PR DESCRIPTION
- Proper styling for MacOS DataGrid RowGroupHeader
- dynamic styling of MacOS DataGrid depending on whether gridlines are displayed 
- Styling of propertyName and itemsCount in the DataGrid RowGroupHeader (MacOS and DevExpress)

![image](https://github.com/user-attachments/assets/d5b4eecc-5b45-430b-8b0d-205f58d8ae6f)

![image](https://github.com/user-attachments/assets/ea682870-1559-4449-bb24-a198d9b5bf84)

