### PR TITLE
Add `HasNotClass` converter (& always use local AvaloniaControls in debugging mode)

### DIFF
--- a/src/Devolutions.AvaloniaControls/Converters/HasClassConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/HasClassConverter.cs
@@ -7,4 +7,7 @@ public static partial class DevoConverters
 {
   public static FuncValueConverter<Classes, string, bool> HasClass { get; } =
     new(static (classes, classToCheck) => classToCheck is not null && classes?.Contains(classToCheck) == true);
+
+  public static FuncValueConverter<Classes, string, bool> HasNotClass { get; } =
+    new(static (classes, classToCheck) => classToCheck is not null && classes?.Contains(classToCheck) == false);
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -17,10 +17,12 @@
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="[11.2.0,)" />
   </ItemGroup>
 
-  <!-- flip these when debugging -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
     <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.6.9,)" />
-    <!--    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />-->
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)' != 'Debug'">

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -19,9 +19,11 @@
     <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)" />
   </ItemGroup>
 
-  <!-- flip these when debugging -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
     <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.6.9,)" />
-    <!--    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />-->
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -17,11 +17,13 @@
     <PackageReference Include="Avalonia.Svg.Skia" Version="[11.2.0,)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="[11.2.0,)" />
   </ItemGroup>
-
-  <!-- flip these when debugging -->
-  <ItemGroup>
+  
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
     <PackageReference Include="Devolutions.AvaloniaControls" Version="[2025.6.9,)" />
-    <!--    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />-->
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a converter that returns `true` when the given Control's classes do NOT contain a specific class.
(I know the name sounds a bit odd, but I think the pattern of IsX and IsNotX is so well established, that it would seem contrived and less intuitive to give the converter some other name like 'LacksClass' (and it would obscure the simple relationship between this and the existing `HasClass` converter.) 

Unrelated, this also automates the switching between published Devolutions.AvaloniaControls nuget in production and the local assembly during debugging. Thanks to @Samuel-B-D for that idea!
