### PR TITLE
fix nightly build

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -75,20 +75,28 @@ jobs:
             throw "invalid version format: $PackageVersion, expected: 1.2.3.4"
           }
                     
-          $PackageList = ""
+          $Packages = @()
           if ('${{ inputs.build-mac }}' -eq 'true') {
-            $PackageList += "AvaloniaTheme.MacOS,"
+              $Packages += "AvaloniaTheme.MacOS"
           }
           if ('${{ inputs.build-devexpress }}' -eq 'true') {
-            $PackageList += "AvaloniaTheme.DevExpress,"
+              $Packages += "AvaloniaTheme.DevExpress"
           }
           if ('${{ inputs.build-linux }}' -eq 'true') {
-            $PackageList += "AvaloniaTheme.Linux,"
+              $Packages += "AvaloniaTheme.Linux"
           }
           if ('${{ inputs.build-controls }}' -eq 'true') {
-            $PackageList += "AvaloniaControls,"
+              $Packages += "AvaloniaControls"
           }
-          $PackageList = $PackageList -replace '[,]$'
+          if ($Packages.Count -eq 0) {
+              $Packages = @(
+                  "AvaloniaTheme.MacOS",
+                  "AvaloniaTheme.DevExpress",
+                  "AvaloniaTheme.Linux",
+                  "AvaloniaControls"
+              )
+          }
+          $PackageList = $Packages -join ","
 
           echo "package-env=$PackageEnv" >> $Env:GITHUB_OUTPUT
           echo "package-version=$PackageVersion" >> $Env:GITHUB_OUTPUT


### PR DESCRIPTION
[Last week's PR ](https://github.com/Devolutions/avalonia-extensions/pull/168) didn't take into account the scheduled builds on Monday that just test everything still builds properly. The important part about scheduled builds is that "inputs" aren't available, not even the default values, so we have to check for empty values in the preflight step. The build failed because of an empty list of packages to build. I modified the workflow to build an array of packages which is then converted to a string separated by commas, and if the list is empty, it just builds all packages. This also means that if you start a build with everything unchecked, it'll build everything, but I guess that's better than just failing.