### PR TITLE
[DevExpress] Change TabControl VerticalContentAlignment

### DIFF
--- a/samples/SampleApp/DemoPages/ListBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/ListBoxDemo.axaml
@@ -5,30 +5,36 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ListBoxDemo">
 
-  <StackPanel Margin="20" Spacing="20">
-    <StackPanel Orientation="Horizontal" Spacing="20">
+  <StackPanel Margin="20" Spacing="20" VerticalAlignment="Stretch">
+
+    <!-- Top row of simple ListBoxes -->
+    <StackPanel Orientation="Horizontal" Spacing="20" Height="140">
       <TextBlock VerticalAlignment="Top" Margin="0 5">Single selection:</TextBlock>
     <ListBox x:Name="animals1" />
-
+  
     <TextBlock VerticalAlignment="Top" Margin="0 5">Multiple selection:</TextBlock>
     <ListBox x:Name="animals2" SelectionMode="Multiple" />
+
+    <TextBlock VerticalAlignment="Top" Margin="0 5">Fewer entries:</TextBlock>
+    <ListBox x:Name="animals3" />
+
+    <TextBlock VerticalAlignment="Top" Margin="0 5" TextWrapping="Wrap" Width="80">More entries: <LineBreak /> (requires <TextBlock Classes="code">Width</TextBlock> set to fit longest entry, or the width will change during scrolling)</TextBlock>
+    <ListBox x:Name="animals6" Width="100" />
     </StackPanel>
 
+    <!-- Bottom row of multi-column ListBoxes -->
     <Grid ColumnSpacing="20" RowSpacing="20" RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *">
       <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0  5 0 0">Multi-column ListBox (with WrapPanel as ItemsTemplate), multiple selection:</TextBlock>
-      <StackPanel Grid.Row="1" Grid.Column="0">
-        <TextBlock Margin="20  0 0 2" TextWrapping="Wrap">Default (with an arbitrary MinWidth=90 to make it  work out of the box):</TextBlock>
-        <ListBox x:Name="animals3" SelectionMode="Multiple" Width="280" HorizontalAlignment="Left" Margin="20 0">
-          <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-              <WrapPanel Orientation="Horizontal" ScrollViewer.VerticalScrollBarVisibility="Auto" />
-            </ItemsPanelTemplate>
-          </ItemsControl.ItemsPanel>
-        </ListBox>
-      </StackPanel>
-      <StackPanel Grid.Row="1" Grid.Column="1">
-        <TextBlock Margin="20  0 0 2" TextWrapping="Wrap">To override default MinWidth, alignment, etc. use a custom ItemTemplate:</TextBlock>
-        <ListBox x:Name="animals4" SelectionMode="Multiple" Width="280" HorizontalAlignment="Left" Margin="20 0">
+      <TextBlock Grid.Row="1" Grid.Column="0" Margin="10 0 0 0" TextWrapping="Wrap">Default (with an arbitrary MinWidth=90 to make it  work out of the box):</TextBlock>
+      <ListBox Grid.Row="2" Grid.Column="0" x:Name="animals4" SelectionMode="Multiple" Margin="10 0 0 0">
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel Orientation="Horizontal" ScrollViewer.VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" />
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+      </ListBox>
+      <TextBlock Grid.Row="1" Grid.Column="1" TextWrapping="Wrap">To override default MinWidth, alignment, etc. use a custom ItemTemplate:</TextBlock>
+      <ListBox Grid.Row="2" Grid.Column="1" x:Name="animals5" SelectionMode="Multiple" VerticalAlignment="Stretch">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
               <WrapPanel Orientation="Horizontal" ScrollViewer.VerticalScrollBarVisibility="Auto" />
@@ -42,7 +48,6 @@
             </DataTemplate>
           </ItemsControl.ItemTemplate>
         </ListBox>
-  </StackPanel>
     </Grid>
   </StackPanel>
 

--- a/samples/SampleApp/DemoPages/ListBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ListBoxDemo.axaml.cs
@@ -12,7 +12,10 @@ public partial class ListBoxDemo : UserControl
         this.animals1.ItemsSource = this.animals2.ItemsSource = new[]
                 { "cat", "mouse", "lion", "zebra" }
             .OrderBy(x => x);
-        this.animals3.ItemsSource = this.animals4.ItemsSource = new[]
+        this.animals3.ItemsSource = new[]
+                { "cat", "zebra" }
+            .OrderBy(x => x);
+        this.animals4.ItemsSource = this.animals5.ItemsSource = this.animals6.ItemsSource = new[]
                 { "cat", "camel", "cow", "chameleon", "mouse", "lion", "zebra", "tiger", "donkey" }
             .OrderBy(x => x);
     }

--- a/samples/SampleApp/DemoPages/TabControlDemo.axaml
+++ b/samples/SampleApp/DemoPages/TabControlDemo.axaml
@@ -8,14 +8,17 @@
 
 
   <StackPanel Orientation="Vertical" Spacing="20" Margin="5">
+    <TextBlock TextWrapping="Wrap">Note that the whole TabControl will not automatically grow to the height of the longest Tab contents, so unless you set to a specific height or stretch, the height will jump when switching tabs. </TextBlock>
     <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Spacing="10">
       <StackPanel Width="400" Spacing="20" Margin="5">
-        <TabControl TabStripPlacement="Left">
+        <TabControl TabStripPlacement="Left" Height="100">
           <TabItem Header="Tab 1">
             <TextBlock Text="Vertical tab view" VerticalAlignment="Top" />
           </TabItem>
           <TabItem Header="Tab 2">
-            <TextBlock Text="Content 2" VerticalAlignment="Top" />
+            <TextBlock VerticalAlignment="Top">
+              Some slightly longer text <LineBreak /> that will require more space <LineBreak /> that will require more space <LineBreak /> that will require more space
+            </TextBlock>
           </TabItem>
           <TabItem Header="Tab 3" IsEnabled="False" />
         </TabControl>
@@ -56,7 +59,9 @@
             <TextBlock Text="Horizontal tab view" VerticalAlignment="Top" />
           </TabItem>
           <TabItem Header="Settings">
-            <TextBlock Text="Content 2" VerticalAlignment="Top" />
+            <TextBlock VerticalAlignment="Top">
+              Some slightly longer text <LineBreak /> that will require more space <LineBreak /> that will require more space <LineBreak /> that will require more space
+            </TextBlock>
           </TabItem>
           <TabItem Header="Disabled Tab" IsEnabled="False" />
           <TabItem Header="Advanced">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TabControl.axaml
@@ -8,8 +8,8 @@
         <TabControl TabStripPlacement="Top" Margin="5">
           <TabItem Header="General">
             <StackPanel Orientation="Horizontal" Spacing="30">
-              <TextBlock Text="Company" VerticalAlignment="Center" />
-              <TextBox Width="200" VerticalAlignment="Center" />
+              <TextBlock Text="Company" />
+              <TextBox Width="200" />
             </StackPanel>
           </TabItem>
           <TabItem Header="Communication">
@@ -24,8 +24,8 @@
         <TabControl TabStripPlacement="Left" Margin="5" Height="200" Classes="NavBar">
           <TabItem Header="General">
             <StackPanel Orientation="Horizontal" Spacing="30">
-              <TextBlock Text="Company" VerticalAlignment="Center" />
-              <TextBox Width="200" VerticalAlignment="Center" />
+              <TextBlock Text="Company" />
+              <TextBox Width="200" />
             </StackPanel>
           </TabItem>
           <TabItem Header="Communication">
@@ -112,7 +112,7 @@
     <Setter Property="Padding" Value="25 20" />
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderMidBrush}" />
-    <Setter Property="VerticalContentAlignment" Value="Top" />
+    <Setter Property="VerticalContentAlignment" Value="Stretch" />
     <Setter Property="ItemContainerTheme"
             Value="{BindingToggler {Binding $self.Classes, Converter={x:Static DevoConverters.HasClass}, ConverterParameter=NavBar},
                                  {DynamicResource Devo_NavBar_TabItem},

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -15,6 +15,7 @@
     <PackageReleaseNotes>
       See https://github.com/Devolutions/avalonia-extensions/blob/master/src/Devolutions.AvaloniaTheme.DevExpress/CHANGELOG.md
 
+      BREAKING: 2025.08.19 - `TabControl`'s `VerticalContentAlignment` changed from `Top` to `Stretch`
       BREAKING: 2025.07.14 - changes to input controls' and `TextBox` layout behaviour (no vertical stretch, no default margins, vertically centered)
     </PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Changes `TabControl`'s `VerticalContentAlignment` from `Top` to `Stretch` to avoid confusing behaviour of child components. 

(All other changes are just in the demo pages to better illustrate/test alignment issues like the one that prompted this change)

