### PR TITLE
[SampleApp] Fix status indicators on non-retina display

### DIFF
--- a/samples/SampleApp/Controls/SampleItemHeader.axaml
+++ b/samples/SampleApp/Controls/SampleItemHeader.axaml
@@ -7,7 +7,8 @@
              x:Class="SampleApp.Controls.SampleItemHeader">
 
   <StackPanel Orientation="Horizontal" Spacing="10">
-    <TextBlock Text="{Binding $parent[controls:SampleItemHeader].Status}" />
+    <!-- Non-retina displays will click the status indicator icon if not set to ClipToBounds="False" -->
+    <TextBlock Text="{Binding $parent[controls:SampleItemHeader].Status}" ClipToBounds="False" />
     <TextBlock Text="{Binding $parent[controls:SampleItemHeader].Title}" />
   </StackPanel>
 </UserControl>


### PR DESCRIPTION
For some reason non-retina displays seem to misjudge the bounds of the status icon when running on Mac ... (perhaps an interesting observation to help with fixing some of the other weird rendering issues on non-retina?)
![image](https://github.com/user-attachments/assets/29356351-5bcb-4cb7-ab80-eeae3c3b2e07)
