### PR TITLE
[Build Workflow] Allow to build any combination of packages in one go

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,28 +3,32 @@ name: build package
 on:
   workflow_dispatch:
     inputs:
+      build-mac:
+        description: 'AvaloniaTheme.MacOS'
+        type: boolean
+        default: false
+      build-devexpress:
+        description: 'AvaloniaTheme.DevExpress'
+        type: boolean
+        default: false
+      build-linux:
+        description: 'AvaloniaTheme.Linux'
+        type: boolean
+        default: false
+      build-controls:
+        description: 'AvaloniaControls'
+        type: boolean
+        default: false
       version:
         description: 'release version'
         default: "latest"
         required: true
-      target-package:
-        type: choice
-        description: target package to build
-        required: true
-        options:
-          - all
-          - AvaloniaTheme.MacOS
-          - AvaloniaTheme.DevExpress
-          - AvaloniaTheme.Linux
-          - AvaloniaControls
       skip-publish:
         description: 'Skip publishing'
-        required: true
         type: boolean
         default: false
       dry-run:
         description: 'Dry run (simulate)'
-        required: true
         type: boolean
         default: true
   schedule:
@@ -70,13 +74,21 @@ jobs:
           if ($PackageVersion -NotMatch '^\d+\.\d+\.\d+\.\d+$') {
             throw "invalid version format: $PackageVersion, expected: 1.2.3.4"
           }
-
-          $TargetPackage = '${{ inputs.target-package }}'
-          if ([string]::IsNullOrEmpty($TargetPackage) -or $TargetPackage -eq 'all') {
-            $PackageList = "AvaloniaTheme.MacOS,AvaloniaTheme.DevExpress,AvaloniaTheme.Linux,AvaloniaControls"
-          } else {
-            $PackageList = $TargetPackage
+                    
+          $PackageList = ""
+          if ('${{ inputs.build-mac }}' -eq 'true) {
+            $PackageList += "AvaloniaTheme.MacOS"
           }
+          if ('${{ inputs.build-devexpress }}' -eq 'true) {
+            $PackageList += "AvaloniaTheme.DevExpress"
+          }
+          if ('${{ inputs.build-linux }}' -eq 'true) {
+            $PackageList += "AvaloniaTheme.Linux"
+          }
+          if ('${{ inputs.build-controls }}' -eq 'true) {
+            $PackageList += "AvaloniaControls"
+          }
+          $PackageList = $PackageList -replace [,]$
 
           echo "package-env=$PackageEnv" >> $Env:GITHUB_OUTPUT
           echo "package-version=$PackageVersion" >> $Env:GITHUB_OUTPUT
@@ -84,6 +96,7 @@ jobs:
           echo "skip-publish=$($SkipPublish.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
           echo "dry-run=$($DryRun.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
 
+          echo "::notice::Building Packages: $PackageList"
           echo "::notice::Version: $PackageVersion"
           echo "::notice::DryRun: $DryRun"
 


### PR DESCRIPTION
The current github workflow for building packages only allows to build an individual package or all of them. However, 'All' is very unlikely to be needed (especially now with themes depending on the Controls, which would have to be built ahead of time), but wanting to build a couple of themes that have been updated is quite a common scenario. So this changes the build script to allow multiple selections, by presenting each package as a checkbox. 

**Note:** I moved the package selection _above_ the release version, so that the version input field can act as a divider between package selection and build options, because I couldn't find another way to visually group the checkboxes.     <img src="https://github.com/user-attachments/assets/1a052a3a-2878-4972-9f38-9d89c41e500a" width="50%" />





