### PR TITLE
[MacOS / DevExpress] Fix TextBox layout jumps

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -98,6 +98,7 @@
   <SolidColorBrush x:Key="SystemRegionBrush" Color="{DynamicResource SystemRegionColor}" />
 
   <FontFamily x:Key="DevExpressThemeFontFamily">Segoe UI, Helvetica Neue, Arial, sans-serif</FontFamily>
+  <x:Double x:Key="DefaultLineHeight">15</x:Double>
   <x:Double x:Key="DefaultFontSize">12</x:Double>
   <x:Double x:Key="ControlFontSize">12</x:Double>
   <x:Double x:Key="PasswordHiddenFontSize">10</x:Double>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -126,6 +126,7 @@
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ContextFlyout"
             Value="{OnFormFactor Desktop={StaticResource DefaultTextBoxContextFlyout}, Mobile={StaticResource HorizontalTextBoxContextFlyout}}" />
+    <Setter Property="LineHeight" Value="{StaticResource DefaultLineHeight}" />
     <Setter Property="FontSize">
       <Setter.Value>
         <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
@@ -187,6 +188,7 @@
                     Margin="{TemplateBinding Padding}">
                     <TextBlock Name="PART_Watermark"
                                Opacity="0.5"
+                               LineHeight="{TemplateBinding LineHeight}"
                                FontSize="{DynamicResource ControlFontSize}"
                                Text="{TemplateBinding Watermark}"
                                TextAlignment="{TemplateBinding TextAlignment}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -264,9 +264,10 @@
   <Thickness x:Key="InputControlsSpaceForFocusBorder">1.5</Thickness>
   <Thickness x:Key="TabControlSpaceForFocusFactors">1 1 1 -1.5</Thickness>
 
+  <x:Double x:Key="DefaultLineHeight">16</x:Double>
   <x:Double x:Key="DefaultFontSize">13</x:Double>
   <x:Double x:Key="ControlFontSize">13</x:Double>
-  <x:Double x:Key="PasswordHiddenFontSize">11</x:Double>
+  <x:Double x:Key="PasswordHiddenFontSize">7.5</x:Double>
 
   <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -99,6 +99,7 @@
     <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="0.6" />
     <Setter Property="CaretBrush" Value="{DynamicResource SystemAccentColor}" />
+    <Setter Property="LineHeight" Value="{StaticResource DefaultLineHeight}" />
     <Setter Property="FontSize">
       <Setter.Value>
         <MultiBinding Converter="{x:Static DevoMultiConverters.RevealPasswordToFontSizeConverter}">
@@ -158,7 +159,8 @@
                       <Panel>
                         <TextBlock Name="PART_Watermark"
                                    Foreground="{DynamicResource ForegroundLowBrush}"
-                                   FontSize="{DynamicResource ControlFontSize}"
+                                   LineHeight="{TemplateBinding LineHeight}"
+                                   FontSize="{StaticResource ControlFontSize}"
                                    Text="{TemplateBinding Watermark}"
                                    TextAlignment="{TemplateBinding TextAlignment}"
                                    TextWrapping="{TemplateBinding TextWrapping}"


### PR DESCRIPTION
Typing a password (switch from Watermark to actual input) and switching between show/hide password caused small height changes in the TextBox. 

