### PR TITLE
[DevExpress] ListBox fix

### DIFF
--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -29,12 +29,8 @@
   <!-- KEPT FOR DESIGNER! -->
   <!-- This also dictates which theme is initially loaded -->
   <Application.Styles>
-    <!-- <actipro:ModernTheme AreNativeControlThemesEnabled="False" /> -->
-
     <!-- <DevolutionsMacOsTheme /> -->
-    <!-- <DevolutionsDevExpressTheme /> -->
-    <DevolutionsLinuxYaruTheme />
-
-    <StyleInclude Source="/Styles.axaml" />
+    <DevolutionsDevExpressTheme />
+    <!-- <DevolutionsLinuxYaruTheme /> -->
   </Application.Styles>
 </Application>

--- a/samples/SampleApp/DemoPages/ListBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/ListBoxDemo.axaml
@@ -2,52 +2,80 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             xmlns:sampleApp="clr-namespace:SampleApp"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="650"
              x:Class="SampleApp.DemoPages.ListBoxDemo">
 
-  <StackPanel Margin="20" Spacing="20" VerticalAlignment="Stretch">
-
-    <!-- Top row of simple ListBoxes -->
-    <StackPanel Orientation="Horizontal" Spacing="20" Height="140">
-      <TextBlock VerticalAlignment="Top" Margin="0 5">Single selection:</TextBlock>
-    <ListBox x:Name="animals1" />
   
-    <TextBlock VerticalAlignment="Top" Margin="0 5">Multiple selection:</TextBlock>
+  <StackPanel Margin="20" Spacing="20" VerticalAlignment="Stretch">
+    <ListBox>
+      <ListBoxItem>No</ListBoxItem>
+      <ListBoxItem IsSelected="True">Yes</ListBoxItem>
+      <ListBoxItem IsEnabled="False">Disabled</ListBoxItem>
+    </ListBox>
+    <!-- Top row of simple ListBoxes -->
+    <StackPanel Orientation="Horizontal" Spacing="20" Height="120">
+      <TextBlock VerticalAlignment="Top" Margin="0 5">Single selection:<LineBreak />(custom width)</TextBlock>
+      <ListBox x:Name="animals1" Width="110" />
+      <TextBlock VerticalAlignment="Top" Margin="0 5">Multiple selection:<LineBreak />(automatic width)</TextBlock>
     <ListBox x:Name="animals2" SelectionMode="Multiple" />
 
-    <TextBlock VerticalAlignment="Top" Margin="0 5">Fewer entries:</TextBlock>
-    <ListBox x:Name="animals3" />
-
-    <TextBlock VerticalAlignment="Top" Margin="0 5" TextWrapping="Wrap" Width="80">More entries: <LineBreak /> (requires <TextBlock Classes="code">Width</TextBlock> set to fit longest entry, or the width will change during scrolling)</TextBlock>
-    <ListBox x:Name="animals6" Width="100" />
+      <TextBlock VerticalAlignment="Top" Margin="15 5 0 5" TextWrapping="Wrap" Width="130">Scrolling: <LineBreak /> (requires <TextBlock Classes="code">Width</TextBlock> set to fit longest entry, or the width will change during scrolling)</TextBlock>
+      <ListBox x:Name="animals4" Width="115" />
     </StackPanel>
-
+  
     <!-- Bottom row of multi-column ListBoxes -->
-    <Grid ColumnSpacing="20" RowSpacing="20" RowDefinitions="Auto, Auto, Auto" ColumnDefinitions="*, *">
-      <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0  5 0 0">Multi-column ListBox (with WrapPanel as ItemsTemplate), multiple selection:</TextBlock>
-      <TextBlock Grid.Row="1" Grid.Column="0" Margin="10 0 0 0" TextWrapping="Wrap">Default (with an arbitrary MinWidth=90 to make it  work out of the box):</TextBlock>
-      <ListBox Grid.Row="2" Grid.Column="0" x:Name="animals4" SelectionMode="Multiple" Margin="10 0 0 0">
+    <Grid ColumnSpacing="20" RowSpacing="20" RowDefinitions="Auto, Auto, 99, Auto, 99" ColumnDefinitions="*, *">
+      <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0  5 0 0">
+        <Bold>Multi-column ListBox (with WrapPanel as ItemsTemplate), multiple selection:</Bold>
+      </TextBlock>
+      <TextBlock Grid.Row="1" Grid.Column="0" Margin="10 0 0 0" TextWrapping="Wrap">
+        Default horizontal WrapPanel requires width setting for items to still line up vertically:
+        <TextBlock Classes="code" Text="&lt;WrapPanel ItemWidth=&quot;99&quot; /&gt;" />
+      </TextBlock>
+      <ListBox Grid.Row="2" Grid.Column="0" x:Name="animals5" SelectionMode="Multiple" Margin="10 0 0 0">
         <ItemsControl.ItemsPanel>
           <ItemsPanelTemplate>
-            <WrapPanel Orientation="Horizontal" ScrollViewer.VerticalScrollBarVisibility="Auto" VerticalAlignment="Stretch" />
+            <WrapPanel ItemWidth="99" />
           </ItemsPanelTemplate>
         </ItemsControl.ItemsPanel>
       </ListBox>
-      <TextBlock Grid.Row="1" Grid.Column="1" TextWrapping="Wrap">To override default MinWidth, alignment, etc. use a custom ItemTemplate:</TextBlock>
-      <ListBox Grid.Row="2" Grid.Column="1" x:Name="animals5" SelectionMode="Multiple" VerticalAlignment="Stretch">
+      <TextBlock Grid.Row="1" Grid.Column="1" TextWrapping="Wrap">
+        Vertical WrapPanel:
+        <TextBlock Classes="code" Text="&lt;WrapPanel Orientation=&quot;Vertical&quot; /&gt;" />
+      </TextBlock>
+      <ListBox Grid.Row="2" Grid.Column="1" x:Name="animals6" SelectionMode="Multiple">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
-              <WrapPanel Orientation="Horizontal" ScrollViewer.VerticalScrollBarVisibility="Auto" />
+              <WrapPanel Orientation="Vertical" />
             </ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
-          <ItemsControl.ItemTemplate>
-            <DataTemplate>
-              <TextBlock Text="{Binding }"
-                         MinWidth="110"
-                         TextAlignment="Center" />
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ListBox>
+      </ListBox>
+      <TextBlock Grid.Row="3" Grid.Column="0" TextWrapping="Wrap">
+        To override default styles, etc. use a custom ItemTemplate:
+        <TextBlock
+          TextWrapping="Wrap"
+          IsVisible="{Binding Source={x:Static sampleApp:App.CurrentTheme}, 
+                       Path=Name,
+                       Converter={StaticResource EqualToComparisonConverter},
+                       ConverterParameter=MacOS}">
+          (Center-aligned text not recommended, unless length variation is minimal)
+        </TextBlock>
+      </TextBlock>
+      <ListBox Grid.Row="4" Grid.Column="0" x:Name="animals7" SelectionMode="Multiple">
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel Orientation="Vertical" />
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ItemsControl.ItemTemplate>
+          <DataTemplate>
+            <TextBlock Text="{Binding }"
+                       MinWidth="99"
+                       TextAlignment="Center" />
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ListBox>
     </Grid>
   </StackPanel>
 

--- a/samples/SampleApp/DemoPages/ListBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/ListBoxDemo.axaml
@@ -14,7 +14,7 @@
       <ListBoxItem IsEnabled="False">Disabled</ListBoxItem>
     </ListBox>
     <!-- Top row of simple ListBoxes -->
-    <StackPanel Orientation="Horizontal" Spacing="20" Height="120">
+    <StackPanel Orientation="Horizontal" Spacing="20" Height="122">
       <TextBlock VerticalAlignment="Top" Margin="0 5">Single selection:<LineBreak />(custom width)</TextBlock>
       <ListBox x:Name="animals1" Width="110" />
       <TextBlock VerticalAlignment="Top" Margin="0 5">Multiple selection:<LineBreak />(automatic width)</TextBlock>
@@ -71,7 +71,7 @@
         <ItemsControl.ItemTemplate>
           <DataTemplate>
             <TextBlock Text="{Binding }"
-                       MinWidth="99"
+                       MinWidth="69"
                        TextAlignment="Center" />
           </DataTemplate>
         </ItemsControl.ItemTemplate>

--- a/samples/SampleApp/DemoPages/ListBoxDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/ListBoxDemo.axaml.cs
@@ -12,10 +12,7 @@ public partial class ListBoxDemo : UserControl
         this.animals1.ItemsSource = this.animals2.ItemsSource = new[]
                 { "cat", "mouse", "lion", "zebra" }
             .OrderBy(x => x);
-        this.animals3.ItemsSource = new[]
-                { "cat", "zebra" }
-            .OrderBy(x => x);
-        this.animals4.ItemsSource = this.animals5.ItemsSource = this.animals6.ItemsSource = new[]
+        this.animals4.ItemsSource = this.animals5.ItemsSource = this.animals6.ItemsSource = this.animals7.ItemsSource = new[]
                 { "cat", "camel", "cow", "chameleon", "mouse", "lion", "zebra", "tiger", "donkey" }
             .OrderBy(x => x);
     }

--- a/samples/SampleApp/MainWindow.axaml
+++ b/samples/SampleApp/MainWindow.axaml
@@ -114,7 +114,7 @@
       </TabItem>
       <TabItem IsSelected="True">
         <TabItem.Header>
-          <controls:SampleItemHeader Title="ListBox" ApplicableTo="Windows - DevExpress" />
+          <controls:SampleItemHeader Title="ListBox" ApplicableTo="MacOS, Windows - DevExpress" />
         </TabItem.Header>
         <demoPages:ListBoxDemo />
       </TabItem>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -196,8 +196,6 @@
   <Thickness x:Key="ComboBoxItemBorderMargin">0</Thickness>
   <Thickness x:Key="MultiColumnListBoxItemBorderMargin">5 1</Thickness>
   <x:Double x:Key="ComboBoxItemMinHeight">24</x:Double>
-  <x:Double x:Key="ComboBoxItemMinWidth">24</x:Double>
-  <x:Double x:Key="MultiColumnListItemDefaultWidth">90</x:Double>
   <x:Double x:Key="ComboBoxSelectionHighlightWidth">3</x:Double>
   <Thickness x:Key="ComboBoxSelectionHighlightMargin">0 1 6 1</Thickness>
   <CornerRadius x:Key="ComboBoxSelectionHighlightRadius">2</CornerRadius>
@@ -206,7 +204,9 @@
   <x:Double x:Key="DropdownButtonHeight">17</x:Double>
   <x:Double x:Key="DropdownButtonIconWidth">9</x:Double>
 
-
+  <ScrollBarVisibility x:Key="ScrollBarVisibilityDisabled">Disabled</ScrollBarVisibility>
+  <ScrollBarVisibility x:Key="ScrollBarVisibilityAuto">Auto</ScrollBarVisibility>
+  
   <SolidColorBrush x:Key="CheckBoxBackgroundBrush" Color="{DynamicResource BackgroundColor}" />
   <SolidColorBrush x:Key="CheckBoxForegroundDisabledBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.56" />
   <SolidColorBrush x:Key="CheckBoxCheckedBackgroundDisabledBrush" Color="{DynamicResource ForegroundColor}"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBox.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Design">
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Design"
+                    xmlns:converters="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Converters">
 
   <!-- 
     Un-comment to allow auto-completion;
@@ -13,14 +14,36 @@
   
   <Design.PreviewWith>
     <design:ThemePreviewer Padding="10">
-    <Border Padding="20">
-      <ListBox SelectionMode="Multiple">
-        <ListBoxItem>Test</ListBoxItem>
-        <ListBoxItem>Test</ListBoxItem>
-        <ListBoxItem>Test</ListBoxItem>
-        <ListBoxItem>Test</ListBoxItem>
-      </ListBox>
-    </Border>
+      <StackPanel Margin="20" Spacing="10">
+        <ListBox Width="80" HorizontalAlignment="Left">
+          <ListBoxItem>Test</ListBoxItem>
+          <ListBoxItem>Test</ListBoxItem>
+          <ListBoxItem>Test</ListBoxItem>
+          <ListBoxItem>Test</ListBoxItem>
+        </ListBox>
+        <ListBox Width="240" Height="150">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <WrapPanel Orientation="Vertical" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ListBoxItem>Monkey</ListBoxItem>
+          <ListBoxItem>Whale</ListBoxItem>
+          <ListBoxItem>Cat</ListBoxItem>
+          <ListBoxItem>Chameleon</ListBoxItem>
+          <ListBoxItem>Lion</ListBoxItem>
+          <ListBoxItem>Tiger</ListBoxItem>
+          <ListBoxItem>Elephant</ListBoxItem>
+          <ListBoxItem>Test8</ListBoxItem>
+          <ListBoxItem>Test2</ListBoxItem>
+          <ListBoxItem>Test3</ListBoxItem>
+          <ListBoxItem>Test4</ListBoxItem>
+          <ListBoxItem>Test5</ListBoxItem>
+          <ListBoxItem>Test6</ListBoxItem>
+          <ListBoxItem>Test7</ListBoxItem>
+          <ListBoxItem>Test8</ListBoxItem>
+        </ListBox>
+      </StackPanel>
     </design:ThemePreviewer>
   </Design.PreviewWith>
 
@@ -29,8 +52,7 @@
     <Setter Property="Background" Value="{DynamicResource BackgroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ScrollControlBorder}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="Padding" Value="{DynamicResource ComboBoxDropDownInnerPadding}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
     <Setter Property="Template">
@@ -44,16 +66,22 @@
           <ScrollViewer Name="PART_ScrollViewer"
                         VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}"
                         HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}"
-                        HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                        VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                         IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                         IsScrollInertiaEnabled="{TemplateBinding (ScrollViewer.IsScrollInertiaEnabled)}"
                         IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}"
                         AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}"
+                        HorizontalScrollBarVisibility="{BindingToggler
+                              {Binding $parent[ListBox], Converter={x:Static converters:DevExpressConverters.IsVerticalMultiColumnListBoxConverter}},
+                              {DynamicResource ScrollBarVisibilityAuto},
+                              {DynamicResource ScrollBarVisibilityDisabled}}"
+                        VerticalScrollBarVisibility="{BindingToggler
+                              {Binding $parent[ListBox], Converter={x:Static converters:DevExpressConverters.IsVerticalMultiColumnListBoxConverter}},
+                              {DynamicResource ScrollBarVisibilityDisabled},
+                              {DynamicResource ScrollBarVisibilityAuto}}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             ItemsPanel="{TemplateBinding ItemsPanel}"
-                            Margin="{StaticResource ComboBoxDropDownInnerPadding}" />
+                            Margin="{TemplateBinding Padding}" />
           </ScrollViewer>
         </Border>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ListBoxItem.axaml
@@ -29,11 +29,6 @@
     <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
-    <Setter Property="MinWidth"
-            Value="{BindingToggler
-                                      {Binding $parent[ListBox], Converter={x:Static converters:DevExpressConverters.IsMultiColumnListBox}},
-                                      {DynamicResource MultiColumnListItemDefaultWidth},
-                                      {DynamicResource ComboBoxItemMinWidth}}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/DevExpressConverters.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/DevExpressConverters.cs
@@ -4,4 +4,5 @@ public static partial class DevExpressConverters
 {
   public static readonly CalendarWeekendHighlightConverter CalendarWeekendHighlightConverter = new();
   public static readonly CharToDevExpressPasswordCharConverter CharToDevExpressPasswordCharConverter = new();
+  public static readonly IsVerticalMultiColumnListBoxConverter IsVerticalMultiColumnListBoxConverter = new();
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Converters/IsVerticalMultiColumnListBoxConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Converters/IsVerticalMultiColumnListBoxConverter.cs
@@ -1,0 +1,24 @@
+namespace Devolutions.AvaloniaTheme.DevExpress.Converters;
+
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml.Templates;
+
+public class IsVerticalMultiColumnListBoxConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is ListBox { ItemsPanel : ItemsPanelTemplate template })
+        {
+            Panel? probe = template.Build(); // off-tree probe
+            if (probe is WrapPanel wp) return wp.Orientation == Orientation.Vertical;
+        }
+
+        return false;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotImplementedException();
+}

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -28,6 +28,7 @@
 
       <Color x:Key="ScrollBarTrackColor">#fbfbfb</Color>
       <Color x:Key="ScrollBarTrackBorderColor">#d6d6d6</Color>
+      <SolidColorBrush x:Key='ScrollControlBorder'>#dddddd</SolidColorBrush>
 
       <Color x:Key="DefaultIconColor">#000000</Color>
       <Color x:Key="CalendarIconColor">#7b7b7b</Color>
@@ -142,7 +143,8 @@
 
       <Color x:Key="ScrollBarTrackColor">#2c2c2c</Color>
       <Color x:Key="ScrollBarTrackBorderColor">#3f3f3f</Color>
-
+      <SolidColorBrush x:Key='ScrollControlBorder'>#343337</SolidColorBrush>
+      
       <Color x:Key="DefaultIconColor">#b8b8b8</Color>
       <Color x:Key="CalendarIconColor">#9f9f9f</Color>
       <Color x:Key="CalendarSelectedBackgroundColor">#454545</Color>
@@ -368,6 +370,10 @@
   <x:Int32 x:Key="ComboBoxItemHeight">22</x:Int32>
   <Thickness x:Key="ComboBoxShadowMargin">4</Thickness>
 
+  <ScrollBarVisibility x:Key="ScrollBarVisibilityDisabled">Disabled</ScrollBarVisibility>
+  <ScrollBarVisibility x:Key="ScrollBarVisibilityAuto">Auto</ScrollBarVisibility>
+
+  <!-- TODO: Use Bindings to named item properties & AddBinding to encode these dependencies more securely -->
   <!-- InitialFirstItemDistance must match ComboBoxShadowMargin.bottom + PopupPadding.top -->
   <x:Int32 x:Key="InitialFirstItemDistance">9</x:Int32>
   <x:Int32 x:Key="PopupTrimHeight">30</x:Int32> <!-- includes Margin, Padding, Shadow -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
@@ -1,24 +1,53 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Converters">
 
+  <!-- 
+    Un-comment to allow auto-completion;
+    DO NOT INCLUDE WHEN PUBLISHING!
+  -->
+  <!-- <ResourceDictionary.MergedDictionaries> -->
+  <!--   <ResourceInclude Source="/Accents/ThemeResources.axaml" /> -->
+  <!-- </ResourceDictionary.MergedDictionaries> -->
+  
   <Design.PreviewWith>
-    <Border Padding="20">
-      <ListBox>
+    <StackPanel Margin="20" Spacing="10">
+      <ListBox Width="80" HorizontalAlignment="Left">
         <ListBoxItem>Test</ListBoxItem>
         <ListBoxItem>Test</ListBoxItem>
         <ListBoxItem>Test</ListBoxItem>
         <ListBoxItem>Test</ListBoxItem>
       </ListBox>
-    </Border>
+      <ListBox Width="240">
+        <ItemsControl.ItemsPanel>
+          <ItemsPanelTemplate>
+            <WrapPanel />
+          </ItemsPanelTemplate>
+        </ItemsControl.ItemsPanel>
+        <ListBoxItem>Monkey</ListBoxItem>
+        <ListBoxItem>Whale</ListBoxItem>
+        <ListBoxItem>Cat</ListBoxItem>
+        <ListBoxItem>Chameleon</ListBoxItem>
+        <ListBoxItem>Lion</ListBoxItem>
+        <ListBoxItem>Tiger</ListBoxItem>
+        <ListBoxItem>Elephant</ListBoxItem>
+        <ListBoxItem>Test8</ListBoxItem>
+        <ListBoxItem>Test2</ListBoxItem>
+        <ListBoxItem>Test3</ListBoxItem>
+        <ListBoxItem>Test4</ListBoxItem>
+        <ListBoxItem>Test5</ListBoxItem>
+        <ListBoxItem>Test6</ListBoxItem>
+        <ListBoxItem>Test7</ListBoxItem>
+        <ListBoxItem>Test8</ListBoxItem>
+      </ListBox>
+    </StackPanel>
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ListBox}" TargetType="ListBox">
-    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />
-    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="BorderBrush" Value="{DynamicResource ScrollControlBorder}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Padding" Value="{DynamicResource PopupPadding}" />
+
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
     <Setter Property="Template">
@@ -32,13 +61,19 @@
           <ScrollViewer Name="PART_ScrollViewer"
                         VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}"
                         HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}"
-                        HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
-                        VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
                         IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
                         IsScrollInertiaEnabled="{TemplateBinding (ScrollViewer.IsScrollInertiaEnabled)}"
                         IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}"
                         AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
-                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}"
+                        HorizontalScrollBarVisibility="{BindingToggler
+                              {Binding $parent[ListBox], Converter={x:Static converters:MacOSConverters.IsVerticalMultiColumnListBoxConverter}},
+                              {DynamicResource ScrollBarVisibilityAuto},
+                              {DynamicResource ScrollBarVisibilityDisabled}}"
+                        VerticalScrollBarVisibility="{BindingToggler
+                              {Binding $parent[ListBox], Converter={x:Static converters:MacOSConverters.IsVerticalMultiColumnListBoxConverter}},
+                              {DynamicResource ScrollBarVisibilityDisabled},
+                              {DynamicResource ScrollBarVisibilityAuto}}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             ItemsPanel="{TemplateBinding ItemsPanel}"
                             Margin="{TemplateBinding Padding}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
@@ -1,0 +1,50 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <ListBox>
+        <ListBoxItem>Test</ListBoxItem>
+        <ListBoxItem>Test</ListBoxItem>
+        <ListBoxItem>Test</ListBoxItem>
+        <ListBoxItem>Test</ListBoxItem>
+      </ListBox>
+    </Border>
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type ListBox}" TargetType="ListBox">
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ListBoxBorderThemeThickness}" />
+    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
+    <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
+    <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Name="border"
+                ClipToBounds="{TemplateBinding ClipToBounds}"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <ScrollViewer Name="PART_ScrollViewer"
+                        VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}"
+                        HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}"
+                        HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                        VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                        IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                        IsScrollInertiaEnabled="{TemplateBinding (ScrollViewer.IsScrollInertiaEnabled)}"
+                        IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}"
+                        AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
+            <ItemsPresenter Name="PART_ItemsPresenter"
+                            ItemsPanel="{TemplateBinding ItemsPanel}"
+                            Margin="{TemplateBinding Padding}" />
+          </ScrollViewer>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
@@ -47,7 +47,6 @@
     <Setter Property="BorderBrush" Value="{DynamicResource ScrollControlBorder}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="Padding" Value="{DynamicResource PopupPadding}" />
-
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
     <Setter Property="Template">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
@@ -3,9 +3,17 @@
                     xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design"
                     x:ClassModifier="internal">
 
+  <!-- 
+    Un-comment to allow auto-completion;
+    DO NOT INCLUDE WHEN PUBLISHING!
+  -->
+  <!-- <ResourceDictionary.MergedDictionaries> -->
+  <!--   <ResourceInclude Source="/Accents/ThemeResources.axaml" /> -->
+  <!-- </ResourceDictionary.MergedDictionaries> -->
+  
   <Design.PreviewWith>
     <design:ThemePreviewer Padding="10">
-      <StackPanel>
+      <StackPanel Width="200">
         <ListBoxItem>No</ListBoxItem>
         <ListBoxItem IsSelected="True">Yes</ListBoxItem>
         <ListBoxItem IsEnabled="False">Disabled</ListBoxItem>
@@ -16,8 +24,6 @@
   <ControlTheme x:Key="{x:Type ListBoxItem}" TargetType="ListBoxItem">
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
-    <Setter Property="HorizontalAlignment" Value="Stretch" />
-    <Setter Property="HorizontalContentAlignment" Value="Left" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
@@ -43,7 +49,7 @@
               </Path.IsVisible>
             </Path>
             <ContentPresenter Name="PART_ContentPresenter"
-                              Padding="4 0"
+                              Padding=" 4 0 2 0"
                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                               Foreground="{TemplateBinding Foreground}"
@@ -60,7 +66,7 @@
     </Style>
     <Style Selector="^:pointerover">
       <Style Selector="^ /template/ Border#RootPanel">
-        <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}" />
+        <Setter Property="Background" Value="{DynamicResource ControlBackgroundAccentRaisedBrush}" />
       </Style>
       <Style Selector="^:selected /template/ Path#CheckMark">
         <Setter Property="Fill" Value="{DynamicResource ControlForegroundAccentHighBrush}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/_index.axaml
@@ -19,6 +19,7 @@
     <MergeResourceInclude Source="EmbeddableControlRoot.axaml" />
     <MergeResourceInclude Source="EditableComboBox.axaml" />
     <MergeResourceInclude Source="GridSplitter.axaml" />
+    <MergeResourceInclude Source="ListBox.axaml" />
     <MergeResourceInclude Source="ListBoxItem.axaml" />
     <MergeResourceInclude Source="Menu.axaml" />
     <MergeResourceInclude Source="MenuFlyoutPresenter.axaml" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Converters/IsVerticalMultiColumnListBoxConverter.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Converters/IsVerticalMultiColumnListBoxConverter.cs
@@ -1,0 +1,24 @@
+namespace Devolutions.AvaloniaTheme.MacOS.Converters;
+
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Layout;
+using Avalonia.Markup.Xaml.Templates;
+
+public class IsVerticalMultiColumnListBoxConverter : IValueConverter
+{
+  public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+  {
+    if (value is ListBox { ItemsPanel : ItemsPanelTemplate template })
+    {
+      Panel? probe = template.Build(); // off-tree probe
+      if (probe is WrapPanel wp) return wp.Orientation == Orientation.Vertical;
+    }
+
+    return false;
+  }
+
+  public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    throw new NotImplementedException();
+}

--- a/src/Devolutions.AvaloniaTheme.MacOS/Converters/MacOSConverters.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Converters/MacOSConverters.cs
@@ -1,6 +1,7 @@
 namespace Devolutions.AvaloniaTheme.MacOS.Converters;
 
-public static class MacOSConverters
+public static partial class MacOSConverters
 {
   public static readonly CharToMacOsPasswordCharConverter CharToMacOsPasswordCharConverter = new();
+  public static readonly IsVerticalMultiColumnListBoxConverter IsVerticalMultiColumnListBoxConverter = new();
 }


### PR DESCRIPTION
- Add support for vertical multi-column ListBox, like in the MacOS theme. 
- Remove the previously set MinWidth for ListBoxItem (it was meant to be a reasonable default, that would allow most typical values to be layed out nicely when centered - but since it cannot be overwritten with a smaller width it would cause problems if all entries were quite short)