### PR TITLE
Add Design ThemePreviewer to the Linux project

### DIFF
--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ButtonSpinner.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ButtonSpinner.axaml
@@ -6,44 +6,47 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="using:System"
                     xmlns:avaloniaConverters="clr-namespace:Avalonia.Controls.Converters;assembly=Avalonia.Controls"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     x:ClassModifier="internal">
 
   <Design.PreviewWith>
-    <ThemeVariantScope RequestedThemeVariant="Light">
-      <StackPanel Spacing="20">
-        <ButtonSpinner Content="Right spinner" />
-        <ButtonSpinner
-          Content="Right spinner half-disabled"
-          ValidSpinDirection="Increase" />
-        <ButtonSpinner ButtonSpinnerLocation="Left"
-                       Content="Left spinner" />
-        <ButtonSpinner ButtonSpinnerLocation="Left"
-                       Content="Left spinner" />
-        <ButtonSpinner BorderThickness="2"
-                       BorderBrush="Blue"
-                       Content="Right Border" />
-        <ButtonSpinner ButtonSpinnerLocation="Left"
-                       BorderThickness="2"
-                       BorderBrush="Blue"
-                       Content="Left Border" />
-        <ButtonSpinner Content="Right disabled"
-                       AllowSpin="False" />
-        <ButtonSpinner ButtonSpinnerLocation="Left"
-                       Content="Left disabled"
-                       AllowSpin="False" />
-        <ButtonSpinner ShowButtonSpinner="False"
-                       Content="Hide spinner" />
-        <ButtonSpinner Content="Error">
-          <DataValidationErrors.Error>
-            <sys:Exception>
-              <x:Arguments>
-                <x:String>Error</x:String>
-              </x:Arguments>
-            </sys:Exception>
-          </DataValidationErrors.Error>
-        </ButtonSpinner>
-      </StackPanel>
-    </ThemeVariantScope>
+    <design:ThemePreviewer>
+      <ThemeVariantScope RequestedThemeVariant="Light">
+        <StackPanel Spacing="20">
+          <ButtonSpinner Content="Right spinner" />
+          <ButtonSpinner
+            Content="Right spinner half-disabled"
+            ValidSpinDirection="Increase" />
+          <ButtonSpinner ButtonSpinnerLocation="Left"
+                         Content="Left spinner" />
+          <ButtonSpinner ButtonSpinnerLocation="Left"
+                         Content="Left spinner" />
+          <ButtonSpinner BorderThickness="2"
+                         BorderBrush="Blue"
+                         Content="Right Border" />
+          <ButtonSpinner ButtonSpinnerLocation="Left"
+                         BorderThickness="2"
+                         BorderBrush="Blue"
+                         Content="Left Border" />
+          <ButtonSpinner Content="Right disabled"
+                         AllowSpin="False" />
+          <ButtonSpinner ButtonSpinnerLocation="Left"
+                         Content="Left disabled"
+                         AllowSpin="False" />
+          <ButtonSpinner ShowButtonSpinner="False"
+                         Content="Hide spinner" />
+          <ButtonSpinner Content="Error">
+            <DataValidationErrors.Error>
+              <sys:Exception>
+                <x:Arguments>
+                  <x:String>Error</x:String>
+                </x:Arguments>
+              </sys:Exception>
+            </DataValidationErrors.Error>
+          </ButtonSpinner>
+        </StackPanel>
+      </ThemeVariantScope>
+    </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <avaloniaConverters:MarginMultiplierConverter x:Key="ButtonSpinnerLeftThickness" Indent="1" Left="True" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CheckBox.axaml
@@ -4,9 +4,11 @@
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <CheckBox>Unchecked</CheckBox>
@@ -15,6 +17,7 @@
         <CheckBox Width="120">Checkbox should wrap its text</CheckBox>
       </StackPanel>
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <StreamGeometry x:Key="CheckMarkPathData">M5.5 10.586 1.707 6.793A1 1 0 0 0 .293 8.207l4.5 4.5a1 1 0 0 0 1.414 0l11-11A1 1 0 0 0 15.793.293L5.5 10.586Z</StreamGeometry>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ContextMenu.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ContextMenu.axaml
@@ -4,9 +4,11 @@
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Background="{DynamicResource SystemAccentColor}"
             Margin="16"
             Padding="48"
@@ -33,6 +35,7 @@
       </Border.ContextMenu>
       <TextBlock Text="Defined in XAML" />
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/DataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/DataGrid.axaml
@@ -4,9 +4,11 @@
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     xmlns:collections="using:Avalonia.Collections">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <DataGrid
       Width="200"
       Height="200">
@@ -21,6 +23,7 @@
         <DataGridTextColumn Header="B" x:DataType="Color" Binding="{Binding B}" />
       </DataGrid.Columns>
     </DataGrid>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource DataGridColumnHeaderForegroundColor}" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/NumericUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/NumericUpDown.axaml
@@ -5,10 +5,12 @@
 <ResourceDictionary
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
   xmlns:sys="clr-namespace:System;assembly=System.Runtime"
   x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <NumericUpDown
@@ -57,6 +59,7 @@
         </NumericUpDown>
       </StackPanel>
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type NumericUpDown}" TargetType="NumericUpDown">

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TabControl.axaml
@@ -4,9 +4,11 @@
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Width="400">
       <TabControl>
         <TabItem Header="Arch">
@@ -20,6 +22,7 @@
         <TabItem Header="Disabled" IsEnabled="False" />
       </TabControl>
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 0</Thickness>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TabItem.axaml
@@ -5,9 +5,11 @@
 <ResourceDictionary
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
   x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <TabItem Header="Leaf" />
@@ -15,6 +17,7 @@
         <TabItem Header="Background" Background="Yellow" />
       </StackPanel>
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <x:Double x:Key="TabItemMinHeight">37</x:Double>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/TextBox.axaml
@@ -4,9 +4,11 @@
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
                     x:ClassModifier="internal">
 
   <Design.PreviewWith>
+    <design:ThemePreviewer>
     <Border Padding="20">
       <StackPanel Spacing="20">
         <TextBox>Left</TextBox>
@@ -19,6 +21,7 @@
         <TextBox Watermark="Floating Watermark" UseFloatingWatermark="True">Content</TextBox>
       </StackPanel>
     </Border>
+  </design:ThemePreviewer>
   </Design.PreviewWith>
 
   <Thickness x:Key="TextBoxTopHeaderMargin">0,0,0,4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.Linux/Design/ThemePreviewer.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Design/ThemePreviewer.axaml
@@ -1,0 +1,142 @@
+<ResourceDictionary
+  xmlns="https://github.com/avaloniaui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design">
+  <Design.PreviewWith>
+    <design:ThemePreviewer Padding="10">
+      <TextBlock Text="test" />
+    </design:ThemePreviewer>
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="ThemePreviewer_TabItem" TargetType="TabItem">
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="Foreground" Value="#555" />
+    <Setter Property="Padding" Value="2 2" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Name="PART_LayoutRoot"
+          Background="#1c1c1c"
+          BorderBrush="#030303"
+          BorderThickness="1 1 1 0"
+          CornerRadius="5 5 0 0"
+          Padding="{TemplateBinding Padding}">
+          <Panel>
+            <ContentPresenter
+              Name="PART_ContentPresenter"
+              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+              Content="{TemplateBinding Header}"
+              ContentTemplate="{TemplateBinding HeaderTemplate}"
+              Padding="10, 0"
+              RecognizesAccessKey="True" />
+            <Border Name="PART_SelectedPipe"
+                    Background="{DynamicResource TabItemHeaderSelectedPipeFill}"
+                    CornerRadius="0"
+                    IsVisible="False" />
+          </Panel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:selected">
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+
+    <Setter Property="Margin" Value="-1 0 0 0" />
+    <Style Selector="^:nth-child(1)">
+      <Setter Property="Margin" Value="0 0 0 0" />
+    </Style>
+  </ControlTheme>
+
+  <ControlTheme x:Key="ThemePreviewer_TabControl" TargetType="TabControl">
+    <Setter Property="ItemContainerTheme" Value="{StaticResource ThemePreviewer_TabItem}" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border BorderThickness="0"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Background="{TemplateBinding Background}"
+                HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                VerticalAlignment="{TemplateBinding VerticalAlignment}">
+          <DockPanel>
+            <Border Name="PART_ItemsPresenterBorder"
+                    DockPanel.Dock="{TemplateBinding TabStripPlacement}"
+                    Padding="0, 0, 0, 0"
+                    HorizontalAlignment="Center"
+                    CornerRadius="0">
+              <ItemsPresenter Name="PART_ItemsPresenter"
+                              ItemsPanel="{TemplateBinding ItemsPanel}" />
+            </Border>
+            <Border
+              BorderBrush="#030303"
+              BorderThickness="1">
+              <ContentPresenter Name="PART_SelectedContentHost"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Content="{TemplateBinding SelectedContent}"
+                                ContentTemplate="{TemplateBinding SelectedContentTemplate}" />
+            </Border>
+          </DockPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+
+  <ControlTheme x:Key="{x:Type design:ThemePreviewer}" TargetType="design:ThemePreviewer">
+    <Setter Property="Margin" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="MinWidth" Value="120" />
+    <Setter Property="Background" Value="#181818" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <TabControl
+          Name="PART_TabControl"
+          Background="{TemplateBinding Background}"
+          Theme="{StaticResource ThemePreviewer_TabControl}">
+          <TabItem Header="Dark" Name="PART_DarkTab">
+            <ThemeVariantScope RequestedThemeVariant="Dark">
+              <ThemeVariantScope.Resources>
+                <ResourceDictionary>
+                  <ResourceDictionary.MergedDictionaries>
+                    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+                  </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+              </ThemeVariantScope.Resources>
+
+              <Border
+                Name="PART_ContentContainer_Dark"
+                Background="#212121"
+                Padding="{TemplateBinding Padding}">
+                <ContentPresenter
+                  Name="PART_ContentPresenter"
+                  Content="{TemplateBinding Content}"
+                  ContentTemplate="{TemplateBinding ContentTemplate}"
+                  Margin="0"
+                  Padding="0" />
+              </Border>
+            </ThemeVariantScope>
+          </TabItem>
+
+          <TabItem Header="Light" Name="PART_LightTab" IsSelected="True">
+            <ThemeVariantScope RequestedThemeVariant="Light">
+              <ThemeVariantScope.Resources>
+                <ResourceDictionary>
+                  <ResourceDictionary.MergedDictionaries>
+                    <ResourceInclude Source="/Accents/ThemeResources.axaml" />
+                  </ResourceDictionary.MergedDictionaries>
+                </ResourceDictionary>
+              </ThemeVariantScope.Resources>
+
+              <Border
+                Name="PART_ContentContainer_Light"
+                Background="#fff"
+                Padding="{TemplateBinding Padding}" />
+            </ThemeVariantScope>
+          </TabItem>
+        </TabControl>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.Linux/Design/ThemePreviewer.axaml.cs
+++ b/src/Devolutions.AvaloniaTheme.Linux/Design/ThemePreviewer.axaml.cs
@@ -1,0 +1,62 @@
+namespace Devolutions.AvaloniaTheme.Linux.Design;
+
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Primitives;
+
+[TemplatePart("PART_TabControl", typeof(TabControl), IsRequired = true)]
+internal class ThemePreviewer : ContentControl
+{
+    private ContentPresenter? presenter;
+    private TabControl? tabControl;
+    private Border? currentContainer;
+    private INameScope? nameScope;
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        if (this.currentContainer is not null)
+        {
+            this.currentContainer.Child = null;
+        }
+
+        if (this.tabControl is not null)
+        {
+            this.tabControl.SelectionChanged -= this.TabControl_OnSelectionChanged;
+        }
+
+        base.OnApplyTemplate(e);
+
+        this.nameScope = e.NameScope;
+        this.tabControl = e.NameScope.Get<TabControl>("PART_TabControl");
+        this.tabControl.SelectionChanged += this.TabControl_OnSelectionChanged;
+    }
+
+    private void TabControl_OnSelectionChanged(object? _, SelectionChangedEventArgs args)
+    {
+        if (args.RemovedItems.Count <= 0 || args.AddedItems.Count <= 0)
+        {
+            return;
+        }
+
+        TabItem? prevTab = args.RemovedItems[0] as TabItem;
+        TabItem? nextTab = args.AddedItems[0] as TabItem;
+
+        if (prevTab is null || nextTab is null || this.nameScope is null)
+        {
+            return;
+        }
+
+        this.presenter = this.nameScope.Get<ContentPresenter>("PART_ContentPresenter");
+
+        Border? prevContainer = this.nameScope.Find<Border>($"PART_ContentContainer_{prevTab.Header}");
+        Border? nextContainer = this.nameScope.Find<Border>($"PART_ContentContainer_{nextTab.Header}");
+
+        if (prevContainer is not null && nextContainer is not null)
+        {
+            prevContainer.Child = null;
+            nextContainer.Child = this.presenter;
+            this.currentContainer = nextContainer;
+        }
+    }
+}

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -37,4 +37,28 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
     <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Design\ThemePreviewer.axaml.cs">
+      <DependentUpon>ThemePreviewer.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="Design\ThemePreviewer.axaml.cs">
+      <DependentUpon>ThemePreviewer.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Update="Internal\DevExpressThemeWithGlobalStyles.axaml.cs">
+      <DependentUpon>DevExpressThemeWithGlobalStyles.axaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="Design\ThemePreviewer.axaml" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <Compile Remove="Design\ThemePreviewer.axaml.cs" />
+    <None Include="Design\ThemePreviewer.axaml.cs" />
+    <AvaloniaXaml Remove="Design\ThemePreviewer.axaml" />
+    <None Include="Design\ThemePreviewer.axaml" />
+  </ItemGroup>
 </Project>

--- a/src/Devolutions.AvaloniaTheme.Linux/DevolutionsLinuxYaruTheme.cs
+++ b/src/Devolutions.AvaloniaTheme.Linux/DevolutionsLinuxYaruTheme.cs
@@ -1,6 +1,7 @@
 namespace Devolutions.AvaloniaTheme.Linux;
 
 using Avalonia.Markup.Xaml;
+using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 
 /// <summary>
@@ -15,5 +16,9 @@ public class DevolutionsLinuxYaruTheme : Styles
     public DevolutionsLinuxYaruTheme(IServiceProvider? sp = null)
     {
         AvaloniaXamlLoader.Load(sp, this);
+#if DEBUG
+        Uri themePreviewerUri = new("avares://Devolutions.AvaloniaTheme.Linux/Design/ThemePreviewer.axaml");
+        this.Resources.MergedDictionaries.Add(new ResourceInclude(themePreviewerUri) { Source = themePreviewerUri });
+#endif
     }
 }


### PR DESCRIPTION
This is the design preview wrapper control we're already using for development of the DevExpress and MacOS themes for easy light & dark mode preview. Just copying it to the Linux project.