### PR TITLE
Clean up SampleApp

### DIFF
--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -21,6 +21,8 @@
       <DevolutionsMacOsThemeGlobalStyles />
       <StyleInclude Source="/Styles.axaml" />
     </Styles>
+    <actipro:ComparisonConverter x:Key="EqualToComparisonConverter" Operator="EqualTo" />
+    <actipro:ComparisonConverter x:Key="NotEqualToComparisonConverter" Operator="NotEqualTo" />
   </Application.Resources>
 
   <!-- KEPT FOR DESIGNER! -->
@@ -28,8 +30,8 @@
   <Application.Styles>
     <actipro:ModernTheme />
 
-    <DevolutionsMacOsTheme />
-    <!-- <DevolutionsDevExpressTheme /> -->
+    <!-- <DevolutionsMacOsTheme /> -->
+    <DevolutionsDevExpressTheme />
     <!-- <DevolutionsLinuxYaruTheme /> -->
 
     <StyleInclude Source="/Styles.axaml" />

--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -24,7 +24,7 @@
   </Application.Resources>
 
   <!-- KEPT FOR DESIGNER! -->
-  <!-- This also dictate which theme is initially loaded -->
+  <!-- This also dictates which theme is initially loaded -->
   <Application.Styles>
     <actipro:ModernTheme />
 

--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -2,7 +2,6 @@ namespace SampleApp;
 
 using System;
 using System.IO;
-using System.Net;
 using System.Xml;
 using Avalonia;
 using Avalonia.Controls;
@@ -10,6 +9,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Avalonia.Svg.Skia;
+using Helpers;
 using ViewModels;
 
 public class App : Application
@@ -115,6 +115,7 @@ public class App : Application
         App app = (App)Current!;
         Theme? previousTheme = CurrentTheme;
         CurrentTheme = theme;
+        ThemeInfo.Instance.CurrentThemeName = theme.Name;
 
         bool reopenWindow = previousTheme != null && previousTheme.Name != theme.Name;
 

--- a/samples/SampleApp/Controls/SampleItemHeader.axaml
+++ b/samples/SampleApp/Controls/SampleItemHeader.axaml
@@ -1,0 +1,18 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:SampleApp.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="SampleApp.Controls.SampleItemHeader">
+
+  <StackPanel Orientation="Horizontal" Spacing="10">
+    <!-- <TextBlock DockPanel.Dock="Right" Text="🟢" -->
+    <!--            IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance},  -->
+    <!--                Path=CurrentThemeName, -->
+    <!--                Converter={StaticResource NotEqualToComparisonConverter}, -->
+    <!--                ConverterParameter=Linux - Yaru}" /> -->
+    <TextBlock Text="{Binding $parent[controls:SampleItemHeader].Status}" />
+    <TextBlock Text="{Binding $parent[controls:SampleItemHeader].Title}" />
+  </StackPanel>
+</UserControl>

--- a/samples/SampleApp/Controls/SampleItemHeader.axaml.cs
+++ b/samples/SampleApp/Controls/SampleItemHeader.axaml.cs
@@ -1,0 +1,52 @@
+namespace SampleApp.Controls;
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Helpers;
+
+public partial class SampleItemHeader : UserControl, INotifyPropertyChanged
+{
+  public new event PropertyChangedEventHandler? PropertyChanged;
+
+  private void OnPropertyChanged(string name) =>
+    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+  public static readonly StyledProperty<string?> TitleProperty =
+    AvaloniaProperty.Register<SampleItemHeader, string?>(nameof(Title));
+
+  public static readonly StyledProperty<string> ApplicableToProperty =
+    AvaloniaProperty.Register<SampleItemHeader, string>(nameof(ApplicableTo), "MacOS");
+
+  public string? Title
+  {
+    get => this.GetValue(TitleProperty);
+    set => this.SetValue(TitleProperty, value);
+  }
+
+  public string ApplicableTo
+  {
+    get => this.GetValue(ApplicableToProperty);
+    set => this.SetValue(ApplicableToProperty, value);
+  }
+
+  private bool IsApplicable =>
+    this.ApplicableTo.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Any(theme =>
+      string.Equals(theme, ThemeInfo.Instance.CurrentThemeName, StringComparison.OrdinalIgnoreCase));
+
+  public string? Status => this.IsApplicable ? "🟢" : "🔴";
+
+
+  public SampleItemHeader()
+  {
+    this.InitializeComponent();
+  }
+
+  protected override void OnInitialized()
+  {
+    base.OnInitialized();
+    this.OnPropertyChanged(nameof(this.Status)); // let Avalonia know to re-evaluate the Status binding
+  }
+}

--- a/samples/SampleApp/DemoPages/ButtonDemo.axaml
+++ b/samples/SampleApp/DemoPages/ButtonDemo.axaml
@@ -2,21 +2,28 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:helpers="clr-namespace:SampleApp.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ButtonDemo">
 
   <StackPanel>
     <Border Margin="20 0">
-      <Grid ColumnDefinitions="100, 72, 40, 72, Auto" RowDefinitions="50, 50, 50" Margin="20">
+      <Grid ColumnDefinitions="100, 72, Auto" RowDefinitions="50, 50, 50" Margin="20">
         <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Default</TextBlock>
         <Button Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Content="Cancel" />
         <TextBlock Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">accent</TextBlock>
         <Button Grid.Row="1" Grid.Column="1" Classes="accent" VerticalAlignment="Center">Open</Button>
         <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">Disabled</TextBlock>
         <Button Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Classes="accent" IsEnabled="False">Submit</Button>
-        <TextBlock Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Center">/</TextBlock>
-        <Button Grid.Row="1" Grid.Column="3" Classes="accentPrecise" VerticalAlignment="Center">Open</Button>
-        <TextBlock Grid.Row="1" Grid.Column="4" VerticalAlignment="Center" Margin="10 0 0 0">(MacOS: More precise look, but not responsive to user-selected accent colour)</TextBlock>
+        <StackPanel Grid.Row="1" Grid.Column="2" Orientation="Horizontal" Spacing="20"
+                    IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance}, 
+                   Path=CurrentThemeName,
+                   Converter={StaticResource EqualToComparisonConverter},
+                   ConverterParameter=MacOS}">
+          <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Margin="20 0 0 0">/</TextBlock>
+          <Button Classes="accentPrecise" VerticalAlignment="Center">Open</Button>
+          <TextBlock VerticalAlignment="Center" Margin="10 0 0 0">(MacOS: More precise look, but not responsive to user-selected accent colour)</TextBlock>
+        </StackPanel>
       </Grid>
     </Border>
     <Border Background="{DynamicResource LayoutBackgroundLowBrush}" Margin="20 0">

--- a/samples/SampleApp/DemoPages/DataGridDemo.axaml
+++ b/samples/SampleApp/DemoPages/DataGridDemo.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SampleApp.ViewModels"
+             xmlns:helpers="using:SampleApp.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.DataGridDemo"
              x:DataType="vm:DataGridViewModel">
@@ -55,7 +56,13 @@
     </TabItem>
     <TabItem Header="Non-Distributed Columns">
       <StackPanel Margin="20" Spacing="10">
-        <TextBlock><Bold>NOTE:</Bold> When none of the columns are sized to fill the width of the table (<TextBlock Classes="code" Text="Width='*'" />), the right row margins are too large</TextBlock>
+        <TextBlock
+          IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance}, 
+                   Path=CurrentThemeName,
+                   Converter={StaticResource EqualToComparisonConverter},
+                   ConverterParameter=MacOS}">
+          <Bold>NOTE:</Bold> When none of the columns are sized to fill the width of the table (<TextBlock Classes="code" Text="Width='*'" />), the right row margins are too large
+        </TextBlock>
         <DataGrid ItemsSource="{Binding Items}">
           <DataGrid.Columns>
             <DataGridTemplateColumn Header="">
@@ -71,7 +78,14 @@
             <DataGridTextColumn Header="Last Modified" Binding="{Binding LastModified}" IsReadOnly="True" />
           </DataGrid.Columns>
         </DataGrid>
-        <TextBlock>This can be fixed by applying <TextBlock Classes="code" Text="Classes='MacOS_NonDistributed_Columns'" />:</TextBlock>
+        <TextBlock
+          IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance}, 
+                   Path=CurrentThemeName,
+                   Converter={StaticResource EqualToComparisonConverter},
+                   ConverterParameter=MacOS}">
+          This can be fixed by applying
+          <TextBlock Classes="code" Text="Classes='MacOS_NonDistributed_Columns'" />:
+        </TextBlock>
         <DataGrid ItemsSource="{Binding Items}"
                   Classes="MacOS_NonDistributed_Columns">
           <DataGrid.Columns>

--- a/samples/SampleApp/DemoPages/MenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:helpers="clr-namespace:SampleApp.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.MenuDemo">
 
@@ -213,7 +214,11 @@
             <MenuItem Header="-" />
           </Menu>
           <Border Background="{DynamicResource BackgroundBrush}" Padding="15">
-            <TextBlock FontSize="12" LineSpacing="2" TextWrapping="Wrap">
+            <TextBlock FontSize="12" LineSpacing="2" TextWrapping="Wrap"
+                       IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance}, 
+                       Path=CurrentThemeName,
+                       Converter={StaticResource EqualToComparisonConverter},
+                       ConverterParameter=MacOS}">
               <Bold>Use the following classes for menu styling:</Bold><LineBreak /><LineBreak />
               • <TextBlock Classes="code" Text="MacOS_Theme_MenuLabelBelowIcon" /> for a toolbar-style menu
               <LineBreak />

--- a/samples/SampleApp/DemoPages/Overview.axaml
+++ b/samples/SampleApp/DemoPages/Overview.axaml
@@ -2,23 +2,28 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:helpers="clr-namespace:SampleApp.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.Overview">
 
   <StackPanel Margin="10">
     <TextBlock Classes="h1" Text="{Binding $parent[Window].Title}" />
     <TextBlock FontSize="15" LineSpacing="2" TextWrapping="Wrap">
-      Elements in this sampler are styled with a partial
-      <TextBlock Classes="code" FontSize="16" Text="Avalonia.MacOS" />
-      theme, built upon <TextBlock Classes="code" FontSize="16" Text="Avalonia.Fluent" />. <LineBreak />
+      Elements in this sampler are styled with partial themes (<TextBlock Classes="code" FontSize="16" Text="Avalonia.MacOS" />,
+      <TextBlock Classes="code" FontSize="16" Text="Avalonia.DevExpress" /> and <TextBlock Classes="code" FontSize="16" Text="Avalonia.Linux" />),
+      all built upon <TextBlock Classes="code" FontSize="16" Text="Avalonia.Fluent" />. <LineBreak />
       <LineBreak />
       <Bold>Note:</Bold> at the moment the base theme is not just a
-      fallback for everything not implemented yet in the MacOS theme, but may in some instances provide
+      fallback for everything not implemented yet in the themes, but may in some instances provide
       the base template to attach styles to (currently the case for buttons) and in most cases there may
       also still be references to colour &amp; other resources provided by Fluent.
       We still need to research what the drawbacks to this approach might be ...
     </TextBlock>
-    <TabControl TabStripPlacement="Top" Margin="0 25 0 0">
+    <StackPanel Orientation="Horizontal" Margin="0 30 0 0">
+      <TextBlock Classes="h1" Text="Quick view of current theme: " />
+      <TextBlock Classes="h1" Foreground="{DynamicResource AccentButtonBackground}" Text="{Binding Source={x:Static helpers:ThemeInfo.Instance}, Path=CurrentThemeName}" />
+    </StackPanel>
+    <TabControl TabStripPlacement="Top" Margin="0 15 0 0">
       <TabItem Header="Tab 1">
         <StackPanel Orientation="Horizontal" Spacing="20">
           <StackPanel>
@@ -45,7 +50,7 @@
             </CheckBox>
           </StackPanel>
           <StackPanel Orientation="Horizontal">
-            <ComboBox PlaceholderText="Chose one" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
+            <ComboBox PlaceholderText="Chose one" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="False">
               <ComboBoxItem>Option 1</ComboBoxItem>
               <ComboBoxItem>Option 2</ComboBoxItem>
               <ComboBoxItem>Option 3</ComboBoxItem>
@@ -59,7 +64,7 @@
                 <ComboBoxItem>Option 4</ComboBoxItem>
               </ComboBox>
               <Border Margin="0 50">
-                <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="True">
+                <ComboBox SelectedIndex="2" VerticalAlignment="Top" Margin="10 0 20 0" IsDropDownOpen="False">
                   <ComboBoxItem>Option 1</ComboBoxItem>
                   <ComboBoxItem>Option 2</ComboBoxItem>
                   <ComboBoxItem>Option 3</ComboBoxItem>
@@ -100,5 +105,13 @@
       <TabItem Header="Tab 3" IsEnabled="False">Content 1</TabItem>
       <TabItem Header="Tab 4">Content 1</TabItem>
     </TabControl>
+
+    <TextBlock FontSize="15" LineSpacing="2" TextWrapping="Wrap" Margin="0 30 0 0">
+      Use the tabs on the left for a closer look at specific controls.<LineBreak />
+      🟢 Controls that have been styled for the current theme (even if they may still need more work)<LineBreak />
+      🔴 Controls not started yet <LineBreak />
+      <LineBreak />
+      Use the tools below to select a different theme or switch modes.<LineBreak />
+    </TextBlock>
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:helpers="clr-namespace:SampleApp.Helpers"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="SampleApp.DemoPages.ScrollViewerDemo">
 
@@ -97,7 +98,12 @@
           </ScrollViewer>
         </Border>
       </Grid>
-      <TextBlock TextWrapping="Wrap">
+      <TextBlock
+        TextWrapping="Wrap"
+        IsVisible="{Binding Source={x:Static helpers:ThemeInfo.Instance}, 
+                   Path=CurrentThemeName,
+                   Converter={StaticResource EqualToComparisonConverter},
+                   ConverterParameter=MacOS}">
         <Bold>Note:</Bold> MacOS hides scrollbars completely (depending on user settings), but they re-appear on scroll events.
         Since Avalonia ScrollBars only expand on pointerOver, hiding them completely would be a bit confusing. So the Thumb sliders
         remain visible even when <TextBlock Classes="code" Text="AllowAutoHide=&quot;True&quot;" />.

--- a/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
+++ b/samples/SampleApp/DemoPages/ScrollViewerDemo.axaml
@@ -99,7 +99,7 @@
       </Grid>
       <TextBlock TextWrapping="Wrap">
         <Bold>Note:</Bold> MacOS hides scrollbars completely (depending on user settings), but they re-appear on scroll events.
-        Since Avalonia ScrollBars only expand on pointerOver hiding them completely would be a bit confusing, so the Thumb sliders
+        Since Avalonia ScrollBars only expand on pointerOver, hiding them completely would be a bit confusing. So the Thumb sliders
         remain visible even when <TextBlock Classes="code" Text="AllowAutoHide=&quot;True&quot;" />.
       </TextBlock>
       <TextBlock TextWrapping="Wrap">

--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -31,7 +31,7 @@
           <TextBox IsEnabled="False">Disabled Filled</TextBox>
           <TextBox PasswordChar="*" Classes="revealPasswordButton">Reveal Password</TextBox>
           <TextBox PasswordChar="*" Classes="revealPasswordButton" RevealPassword="True">Password Revealed</TextBox>
-          <TextBlock Classes="Label">Custom Height:</TextBlock>
+          <Label>Custom Height:</Label>
           <Grid ColumnDefinitions="*, Auto" HorizontalAlignment="Stretch">
             <TextBox Grid.Column="0" Watermark="Type here" Height="35" VerticalContentAlignment="Center" />
             <Button Grid.Column="1" Content="..." HorizontalContentAlignment="Center" Height="35" Width="35"

--- a/samples/SampleApp/Helpers/ThemeInfo.cs
+++ b/samples/SampleApp/Helpers/ThemeInfo.cs
@@ -1,0 +1,10 @@
+namespace SampleApp.Helpers;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+public partial class ThemeInfo : ObservableObject
+{
+  [ObservableProperty] private string? currentThemeName;
+
+  public static ThemeInfo Instance { get; } = new();
+}

--- a/samples/SampleApp/MainWindow.axaml
+++ b/samples/SampleApp/MainWindow.axaml
@@ -7,6 +7,7 @@
         xmlns:vm="clr-namespace:SampleApp.ViewModels"
         xmlns:sampleApp="clr-namespace:SampleApp"
         xmlns:actipro="http://schemas.actiprosoftware.com/avaloniaui"
+        xmlns:controls="clr-namespace:SampleApp.Controls"
         mc:Ignorable="d" d:DesignWidth="1000" d:DesignHeight="450"
         Width="1250"
         Height="800"
@@ -23,63 +24,114 @@
         </TabItem.Header>
         <demoPages:Overview />
       </TabItem>
-      <TabItem Header="Button">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="Button" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:ButtonDemo />
       </TabItem>
-      <TabItem Header="CheckBox">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="CheckBox" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:CheckBoxDemo />
       </TabItem>
-      <TabItem Header="ComboBox">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="ComboBox" ApplicableTo="MacOS, Windows - DevExpress" />
+        </TabItem.Header>
         <demoPages:ComboBoxDemo />
       </TabItem>
-      <TabItem Header="EditableComboBox">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="EditableComboBox" ApplicableTo="MacOS, Windows - DevExpress" />
+        </TabItem.Header>
         <demoPages:EditableComboBoxDemo />
       </TabItem>
-      <TabItem Header="ContextMenu">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="ContextMenu" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:ContextMenuDemo />
       </TabItem>
-      <TabItem Header="DataGrid">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="DataGrid" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:DataGridDemo>
           <demoPages:DataGridDemo.DataContext>
             <vm:DataGridViewModel />
           </demoPages:DataGridDemo.DataContext>
         </demoPages:DataGridDemo>
       </TabItem>
-      <TabItem Header="DataGrid grouped">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="DataGrid grouped" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:DataGridGroupedDemo>
           <demoPages:DataGridGroupedDemo.DataContext>
             <vm:DataGridGroupedViewModel />
           </demoPages:DataGridGroupedDemo.DataContext>
         </demoPages:DataGridGroupedDemo>
       </TabItem>
-      <TabItem Header="Menu">
-        <demoPages:MenuDemo />
-      </TabItem>
-      <TabItem Header="GridSplitter">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="GridSplitter" ApplicableTo="MacOS" />
+        </TabItem.Header>
         <demoPages:GridSplitterDemo />
       </TabItem>
-      <TabItem Header="MenuFlyout">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="Menu" ApplicableTo="MacOS" />
+        </TabItem.Header>
+        <demoPages:MenuDemo />
+      </TabItem>
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="MenuFlyout" ApplicableTo="MacOS" />
+        </TabItem.Header>
         <demoPages:MenuFlyoutDemo />
       </TabItem>
-      <TabItem Header="NumericUpDown">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="NumericUpDown" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:NumericUpDownDemo />
       </TabItem>
-      <TabItem Header="ScrollViewer">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="ScrollViewer" ApplicableTo="MacOS, Windows - DevExpress" />
+        </TabItem.Header>
         <demoPages:ScrollViewerDemo />
       </TabItem>
-      <TabItem Header="TabControl">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="TabControl" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:TabControlDemo />
       </TabItem>
-      <TabItem Header="TextBox">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="TextBox" ApplicableTo="MacOS, Windows - DevExpress, Linux - Yaru" />
+        </TabItem.Header>
         <demoPages:TextBoxDemo />
       </TabItem>
-      <TabItem Header="Toggle Switch [WIP]">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="Toggle Switch" ApplicableTo="" />
+        </TabItem.Header>
         <demoPages:ToggleSwitchDemo />
       </TabItem>
-      <TabItem Header="TreeView">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="TreeView" ApplicableTo="MacOS, Windows - DevExpress" />
+        </TabItem.Header>
         <demoPages:TreeViewDemo />
       </TabItem>
-      <TabItem Header="ToolTip">
+      <TabItem>
+        <TabItem.Header>
+          <controls:SampleItemHeader Title="ToolTip" ApplicableTo="MacOS" />
+        </TabItem.Header>
         <demoPages:ToolTipDemo />
       </TabItem>
       <TabItem Header="✜ Control Alignment">

--- a/samples/SampleApp/Styles.axaml
+++ b/samples/SampleApp/Styles.axaml
@@ -7,7 +7,7 @@
     <Thickness x:Key="H1Margins">0,0,0,10</Thickness>
 
     <FontFamily x:Key="CodeFontFamily">"Courier New, Courier, monospace"</FontFamily>
-    <Color x:Key="CodeFontColor">#23b4c8</Color>
+    <Color x:Key="CodeFontColor">#3597A5</Color>
   </Styles.Resources>
 
   <Style Selector="Panel.mainControl">
@@ -25,7 +25,8 @@
     <Setter Property="FontFamily" Value="{DynamicResource CodeFontFamily}" />
     <Setter Property="Foreground" Value="{DynamicResource CodeFontColor}" />
     <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
-    <Setter Property="Padding" Value="2,2,1,1" />
+    <Setter Property="Padding" Value="4,4,4,0" />
+    <Setter Property="Margin" Value="0 0 0 -2" />
     <Setter Property="VerticalAlignment" Value="Center" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabControl.axaml
@@ -40,7 +40,7 @@
                   ColumnDefinitions="Auto, *">
               <ItemsPresenter Name="PART_ItemsPresenter"
                               Grid.Column="0"
-                              VerticalAlignment="Bottom"
+                              VerticalAlignment="Top"
                               ItemsPanel="{TemplateBinding ItemsPanel}" />
               <Border Name="CardBorderBeyondTheTabs"
                       Grid.Column="1"


### PR DESCRIPTION
- add a helper that allows us to display different explanations depending on the selected theme 
- clean up some typos and the overview page that was still from the time when we only had the MacOS theme
- indicate on the tabs which controls are actually implemented for the current theme 