### PR TITLE
[MacOS] Fix DataGrid rows when columns are sized to fill the space

### DIFF
--- a/samples/SampleApp/DemoPages/DataGridDemo.axaml
+++ b/samples/SampleApp/DemoPages/DataGridDemo.axaml
@@ -11,43 +11,84 @@
     <vm:DataGridViewModel />
   </Design.DataContext>
 
-  <StackPanel Margin="20" Spacing="30">
-    <DataGrid ItemsSource="{Binding Items}"
-              Height="150"
-              IsReadOnly="False">
-      <DataGrid.Columns>
-        <DataGridTemplateColumn Header="">
-          <DataGridTemplateColumn.CellTemplate>
-            <DataTemplate>
-              <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
-            </DataTemplate>
-          </DataGridTemplateColumn.CellTemplate>
-        </DataGridTemplateColumn>
-        <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" />
-        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" />
-        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" />
-        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" />
-      </DataGrid.Columns>
-    </DataGrid>
-    <StackPanel Spacing="10">
-      <TextBlock>With <TextBlock Classes="code" Text="Classes='cell-selectable-style'" /></TextBlock>
-      <DataGrid ItemsSource="{Binding Items}"
-                Classes="cell-selectable-style"
-                IsReadOnly="False">
-        <DataGrid.Columns>
-          <DataGridTemplateColumn Header="">
-            <DataGridTemplateColumn.CellTemplate>
-              <DataTemplate>
-                <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
-              </DataTemplate>
-            </DataGridTemplateColumn.CellTemplate>
-          </DataGridTemplateColumn>
-          <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" />
-          <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" />
-          <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" />
-          <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" />
-        </DataGrid.Columns>
-      </DataGrid>
-    </StackPanel>
-  </StackPanel>
+  <TabControl TabStripPlacement="Top" Margin="20">
+    <TabItem Header="DataGrid">
+      <StackPanel Margin="20" Spacing="30">
+        <DataGrid ItemsSource="{Binding Items}"
+                  Height="150"
+                  IsReadOnly="False">
+          <DataGrid.Columns>
+            <DataGridTemplateColumn Header="">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" Width="*" />
+            <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" Width="*" />
+            <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" Width="*" />
+            <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" Width="*" />
+          </DataGrid.Columns>
+        </DataGrid>
+        <StackPanel Spacing="10">
+          <TextBlock>With <TextBlock Classes="code" Text="Classes='cell-selectable-style'" /></TextBlock>
+          <DataGrid ItemsSource="{Binding Items}"
+                    Classes="cell-selectable-style"
+                    IsReadOnly="False">
+            <DataGrid.Columns>
+              <DataGridTemplateColumn Header="">
+                <DataGridTemplateColumn.CellTemplate>
+                  <DataTemplate>
+                    <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
+                  </DataTemplate>
+                </DataGridTemplateColumn.CellTemplate>
+              </DataGridTemplateColumn>
+              <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" Width="*" />
+              <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" Width="*" />
+              <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" Width="*" />
+              <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" Width="*" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </StackPanel>
+      </StackPanel>
+    </TabItem>
+    <TabItem Header="Non-Distributed Columns">
+      <StackPanel Margin="20" Spacing="10">
+        <TextBlock><Bold>NOTE:</Bold> When none of the columns are sized to fill the width of the table (<TextBlock Classes="code" Text="Width='*'" />), the right row margins are too large</TextBlock>
+        <DataGrid ItemsSource="{Binding Items}">
+          <DataGrid.Columns>
+            <DataGridTemplateColumn Header="">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" />
+            <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" />
+            <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" />
+            <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" />
+          </DataGrid.Columns>
+        </DataGrid>
+        <TextBlock>This can be fixed by applying <TextBlock Classes="code" Text="Classes='MacOS_NonDistributed_Columns'" />:</TextBlock>
+        <DataGrid ItemsSource="{Binding Items}"
+                  Classes="MacOS_NonDistributed_Columns">
+          <DataGrid.Columns>
+            <DataGridTemplateColumn Header="">
+              <DataGridTemplateColumn.CellTemplate>
+                <DataTemplate>
+                  <Svg Path="/Assets/Computer.svg" Width="16" Height="16" Css=".st0 {fill: #3B86EA}" />
+                </DataTemplate>
+              </DataGridTemplateColumn.CellTemplate>
+            </DataGridTemplateColumn>
+            <DataGridTextColumn Header="Type" Binding="{Binding ItemType}" />
+            <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" />
+            <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" />
+            <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" />
+          </DataGrid.Columns>
+        </DataGrid>
+      </StackPanel>
+    </TabItem>
+  </TabControl>
 </UserControl>

--- a/samples/SampleApp/DemoPages/DataGridGroupedDemo.axaml
+++ b/samples/SampleApp/DemoPages/DataGridGroupedDemo.axaml
@@ -33,9 +33,9 @@
             </DataTemplate>
           </DataGridTemplateColumn.CellTemplate>
         </DataGridTemplateColumn>
-        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" />
-        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" />
-        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" Width="*" />
+        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" Width="*" />
+        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" Width="*" />
       </DataGrid.Columns>
     </DataGrid>
     <TextBlock>
@@ -64,9 +64,9 @@
             </DataTemplate>
           </DataGridTemplateColumn.CellTemplate>
         </DataGridTemplateColumn>
-        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" />
-        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" />
-        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" />
+        <DataGridTextColumn Header="Common Name" Binding="{Binding CommonName}" x:DataType="local:DataGridItem" Width="*" />
+        <DataGridTextColumn Header="Account Name" Binding="{Binding AccountName}" x:DataType="local:DataGridItem" Width="*" />
+        <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" x:DataType="local:DataGridItem" Width="*" />
       </DataGrid.Columns>
     </DataGrid>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -391,6 +391,7 @@
   <x:Double x:Key="DataGridSortChevronSize">7</x:Double>
   <Thickness x:Key="DataGridRowPadding">6 0</Thickness>
   <Thickness x:Key="DataGridRowMargin">8 0</Thickness>
+  <Thickness x:Key="DataGridDistributedColumnsRowMargin">8 0 18 0</Thickness>  
   <Thickness x:Key="DataGridGroupHeaderBorderThickness">1</Thickness>
   <Thickness x:Key="DataGridGroupHeaderBorderThicknessGridLinesVisible">0 1</Thickness>
   <Thickness x:Key="DataGridGroupHeaderMargin">8 2</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DataGrid.axaml
@@ -371,7 +371,6 @@
           <DataGridFrozenGrid Name="PART_Root"
                               ColumnDefinitions="Auto,*"
                               RowDefinitions="*,Auto,Auto">
-
             <Border Name="ItemBorder"
                     Background="{TemplateBinding Background}"
                     Grid.RowSpan="2"
@@ -380,7 +379,12 @@
                 <MultiBinding Converter="{x:Static DevoMultiConverters.OptionsToChoiceConverter}"
                               ConverterParameter="None,All,Horizontal,Vertical">
                   <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="GridLinesVisibility" />
+                  <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
+                                ConverterParameter="MacOS_NonDistributed_Columns">
+                    <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=DataGrid}" Path="Classes" />
                   <Binding Source="{StaticResource DataGridRowMargin}" />
+                    <Binding Source="{StaticResource DataGridDistributedColumnsRowMargin}" />
+                  </MultiBinding>
                   <Binding Source="{StaticResource DataGridGroupHeaderMarginGridLinesVisible}" />
                 </MultiBinding>
               </Border.Margin>


### PR DESCRIPTION
### Before:
![image](https://github.com/user-attachments/assets/c959272e-6fbc-46e8-9175-9c41f61b87de)

### After: 
![image](https://github.com/user-attachments/assets/5667adc6-459c-45c2-a352-8e02e2b2da92)

Unfortunately I haven't found a way to make it work equally well for both scenarios: DataGrids that do **not** size the columns to take up all of the space will show an oversized right row margin, unless explicitly marked with `Classes="MacOS_NonDistributed_Columns"`. 

(RDM seems to use `Width="*"` in all cases, so this solution seemed best for our purposes.)