### PR TITLE
[DevExpress] Distinguish selected vs hover for single-column ListBox too

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/AutoCompleteBox.axaml
@@ -29,6 +29,13 @@
     <Setter Property="MinHeight" Value="1" />
     <Setter Property="Height" Value="26" />
     <Setter Property="Padding" Value="10 2" />
+    
+    <Style Selector="^:pointerover">
+
+      <Style Selector="^ /template/ Border#SingleColumnListBox_SelectionHighlight">
+        <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
+      </Style>
+    </Style>
   </ControlTheme>
 
   <ControlTheme x:Key="{x:Type AutoCompleteBox}" TargetType="AutoCompleteBox">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBoxItem.axaml
@@ -113,9 +113,6 @@
           <Setter Property="Background" Value="Transparent" />
         </Style>
       </Style>
-      <Style Selector="^ /template/ Border#SingleColumnListBox_SelectionHighlight">
-        <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
-      </Style>
     </Style>
 
     <!--  Disabled state  -->


### PR DESCRIPTION
#224 introduced a different look for multi-column ListBox, to clearly distinguish selections and hover state. I'm making a similar change to all ListBoxes now - even though it's less of a problem in a single column, it could still be confusing.

<img width="218" alt="image" src="https://github.com/user-attachments/assets/f790805d-931f-4a1a-a7a0-94e5bd860c99" />
