### PR TITLE
Temporary work-around for blurry/light text in DevExpress light theme in RDM

### DIFF
--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml
@@ -5,32 +5,63 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.TabControlDemo">
 
+  <StackPanel Orientation="Vertical" Spacing="20">
+    <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Spacing="10">
+      <Border Width="500">
+        <TabControl TabStripPlacement="Left">
+          <TabItem Header="Tab 1">
+            <TextBlock Text="Vertical tab view" />
+          </TabItem>
+          <TabItem Header="Tab 2">
+            <TextBlock Text="Content 2" />
+          </TabItem>
+          <TabItem Header="Tab3" IsEnabled="False" />
+        </TabControl>
+      </Border>
 
-  <StackPanel Orientation="Horizontal" VerticalAlignment="Top">
-    <Border Width="500">
-      <TabControl TabStripPlacement="Left">
-        <TabItem Header="Tab 1">
-          <TextBlock Text="Vertical tab view" />
-        </TabItem>
-        <TabItem Header="Tab 2">
-          <TextBlock Text="Content 2" />
-        </TabItem>
-        <TabItem Header="Tab3" IsEnabled="False" />
-      </TabControl>
-    </Border>
-    <Border Width="500">
-      <TabControl TabStripPlacement="Top">
-        <TabItem Header="General">
-          <TextBlock Text="Horizontal tab view" />
-        </TabItem>
-        <TabItem Header="Settings">
-          <TextBlock Text="Content 2" />
-        </TabItem>
-        <TabItem Header="Disabled Tab" IsEnabled="False" />
-        <TabItem Header="Advanced">
-          <TextBlock Text="Content 3" />
-        </TabItem>
-      </TabControl>
-    </Border>
+      <Border Width="500">
+        <TabControl TabStripPlacement="Top">
+          <TabItem Header="General">
+            <TextBlock Text="Horizontal tab view" />
+          </TabItem>
+          <TabItem Header="Settings">
+            <TextBlock Text="Content 2" />
+          </TabItem>
+          <TabItem Header="Disabled Tab" IsEnabled="False" />
+          <TabItem Header="Advanced">
+            <TextBlock Text="Content 3" />
+          </TabItem>
+        </TabControl>
+      </Border>
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Spacing="10">
+      <Border Width="500">
+        <TabPane TabStripPlacement="Left">
+          <TabItem Header="Tab 1">
+            <TextBlock Text="Vertical TabPane" />
+          </TabItem>
+          <TabItem Header="Tab 2">
+            <TextBlock Text="Content 2" />
+          </TabItem>
+          <TabItem Header="Tab3" IsEnabled="False" />
+        </TabPane>
+      </Border>
+
+      <Border Width="500">
+        <TabPane TabStripPlacement="Top">
+          <TabItem Header="General">
+            <TextBlock Text="Horizontal TabPane" />
+          </TabItem>
+          <TabItem Header="Settings">
+            <TextBlock Text="Content 2" />
+          </TabItem>
+          <TabItem Header="Disabled Tab" IsEnabled="False" />
+          <TabItem Header="Advanced">
+            <TextBlock Text="Content 3" />
+          </TabItem>
+        </TabPane>
+      </Border>
+    </StackPanel>
   </StackPanel>
 </UserControl>

--- a/src/Devolutions.AvaloniaControls/Controls/TabPane.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/TabPane.cs
@@ -1,0 +1,17 @@
+namespace Devolutions.AvaloniaControls.Controls;
+
+using Avalonia.Controls;
+using Avalonia.Styling;
+
+public class TabPane : TabControl
+{
+    protected override void PrepareContainerForItemOverride(Control element, object? item, int index)
+    {
+        base.PrepareContainerForItemOverride(element, item, index);
+
+        if (element.FindResource("TabPane_TabItem") is ControlTheme theme)
+        {
+            element.Theme = theme;
+        }
+    }
+}

--- a/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
+++ b/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
@@ -8,5 +8,7 @@
         <MergeResourceInclude Source="Controls/EditableComboBox/EditableComboBox.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
+    
+    <StaticResource x:Key="{x:Type TabPane}" ResourceKey="{x:Type TabControl}" />
   </Styles.Resources>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -49,6 +49,15 @@
 
       <Color x:Key='SecondarySearchHighlightBackground'>#77fad000</Color>
       <Color x:Key='SecondarySearchHighlightForeground'>#ee000000</Color>
+
+      <!-- 
+        Temporary work-around; currently, black text in light theme looks blurry / grey-ish instead of
+        black and crisp.
+        This seems to be due to poor hinting for the Segoe UI font when rendered with Skia.
+        For now, demi-bold is the compromise we were the least dissatisfied with.
+      -->
+      <FontWeight x:Key="DefaultFontWeight">DemiBold</FontWeight>
+      <FontWeight x:Key="DemiBoldWeight">Bold</FontWeight>
     </ResourceDictionary>
 
     <!-- TODO: Darkmode colours just roughly -->
@@ -97,9 +106,13 @@
 
       <Color x:Key='SearchHighlightBackground'>#ffe6af56</Color>
       <Color x:Key='SearchHighlightForeground'>#ff202020</Color>
+      <StaticResource x:Key="DataGridFillerColumnGridLinesBrush" ResourceKey="SearchHighlightBackground" />
 
       <Color x:Key='SecondarySearchHighlightBackground'>#aae6af56</Color>
       <Color x:Key='SecondarySearchHighlightForeground'>#ee202020</Color>
+
+      <FontWeight x:Key="DefaultFontWeight">Normal</FontWeight>
+      <FontWeight x:Key="DemiBoldWeight">DemiBold</FontWeight>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
@@ -108,7 +121,7 @@
   <SolidColorBrush x:Key="TransparentBrush" Color="Transparent" />
   <SolidColorBrush x:Key="SystemRegionBrush" Color="{DynamicResource SystemRegionColor}" />
 
-  <FontFamily x:Key="DevExpressThemeFontFamily">Segoe UI, Helvetica Neue, Arial, sans-serif</FontFamily>
+  <FontFamily x:Key="DevExpressThemeFontFamily">Segoe UI, Tahoma, sans-serif</FontFamily>
   <x:Double x:Key="DefaultLineHeight">15</x:Double>
   <x:Double x:Key="DefaultFontSize">12</x:Double>
   <x:Double x:Key="ControlFontSize">12</x:Double>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
@@ -350,7 +350,7 @@
     <Setter Property="SelectionBrush" Value="{DynamicResource TextSelectionBrush}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Padding" Value="4 3 2 3" />
-    <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
 
     <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EmbeddableControlRoot.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EmbeddableControlRoot.axaml
@@ -5,8 +5,9 @@
     <Setter Property="Background" Value="{DynamicResource BackgroundBrush}" />
     <Setter Property="TopLevel.SystemBarColor" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExpressThemeFontFamily}" />
     <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
-    <Setter Property="FontFamily" Value="{StaticResource DevExpressThemeFontFamily}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DefaultFontWeight}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabPane.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabPane.axaml
@@ -1,0 +1,205 @@
+<!-- 
+    Based from: 
+    https://github.com/amwx/FluentAvalonia/blob/master/src/FluentAvalonia/Styling/ControlThemes/BasicControls/TabControlStyles.axaml
+-->
+<ResourceDictionary
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:CompileBindings="True">
+  <Design.PreviewWith>
+    <Border Width="400">
+      <TabPane>
+        <TabItem Header="Arch">
+          <Border Background="AntiqueWhite"
+                  Height="100">
+            <TextBlock Text="Content" Foreground="Black" FontSize="20" />
+          </Border>
+        </TabItem>
+        <TabItem Header="Leaf">
+          <Border Background="Green"
+                  Height="100" />
+        </TabItem>
+        <TabItem Header="Disabled"
+                 IsEnabled="False" />
+      </TabPane>
+    </Border>
+  </Design.PreviewWith>
+
+  <x:Double x:Key="TabItemPipeThickness">3</x:Double>
+  <x:Double x:Key="TabItemMinHeight">37</x:Double>
+  <x:Double x:Key="TabItemHeaderFontSize">12</x:Double>
+  <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{DynamicResource ForegroundColor}" />
+  <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{DynamicResource ForegroundColor}" />
+
+  <ControlTheme x:Key="TabPane_TabItem" TargetType="TabItem">
+    <Setter Property="FontSize" Value="{DynamicResource TabItemHeaderFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource TabItemHeaderThemeFontWeight}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource Foreground}" />
+    <Setter Property="Padding" Value="{DynamicResource TabItemHeaderMargin}" />
+    <Setter Property="Margin" Value="0 -7 0 0" />
+    <Setter Property="MinHeight" Value="{DynamicResource TabItemMinHeight}" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="PART_LayoutRoot"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Padding="{TemplateBinding Padding}"
+                Background="{Binding $parent[TabItem].Background}">
+          <Panel>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              Content="{TemplateBinding Header}"
+                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                              FontFamily="{TemplateBinding FontFamily}"
+                              FontSize="{TemplateBinding FontSize}"
+                              FontWeight="{TemplateBinding FontWeight}" />
+            <Rectangle Name="PART_SelectedPipe"
+                       Fill="{DynamicResource Border}"
+                       IsVisible="False"
+                       RadiusX="2"
+                       RadiusY="2" />
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+
+    <Style Selector="^:selected">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="IsVisible" Value="True" />
+        <Setter Property="Fill" Value="{DynamicResource SystemAccentColor}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:pointerover">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+    </Style>
+
+    <Style Selector="^:pressed">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+    </Style>
+
+    <!--  Disabled state  -->
+    <Style Selector="^:disabled /template/ Border#PART_LayoutRoot">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="TextElement.Foreground" Value="{DynamicResource TabItemHeaderForegroundDisabled}" />
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Left]">
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="Width" Value="{DynamicResource TabItemPipeThickness}" />
+        <Setter Property="Height" Value="{DynamicResource TabItemVerticalPipeHeight}" />
+        <Setter Property="Margin" Value="0,0,2,0" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+      </Style>
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Margin" Value="8,0,0,0" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Top]">
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="Height" Value="{DynamicResource TabItemPipeThickness}" />
+        <Setter Property="Margin" Value="0,0,0,3" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Bottom" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Right]">
+      <Setter Property="HorizontalContentAlignment" Value="Right" />
+
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="Width" Value="{DynamicResource TabItemPipeThickness}" />
+        <Setter Property="Height" Value="{DynamicResource TabItemVerticalPipeHeight}" />
+        <Setter Property="Margin" Value="2,0,0,0" />
+        <Setter Property="HorizontalAlignment" Value="Right" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+      </Style>
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Margin" Value="0,0,8,0" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Bottom]">
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="Height" Value="{DynamicResource TabStripItemPipeThickness}" />
+        <Setter Property="Margin" Value="0,-1,0,2" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Bottom" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:pointerover">
+      <Style Selector="^ /template/ Rectangle#PART_SelectedPipe">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:selected">
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="TabPaneTheme" TargetType="TabControl">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource Foreground}" />
+    <Setter Property="ItemContainerTheme" Value="{StaticResource TabPane_TabItem}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Margin="{TemplateBinding Margin}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Background="{TemplateBinding Background}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}">
+          <DockPanel>
+            <Border DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                    Name="PART_UnderBorder"
+                    BorderBrush="{DynamicResource BorderBrush}"
+                    Padding="0 0 0 -5"
+                    Margin="0 0 0 6"
+                    BorderThickness="0 0 0 1">
+              <ItemsPresenter Name="PART_ItemsPresenter"
+                              ItemsPanel="{TemplateBinding ItemsPanel}" />
+            </Border>
+            <ContentPresenter Name="PART_SelectedContentHost"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding SelectedContent}"
+                              ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^[TabStripPlacement=Left]">
+      <Style Selector="^ /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+        <Setter Property="Orientation" Value="Vertical" />
+      </Style>
+      <Style Selector="^ /template/ Border#PART_UnderBorder">
+        <Setter Property="BorderThickness" Value="0 0 1 0" />
+        <Setter Property="Margin" Value="0 0 6 0" />
+      </Style>
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+      <Setter Property="Orientation" Value="Vertical" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter">
+      <Setter Property="Margin" Value="{DynamicResource TabControlTopPlacementItemMargin}" />
+    </Style>
+  </ControlTheme>
+
+  <StaticResource x:Key="{x:Type TabPane}" ResourceKey="TabPaneTheme" />
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Window.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Window.axaml
@@ -6,8 +6,9 @@
     <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
     <Setter Property="TopLevel.SystemBarColor" Value="{DynamicResource SystemControlBackgroundAltHighBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExpressThemeFontFamily}" />
     <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
-    <Setter Property="FontFamily" Value="{StaticResource DevExpressThemeFontFamily}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DefaultFontWeight}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/_index.axaml
@@ -19,6 +19,7 @@
     <MergeResourceInclude Source="SplitButton.axaml" />
     <MergeResourceInclude Source="TabControl.axaml" />
     <MergeResourceInclude Source="TabItem.axaml" />
+    <MergeResourceInclude Source="TabPane.axaml" />
     <MergeResourceInclude Source="TextBox.axaml" />
     <MergeResourceInclude Source="TextBlock.axaml" />
     <MergeResourceInclude Source="TreeView.axaml" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/_index.axaml
@@ -15,4 +15,6 @@
     <MergeResourceInclude Source="TextBox.axaml" />
     <MergeResourceInclude Source="Window.axaml" />
   </ResourceDictionary.MergedDictionaries>
+
+  <StaticResource x:Key="{x:Type TabPane}" ResourceKey="{x:Type TabControl}" />
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabPane.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabPane.axaml
@@ -1,0 +1,91 @@
+<!-- 
+    Based from: 
+    https://github.com/AvaloniaUI/Avalonia/blob/603a2bdb43b7e8b2d1c8919f9d0669af7b33f117/src/Avalonia.Themes.Fluent/Controls/TabControl.xaml
+-->
+<ResourceDictionary
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  x:ClassModifier="internal">
+  <Design.PreviewWith>
+    <Border Width="400">
+      <TabControl>
+        <TabItem Header="Arch">
+          <Border Background="AntiqueWhite" Height="100">
+            <TextBlock Text="Content" Foreground="Black" FontSize="20" />
+          </Border>
+        </TabItem>
+        <TabItem Header="Leaf">
+          <Border Background="Green" Height="100" />
+        </TabItem>
+        <TabItem Header="Disabled" IsEnabled="False" />
+      </TabControl>
+    </Border>
+  </Design.PreviewWith>
+
+  <Thickness x:Key="TabPaneTopPlacementItemMargin">0 0 0 0</Thickness>
+
+  <ControlTheme x:Key="TabPaneTheme" TargetType="TabControl">
+    <Setter Property="BorderBrush" Value="{DynamicResource InputBorder}" />
+    <Setter Property="BorderThickness" Value="1" />
+
+    <Setter Property="Padding" Value="10" />
+    <Setter Property="Background" Value="{DynamicResource TabControlBackground}" />
+    <Setter Property="CornerRadius" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Background="{TemplateBinding Background}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}">
+          <DockPanel>
+            <Border Name="PART_ItemsPresenterBorder"
+                    DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="0 0 0 1"
+                    Padding="4, 0, 4, -1"
+                    CornerRadius="0">
+              <ItemsPresenter Name="PART_ItemsPresenter"
+                              ItemsPanel="{TemplateBinding ItemsPanel}" />
+            </Border>
+            <ContentPresenter Name="PART_SelectedContentHost"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Content="{TemplateBinding SelectedContent}"
+                              ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^[TabStripPlacement=Left] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+      <Setter Property="Orientation" Value="Vertical" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+      <Setter Property="Orientation" Value="Vertical" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter">
+      <Setter Property="Margin" Value="{DynamicResource TabPaneTopPlacementItemMargin}" />
+    </Style>
+
+    <Style
+      Selector="^[TabStripPlacement=Top] /template/ ItemsPresenter#PART_ItemsPresenter Border#PART_SelectedPipe">
+      <Setter Property="Height" Value="3" />
+      <Setter Property="CornerRadius" Value="0" />
+    </Style>
+
+    <Style Selector="^[TabStripPlacement=Left] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="0 0 1 0" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Right] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="1 0 0 0" />
+    </Style>
+    <Style Selector="^[TabStripPlacement=Bottom] /template/ Border#PART_ItemsPresenterBorder">
+      <Setter Property="BorderThickness" Value="0 1 0 0" />
+    </Style>
+  </ControlTheme>
+
+  <StaticResource x:Key="{x:Type TabPane}" ResourceKey="TabPaneTheme" />
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
@@ -23,6 +23,7 @@
     <MergeResourceInclude Source="Separator.axaml" />
     <MergeResourceInclude Source="TabControl.axaml" />
     <MergeResourceInclude Source="TabItem.axaml" />
+    <MergeResourceInclude Source="TabPane.axaml" />
     <MergeResourceInclude Source="TextBox.axaml" />
     <MergeResourceInclude Source="ToggleSwitch.axaml" />
     <MergeResourceInclude Source="ToolTip.axaml" />


### PR DESCRIPTION
Exposed as dynamically-looked-up resources to allow consumers to override