### PR TITLE
Fix TextBox text to align cleanly with other controls' text

### DIFF
--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -8,25 +8,26 @@
   
   <StackPanel Margin="10">
     <TextBlock Classes="h1" Text="Grids" />
-    <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+    <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
           ColumnSpacing="10"
           Margin="10">
       <TextBlock Grid.Column="0">TextBlock</TextBlock>
       <TextBox Grid.Column="1" Watermark="TextBox" />
-      <ComboBox Grid.Column="2" SelectedIndex="2">
+      <TextBox Grid.Column="2" Height="22" MinHeight="22" MaxHeight="22">thin</TextBox>
+      <ComboBox Grid.Column="3" SelectedIndex="2">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4 much longer</ComboBoxItem>
         </ComboBox>
-      <AutoCompleteBox Grid.Column="3" x:Name="Animals" FilterMode="Contains" Watermark="AutoComplete" />
-      <NumericUpDown Grid.Column="4" Value="0"
+      <AutoCompleteBox Grid.Column="4" x:Name="Animals" FilterMode="Contains" Watermark="AutoComplete" />
+      <NumericUpDown Grid.Column="5" Value="0"
                      Increment="1"
                      Watermark="mm" />
-      <Button Grid.Column="5" Content="Button" />
-      <CheckBox Grid.Column="6" Content="Checkbox" IsChecked="True" />
+      <Button Grid.Column="6" Content="Button" />
+      <CheckBox Grid.Column="7" Content="Checkbox" IsChecked="True" />
       <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
-      <TextBlock Grid.Column="7" Text="🙂" FontSize="45" />
+      <TextBlock Grid.Column="8" Text="🙂" FontSize="45" />
     </Grid>
 
     <Grid RowDefinitions="*, *, *, *, *, *, *, *, *"
@@ -54,21 +55,22 @@
     <StackPanel Orientation="Vertical" Margin="0 10" Spacing="20" VerticalAlignment="Top">
       <StackPanel Orientation="Horizontal" Margin="10" Spacing="10" VerticalAlignment="Top">
         <TextBlock>TextBlock</TextBlock>
-          <TextBox Watermark="TextBox" />
-          <ComboBox SelectedIndex="2">
-            <ComboBoxItem>Option 1</ComboBoxItem>
-            <ComboBoxItem>Option 2</ComboBoxItem>
-            <ComboBoxItem>Option 3</ComboBoxItem>
-            <ComboBoxItem>Option 4</ComboBoxItem>
-          </ComboBox>
-          <AutoCompleteBox x:Name="Animals3" FilterMode="Contains" Watermark="AutoComplete" />
-          <NumericUpDown Value="0"
-                         Increment="1"
-                         Watermark="mm" />
-          <Button Content="Button" />
-          <CheckBox Content="Checkbox" IsChecked="True" />
-          <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
-          <TextBlock Text="🙂" FontSize="45" />
+        <TextBox Watermark="TextBox" />
+        <TextBox Grid.Column="2" Height="22" MinHeight="22" MaxHeight="22">thin</TextBox>
+        <ComboBox SelectedIndex="2">
+          <ComboBoxItem>Option 1</ComboBoxItem>
+          <ComboBoxItem>Option 2</ComboBoxItem>
+          <ComboBoxItem>Option 3</ComboBoxItem>
+          <ComboBoxItem>Option 4</ComboBoxItem>
+        </ComboBox>
+        <AutoCompleteBox x:Name="Animals3" FilterMode="Contains" Watermark="AutoComplete" />
+        <NumericUpDown Value="0"
+                       Increment="1"
+                       Watermark="mm" />
+        <Button Content="Button" />
+        <CheckBox Content="Checkbox" IsChecked="True" />
+        <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
+        <TextBlock Text="🙂" FontSize="45" />
       </StackPanel>
       <StackPanel Orientation="Vertical" Width="100" Margin="10" Spacing="10" VerticalAlignment="Top" HorizontalAlignment="Left">
         <TextBlock>TextBlock</TextBlock>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -171,6 +171,7 @@
   <SolidColorBrush x:Key="TextBoxBorderBrush" Color="{DynamicResource ControlBorderLowColorSolid}" />
   <SolidColorBrush x:Key="TextBoxBottomBorderBrush" Color="{DynamicResource TextBoxBorderBottomColor}" />
   <SolidColorBrush x:Key="TextBoxDisabledBorderSelectedBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.1" />
+  <Thickness x:Key="TextBoxPadding">4 0.5 4 1.5</Thickness>
 
   <x:Double x:Key="TextBasedInputMinHeight">23</x:Double>
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
@@ -39,7 +39,7 @@
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
-    <Setter Property="Padding" Value="10 2 10 2.5" />
+    <Setter Property="Padding" Value="{DynamicResource TextBoxPadding}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -123,7 +123,7 @@
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="MinHeight" Value="{DynamicResource TextBasedInputMinHeight}" />
     <Setter Property="MinWidth" Value="{DynamicResource TextBasedInputMinHeight}" />
-    <Setter Property="Padding" Value="4 1" />
+    <Setter Property="Padding" Value="{DynamicResource TextBoxPadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ContextFlyout"


### PR DESCRIPTION
Padding changes in #202 caused the text in TextBox-based inputs to sit slightly lower within the box than the text on other input controls. Just changed the bottom padding to be slightly larger than top padding to fix this & created a shared resource to make sure `AutoComplete` always looks the same as `TextBox`  