### PR TITLE
Fix alignment & cross-platform consistency issues

### DIFF
--- a/samples/SampleApp/DemoPages/ContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/ContextMenuDemo.axaml
@@ -20,7 +20,7 @@
         </MenuItem>
       </ContextMenu>
     </Border.ContextMenu>
-    <TextBlock Margin="10">Right-click anywhere in this space</TextBlock>
+    <TextBlock Margin="10" VerticalAlignment="Top">Right-click anywhere in this space</TextBlock>
   </Border>
 
 </UserControl>

--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -4,141 +4,87 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ControlAlignment">
-
-  <UserControl.Styles>
-    <Style Selector="StackPanel > Border">
-      <!-- <Setter Property="BorderBrush" Value="BlueViolet" /> -->
-      <!-- <Setter Property="BorderThickness" Value="1" /> -->
-      <Setter Property="VerticalAlignment" Value="Center" />
-    </Style>
-  </UserControl.Styles>
+  
+  
   <StackPanel Margin="10">
-    <TextBlock Classes="h1" Text="Grid" />
-    <Grid RowDefinitions="*, *, *, *, *, *, *, *, *"
-          ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
-          RowSpacing="5"
+    <TextBlock Classes="h1" Text="Grids" />
+    <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
           ColumnSpacing="10"
           Margin="10">
-      <Border Grid.Row="0" Grid.Column="0">
-        <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
-      </Border>
-      <Border Grid.Row="0" Grid.Column="1">
-        <TextBox Watermark="TextBox" />
-      </Border>
-      <Border Grid.Row="0" Grid.Column="2">
-        <ComboBox SelectedIndex="2">
+      <TextBlock Grid.Column="0">TextBlock</TextBlock>
+      <TextBox Grid.Column="1" Watermark="TextBox" />
+      <ComboBox Grid.Column="2" SelectedIndex="2">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4 much longer</ComboBoxItem>
         </ComboBox>
-      </Border>
-      <Border Grid.Row="0" Grid.Column="3">
-        <AutoCompleteBox x:Name="Animals" FilterMode="Contains" />
-      </Border>
-      <Border Grid.Row="0" Grid.Column="4">
-        <NumericUpDown Value="0"
-                       Increment="1"
-                       Watermark="mm" />
-      </Border>
-      <Border Grid.Row="0" Grid.Column="5">
-        <Button Content="Button" />
-      </Border>
-      <Border Grid.Row="0" Grid.Column="6">
-        <CheckBox Content="Checkbox" IsChecked="True" />
-      </Border>
+      <AutoCompleteBox Grid.Column="3" x:Name="Animals" FilterMode="Contains" Watermark="AutoComplete" />
+      <NumericUpDown Grid.Column="4" Value="0"
+                     Increment="1"
+                     Watermark="mm" />
+      <Button Grid.Column="5" Content="Button" />
+      <CheckBox Grid.Column="6" Content="Checkbox" IsChecked="True" />
+      <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
+      <TextBlock Grid.Column="7" Text="🙂" FontSize="45" />
+    </Grid>
 
-      <Border Grid.Row="2" Grid.Column="0">
-        <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
-      </Border>
-      <Border Grid.Row="3" Grid.Column="0">
-        <TextBox Watermark="TextBox" />
-      </Border>
-      <Border Grid.Row="4" Grid.Column="0">
-        <ComboBox SelectedIndex="2">
-          <ComboBoxItem>Option 1</ComboBoxItem>
-          <ComboBoxItem>Option 2</ComboBoxItem>
-          <ComboBoxItem>Option 3</ComboBoxItem>
-          <ComboBoxItem>Option 4</ComboBoxItem>
-        </ComboBox>
-      </Border>
-      <Border Grid.Row="5" Grid.Column="0">
-        <AutoCompleteBox x:Name="Animals2" FilterMode="Contains" />
-      </Border>
-      <Border Grid.Row="6" Grid.Column="0">
-        <NumericUpDown Value="0"
-                       Increment="1"
-                       Watermark="mm" />
-      </Border>
-      <Border Grid.Row="7" Grid.Column="0">
-        <Button Content="Button" />
-      </Border>
-      <Border Grid.Row="8" Grid.Column="">
-        <CheckBox Content="Checkbox" IsChecked="True" />
-      </Border>
+    <Grid RowDefinitions="*, *, *, *, *, *, *, *, *"
+          RowSpacing="5"
+          Width="100"
+          HorizontalAlignment="Left"
+          Margin="10">
+      <TextBlock Grid.Row="2">TextBlock</TextBlock>
+      <TextBox Grid.Row="3" Watermark="TextBox" />
+      <ComboBox Grid.Row="4" SelectedIndex="2">
+        <ComboBoxItem>Option 1</ComboBoxItem>
+        <ComboBoxItem>Option 2</ComboBoxItem>
+        <ComboBoxItem>Option 3</ComboBoxItem>
+        <ComboBoxItem>Option 4</ComboBoxItem>
+      </ComboBox>
+      <AutoCompleteBox Grid.Row="5" x:Name="Animals2" FilterMode="Contains" Watermark="AutoComplete" />
+      <NumericUpDown Grid.Row="6" Value="0"
+                     Increment="1"
+                     Watermark="mm" />
+      <Button Grid.Row="7" Content="Button" />
+      <CheckBox Grid.Row="8" Content="Checkbox" IsChecked="True" />
     </Grid>
 
     <TextBlock Classes="h1" Text="StackPanels" Margin="0 20 0 0 " />
-    <StackPanel Orientation="Vertical" Margin="10" Spacing="20" VerticalAlignment="Top">
+    <StackPanel Orientation="Vertical" Margin="0 10" Spacing="20" VerticalAlignment="Top">
       <StackPanel Orientation="Horizontal" Margin="10" Spacing="10" VerticalAlignment="Top">
-        <Border>
-          <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
-        </Border>
-        <Border>
+        <TextBlock>TextBlock</TextBlock>
           <TextBox Watermark="TextBox" />
-        </Border>
-        <Border>
           <ComboBox SelectedIndex="2">
             <ComboBoxItem>Option 1</ComboBoxItem>
             <ComboBoxItem>Option 2</ComboBoxItem>
             <ComboBoxItem>Option 3</ComboBoxItem>
             <ComboBoxItem>Option 4</ComboBoxItem>
           </ComboBox>
-        </Border>
-        <Border>
-          <AutoCompleteBox x:Name="Animals3" FilterMode="Contains" />
-        </Border>
-        <Border>
+          <AutoCompleteBox x:Name="Animals3" FilterMode="Contains" Watermark="AutoComplete" />
           <NumericUpDown Value="0"
                          Increment="1"
                          Watermark="mm" />
-        </Border>
-        <Border>
           <Button Content="Button" />
-        </Border>
-        <Border>
           <CheckBox Content="Checkbox" IsChecked="True" />
-        </Border>
+          <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
+          <TextBlock Text="🙂" FontSize="45" />
       </StackPanel>
-      <StackPanel Orientation="Vertical" Width="90" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
-        <Border>
-          <TextBlock VerticalAlignment="Center">TextBlock</TextBlock>
-        </Border>
-        <Border>
+      <StackPanel Orientation="Vertical" Width="100" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
+        <TextBlock>TextBlock</TextBlock>
           <TextBox Watermark="TextBox" />
-        </Border>
-        <Border>
           <ComboBox SelectedIndex="2">
             <ComboBoxItem>Option 1</ComboBoxItem>
             <ComboBoxItem>Option 2</ComboBoxItem>
             <ComboBoxItem>Option 3</ComboBoxItem>
             <ComboBoxItem>Option 4</ComboBoxItem>
           </ComboBox>
-        </Border>
-        <Border>
-          <AutoCompleteBox x:Name="Animals4" FilterMode="Contains" />
-        </Border>
-        <Border>
+          <AutoCompleteBox x:Name="Animals4" FilterMode="Contains" Watermark="AutoComplete" />
           <NumericUpDown Value="0"
                          Increment="1"
                          Watermark="mm" />
-        </Border>
-        <Border>
           <Button Content="Button" />
-        </Border>
-        <Border>
           <CheckBox Content="Checkbox" IsChecked="True" />
-        </Border>
       </StackPanel>
     </StackPanel>
   </StackPanel>

--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml
@@ -10,10 +10,10 @@
     <Border Width="500">
       <TabControl TabStripPlacement="Left">
         <TabItem Header="Tab 1">
-          <TextBlock Text="Vertical tab view" />
+          <TextBlock Text="Vertical tab view" VerticalAlignment="Top" />
         </TabItem>
         <TabItem Header="Tab 2">
-          <TextBlock Text="Content 2" />
+          <TextBlock Text="Content 2" VerticalAlignment="Top" />
         </TabItem>
         <TabItem Header="Tab3" IsEnabled="False" />
       </TabControl>
@@ -21,14 +21,14 @@
     <Border Width="500">
       <TabControl TabStripPlacement="Top">
         <TabItem Header="General">
-          <TextBlock Text="Horizontal tab view" />
+          <TextBlock Text="Horizontal tab view" VerticalAlignment="Top" />
         </TabItem>
         <TabItem Header="Settings">
-          <TextBlock Text="Content 2" />
+          <TextBlock Text="Content 2" VerticalAlignment="Top" />
         </TabItem>
         <TabItem Header="Disabled Tab" IsEnabled="False" />
         <TabItem Header="Advanced">
-          <TextBlock Text="Content 3" />
+          <TextBlock Text="Content 3" VerticalAlignment="Top" />
         </TabItem>
       </TabControl>
     </Border>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
@@ -40,6 +40,7 @@
     <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="Padding" Value="10 2 10 2.5" />
+    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
 
     <Setter Property="MaxDropDownHeight" Value="{DynamicResource AutoCompleteListMaxHeight}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Button.axaml
@@ -26,6 +26,7 @@
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="FontWeight" Value="SemiLight" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
@@ -61,7 +61,7 @@
     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
-    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
@@ -28,7 +28,6 @@
 
   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-    <Setter Property="FontWeight" Value="Regular" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -119,6 +119,7 @@
     <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionColorSolid}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="Padding" Value="10 2 10 2.5" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBlock.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBlock.axaml
@@ -1,14 +1,14 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Design">
+                    xmlns:design1="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
 
   <Design.PreviewWith>
-    <design:ThemePreviewer>
+    <design1:ThemePreviewer>
       <StackPanel Margin="20" Width="300" Spacing="10" HorizontalAlignment="Left">
         <TextBlock Classes="section-title">Some text</TextBlock>
         <TextBlock>Some text</TextBlock>
       </StackPanel>
-    </design:ThemePreviewer>
+    </design1:ThemePreviewer>
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type TextBlock}" TargetType="TextBlock">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
@@ -23,6 +23,7 @@
     <MergeResourceInclude Source="Separator.axaml" />
     <MergeResourceInclude Source="TabControl.axaml" />
     <MergeResourceInclude Source="TabItem.axaml" />
+    <MergeResourceInclude Source="TextBlock.axaml" />
     <MergeResourceInclude Source="TextBox.axaml" />
     <MergeResourceInclude Source="ToggleSwitch.axaml" />
     <MergeResourceInclude Source="ToolTip.axaml" />


### PR DESCRIPTION
This brings the input controls in MacOS and DevExpress themes to follow the same consistent behaviour when placed together in StackPanels or Grids without any explicit layout properties: no vertical stretching to fill the container height, no default margins, all elements vertically centered. 

<img alt="image" src="https://github.com/user-attachments/assets/d299aea1-eac9-4f6c-8187-1c2876a452bc" styles="width: 1258px; max-width: 100%" />
