### PR TITLE
[MacOS] Add default background colour to DataGrid

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -33,7 +33,7 @@
 
       <Color x:Key="TransparentColor">Transparent</Color>
 
-      <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" Opacity="1" />
+      <SolidColorBrush x:Key="BackgroundBrush" Color="{DynamicResource BackgroundColor}" />
 
       <SolidColorBrush x:Key="ForegroundHighMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.73" />
       <SolidColorBrush x:Key="ForegroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.5" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
@@ -584,6 +584,7 @@
     <Setter Property="CanUserReorderColumns" Value="True" />
     <Setter Property="CanUserResizeColumns" Value="True" />
     <Setter Property="CanUserSortColumns" Value="True" />
+    <Setter Property="Background" Value="{DynamicResource BackgroundBrush}" />
     <Setter Property="RowBackground" Value="Transparent" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="BorderThickness" Value="1" />


### PR DESCRIPTION
This adds the default background color for DataGrid to the MacOS theme, so all DataGrid related rules can now be deleted from styles.MacOS / moved from styles.axaml to styles.Windows and styles.Linux 