### PR TITLE
[MacOS] Fix DatePicker width for long format & remove format presets

### DIFF
--- a/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml
+++ b/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml
@@ -8,9 +8,10 @@
 
   <StackPanel Orientation="Horizontal" Margin="20" Spacing="20">
     <StackPanel Spacing="20">
-    <CalendarDatePicker HorizontalAlignment="Left" />
+      <CalendarDatePicker Watermark="yyyy-MM-dd" HorizontalAlignment="Left" />
     <CalendarDatePicker Name="DatePicker" HorizontalAlignment="Left" />
     <CalendarDatePicker Name="DatePicker2" HorizontalAlignment="Left" IsEnabled="False" />
+      <CalendarDatePicker Name="DatePicker3" HorizontalAlignment="Left" SelectedDateFormat="Long" />
     </StackPanel>
     <CalendarDatePicker HorizontalAlignment="Left" VerticalAlignment="Top">
       <DataValidationErrors.Error>

--- a/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml.cs
@@ -8,6 +8,6 @@ public partial class CalendarDatePickerDemo : UserControl
   public CalendarDatePickerDemo()
   {
     this.InitializeComponent();
-    this.DatePicker.SelectedDate = this.DatePicker2.SelectedDate = DateTime.Today;
+    this.DatePicker.SelectedDate = this.DatePicker2.SelectedDate = this.DatePicker3.SelectedDate = DateTime.Today;
   }
 }

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Calendar.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Calendar.axaml
@@ -11,12 +11,15 @@
 -->
 
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
 
   <Design.PreviewWith>
-    <Border Padding="20">
-      <Calendar />
-    </Border>
+    <design:ThemePreviewer>
+      <Border Padding="20">
+        <Calendar />
+      </Border>
+    </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type Calendar}" TargetType="Calendar">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -5,11 +5,13 @@
 
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design"
+                    xmlns:sys="clr-namespace:System;assembly=System.Runtime">
   <Design.PreviewWith>
     <design:ThemePreviewer>
       <StackPanel Margin="20" Spacing="20">
         <CalendarDatePicker />
+        <CalendarDatePicker SelectedDate="{Binding Source={x:Static sys:DateTime.Today}}" />
         <TextBox Classes="revealPasswordButton" PasswordChar="*" Text="tests" />
         <TextBox Watermark="&lt;yyyy-MM-dd&gt;" />
         <CalendarDatePicker IsEnabled="False" />
@@ -31,9 +33,7 @@
   </ControlTheme>
   
   <ControlTheme x:Key="{x:Type CalendarDatePicker}" TargetType="CalendarDatePicker">
-    <Setter Property="Watermark" Value="yyyy-MM-dd" />
     <Setter Property="IsTodayHighlighted" Value="True" />
-    <Setter Property="FirstDayOfWeek" Value="Monday" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource TextBoxBackgroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource TextBoxBorderBrush}" />
@@ -41,7 +41,7 @@
     <Setter Property="CornerRadius" Value="{DynamicResource TextBoxCornerRadius}" />
     <Setter Property="FontSize" Value="{StaticResource ControlFontSize}" />
     <Setter Property="MinHeight" Value="{DynamicResource CalendarControlHeight}" />
-    <Setter Property="MinWidth" Value="120" />
+    <!-- <Setter Property="MinWidth" Value="120" /> -->
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
@@ -59,8 +59,11 @@
                        Background="{TemplateBinding Background}"
                        BorderBrush="{TemplateBinding BorderBrush}"
                        BorderThickness="{TemplateBinding BorderThickness}"
-                       CornerRadius="{TemplateBinding CornerRadius}"
-                       Padding="{TemplateBinding Padding}" />
+                       CornerRadius="{TemplateBinding CornerRadius}">
+                <TextBox.InnerRightContent>
+                  <Rectangle Width="20" Fill="Transparent"/>
+                </TextBox.InnerRightContent>
+              </TextBox>
                   <!-- Brittle Button placement! Placing the Button as TextBox.InnerRightContent breaks functionality,
                        But this placement breaks if ValidationError text is positioned _above_ the TextBox 
                        Also: centering the button via setting a top margin gives inconsistent results on different monitors -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -20,7 +20,6 @@
 
   <ControlTheme x:Key="DatePickerButton"
                 TargetType="Button">
-    <Setter Property="Margin" Value="2 0 2 1" /> 
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="Button">
@@ -64,27 +63,17 @@
                        Padding="{TemplateBinding Padding}" />
                   <!-- Brittle Button placement! Placing the Button as TextBox.InnerRightContent breaks functionality,
                        But this placement breaks if ValidationError text is positioned _above_ the TextBox 
-                       Also: centering the button via setting a top margin give inconsistent results on different monitors -->
+                       Also: centering the button via setting a top margin gives inconsistent results on different monitors -->
               <Panel Height="{DynamicResource CalendarControlHeight}" VerticalAlignment="Top">
                   <Button Name="PART_Button"
                                 Theme="{StaticResource DatePickerButton}"
                                 ClipToBounds="False"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Center"
-                                Margin="0 0 10 0">
+                                Margin="0 0 8 0">
                     <Panel>
                       <PathIcon Data="{StaticResource CalendarIconPath}"
-                                Foreground="{DynamicResourceToggler 
-                                  {Binding IsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=CalendarDatePicker}
-                                  }, 
-                                  CalendarIconBrush,
-                                  ForegroundLowBrush
-                                }"
                                 Height="13" />
-                      <PathIcon Data="{StaticResource CalendarIconPath}"
-                                Foreground="{DynamicResource AccentButtonBackground}"
-                                Height="13"
-                                IsVisible="{Binding $parent[CalendarDatePicker].IsDropDownOpen}" />
                     </Panel>
                   </Button>
               </Panel>
@@ -117,6 +106,20 @@
       </ControlTemplate>
     </Setter>
 
+    <Style Selector="^ /template/ Button#PART_Button PathIcon">
+      <Setter Property="Foreground"
+              Value="{DynamicResourceToggler 
+                                  {Binding IsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=CalendarDatePicker}
+                                  }, 
+                                  CalendarIconBrush,
+                                  ForegroundLowBrush
+                                }" />
+    </Style>
+
+    <Style Selector="^:flyout-open /template/ Button#PART_Button PathIcon">
+      <Setter Property="Foreground" Value="{DynamicResource AccentButtonBackground}" />
+    </Style>
+    
     <!-- Error State -->
     <Style Selector="^:error /template/ TextBox#PART_TextBox">
       <Setter Property="BorderBrush" Value="{DynamicResource SystemControlErrorTextForegroundBrush}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -5,14 +5,16 @@
 
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="using:System">
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
   <Design.PreviewWith>
-    <StackPanel Margin="20" Spacing="20">
-      <CalendarDatePicker />
-      <TextBox Classes="revealPasswordButton" PasswordChar="*" Text="tests" />
-      <TextBox Watermark="&lt;yyyy-MM-dd&gt;" />
-      <CalendarDatePicker IsEnabled="False" />
-    </StackPanel>
+    <design:ThemePreviewer>
+      <StackPanel Margin="20" Spacing="20">
+        <CalendarDatePicker />
+        <TextBox Classes="revealPasswordButton" PasswordChar="*" Text="tests" />
+        <TextBox Watermark="&lt;yyyy-MM-dd&gt;" />
+        <CalendarDatePicker IsEnabled="False" />
+      </StackPanel>
+    </design:ThemePreviewer>
   </Design.PreviewWith>
 
 


### PR DESCRIPTION
- The last version wasn't flexible enough to accommodate all different date formats. 
- I also didn't realize that it will pick up system settings on date format, so I removed the settings I baked in.
- Plus some code tidying 