### PR TITLE
Support ItemTemplate in MultiComboBox

### DIFF
--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -30,7 +30,7 @@
   <!-- This also dictates which theme is initially loaded -->
   <Application.Styles>
     <!-- <DevolutionsMacOsTheme /> -->
-    <DevolutionsDevExpressTheme />
-    <!-- <DevolutionsLinuxYaruTheme /> -->
+    <!-- <DevolutionsDevExpressTheme /> -->
+    <DevolutionsLinuxYaruTheme />
   </Application.Styles>
 </Application>

--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -4,7 +4,7 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:vm="clr-namespace:SampleApp.ViewModels"
-  mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="550"
+  mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="700"
   x:Class="SampleApp.DemoPages.MultiComboBoxDemo"
   x:DataType="vm:MultiComboBoxViewModel">
 
@@ -90,6 +90,24 @@
         IsEnabled="False"
         ItemsSource="{Binding Items}"
         SelectedItems="{Binding SelectedItems, Mode=TwoWay}" />
+
+      <Separator Margin="0 10" />
+
+      <TextBlock>Custom Item Template</TextBlock>
+      <MultiComboBox
+        HorizontalAlignment="Left"
+        Watermark="Custom Item Template"
+        ItemsSource="{Binding Items}"
+        SelectedItems="{Binding SelectedItems, Mode=TwoWay}">
+        <MultiComboBox.ItemTemplate>
+          <DataTemplate>
+            <StackPanel Orientation="Horizontal">
+              <Border Width="12" Height="12" Background="Green" Margin="0 0 5 0" />
+              <TextBlock Text="{Binding}" />
+            </StackPanel>
+          </DataTemplate>
+        </MultiComboBox.ItemTemplate>
+      </MultiComboBox>
     </StackPanel>
   </Border>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -4,7 +4,7 @@
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:vm="clr-namespace:SampleApp.ViewModels"
-  mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="700"
+  mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="800"
   x:Class="SampleApp.DemoPages.MultiComboBoxDemo"
   x:DataType="vm:MultiComboBoxViewModel">
 
@@ -12,7 +12,7 @@
     <vm:MultiComboBoxViewModel />
   </Design.DataContext>
 
-  <Border Margin="20" Padding="20" HorizontalAlignment="Stretch">
+  <Border Margin="10" Padding="10" HorizontalAlignment="Stretch">
     <StackPanel Orientation="Vertical">
       <MultiComboBox Width="200" Watermark="select...">
         <MultiComboBoxItem IsSelected="True">Item 1</MultiComboBoxItem>
@@ -22,7 +22,7 @@
         <MultiComboBoxItem>Item 5</MultiComboBoxItem>
       </MultiComboBox>
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>OverflowMode = Scroll (Default)</TextBlock>
       <TextBlock Margin="10 0 0 0">
@@ -39,7 +39,7 @@
         <MultiComboBoxItem IsSelected="True">Item 5</MultiComboBoxItem>
       </MultiComboBox>
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>OverflowMode = Wrap</TextBlock>
       <MultiComboBox Width="200" Watermark="select..." OverflowMode="Wrap" SelectAllLabel="Select All">
@@ -50,7 +50,7 @@
         <MultiComboBoxItem IsSelected="True">Item 5</MultiComboBoxItem>
       </MultiComboBox>
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <MultiComboBox
         HorizontalAlignment="Left"
@@ -62,7 +62,7 @@
         <TextBlock Text="{Binding SelectedText}" />
       </StackPanel>
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>"Select All" feature</TextBlock>
       <MultiComboBox
@@ -72,7 +72,7 @@
         ItemsSource="{Binding Items}"
         SelectedItems="{Binding SelectedItems, Mode=TwoWay}" />
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>LOT of values</TextBlock>
       <MultiComboBox
@@ -81,7 +81,7 @@
         SelectAllLabel="Select All"
         ItemsSource="{Binding LotOfItems}" />
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>Disabled</TextBlock>
       <MultiComboBox
@@ -91,7 +91,7 @@
         ItemsSource="{Binding Items}"
         SelectedItems="{Binding SelectedItems, Mode=TwoWay}" />
 
-      <Separator Margin="0 10" />
+      <Separator Margin="0 5" />
 
       <TextBlock>Custom Item Template</TextBlock>
       <MultiComboBox
@@ -108,6 +108,19 @@
           </DataTemplate>
         </MultiComboBox.ItemTemplate>
       </MultiComboBox>
+
+      <Separator Margin="0 5" />
+
+      <TextBlock>Enum Values</TextBlock>
+      <MultiComboBox
+        HorizontalAlignment="Left"
+        Watermark="Enum Values"
+        ItemsSource="{Binding EnumValues}"
+        SelectedItems="{Binding SelectedEnumValues, Mode=TwoWay}" />
+      <StackPanel Orientation="Horizontal">
+        <TextBlock Text="Selected: " />
+        <TextBlock Text="{Binding SelectedEnumValuesText}" />
+      </StackPanel>
     </StackPanel>
   </Border>
 </UserControl>

--- a/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
@@ -1,24 +1,39 @@
 namespace SampleApp.ViewModels;
 
+using System;
 using System.Collections.ObjectModel;
+using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
+
+public enum MultiComboBoxDemoEnum
+{
+    EnumA,
+    EnumValueB,
+}
 
 public partial class MultiComboBoxViewModel : ObservableObject
 {
+    [ObservableProperty]
+    private MultiComboBoxDemoEnum[] enumValues = Enum.GetValues<MultiComboBoxDemoEnum>();
+
     [ObservableProperty]
     private string[] items = ["item 1", "item 2", "item 3"];
 
     [ObservableProperty]
     private ObservableCollection<string> lotOfItems = [];
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectedEnumValuesText))]
+    private AvaloniaList<MultiComboBoxDemoEnum> selectedEnumValues = [MultiComboBoxDemoEnum.EnumA];
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SelectedText))]
-    private ObservableCollection<string> selectedItems = ["item 2"];
+    private AvaloniaList<string> selectedItems = ["item 2"];
 
     public MultiComboBoxViewModel()
     {
-        this.selectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedText));
+        this.SelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedText));
+        this.SelectedEnumValues.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedEnumValuesText));
 
         for (var i = 1; i <= 1000; ++i)
         {
@@ -27,4 +42,6 @@ public partial class MultiComboBoxViewModel : ObservableObject
     }
 
     public string SelectedText => this.SelectedItems.Count > 0 ? string.Join(", ", this.SelectedItems) : "None";
+
+    public string SelectedEnumValuesText => this.SelectedEnumValues.Count > 0 ? string.Join(", ", this.SelectedEnumValues) : "None";
 }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
@@ -121,7 +121,7 @@
                 Margin="1">
                 <u:MultiComboBoxSelectedItemList
                   VerticalAlignment="Center"
-                  ItemTemplate="{TemplateBinding SelectedItemTemplate}"
+                  ItemTemplate="{TemplateBinding EffectiveSelectedItemTemplate}"
                   ItemsSource="{TemplateBinding SelectedItems}"
                   RemoveCommand="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Remove}"
                   ItemsPanel="{TemplateBinding EffectiveSelectedItemsPanel}" />

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -14,10 +14,8 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Metadata;
+using Irihi.Avalonia.Shared.Helpers;
 using static Extensions.AvaloniaExtensions;
-using AvaloniaPropertyExtension = Irihi.Avalonia.Shared.Helpers.AvaloniaPropertyExtension;
-using ObservableExtension = Irihi.Avalonia.Shared.Helpers.ObservableExtension;
-using RoutedEventExtension = Irihi.Avalonia.Shared.Helpers.RoutedEventExtension;
 
 public enum MultiComboBoxOverflowMode
 {
@@ -117,7 +115,7 @@ public class MultiComboBox : SelectingItemsControl
     {
         FocusableProperty.OverrideDefaultValue<MultiComboBox>(true);
         ItemsPanelProperty.OverrideDefaultValue<MultiComboBox>(DefaultPanel);
-        AvaloniaPropertyExtension.AffectsPseudoClass<MultiComboBox>(IsDropDownOpenProperty, PC_DropDownOpen);
+        IsDropDownOpenProperty.AffectsPseudoClass<MultiComboBox>(PC_DropDownOpen);
         SelectedItemsProperty.Changed.AddClassHandler<MultiComboBox, IList?>((box, args) => box.OnSelectedItemsChanged(args));
     }
 
@@ -325,27 +323,26 @@ public class MultiComboBox : SelectingItemsControl
 
         this.selectAllItem?.UpdateSelection();
 
-        RoutedEventExtension.RemoveHandler(PointerPressedEvent, this.OnBackgroundPointerPressed, this.rootBorder);
+        PointerPressedEvent.RemoveHandler(this.OnBackgroundPointerPressed, this.rootBorder);
         this.rootBorder = e.NameScope.Find<Border>(PART_BackgroundBorder);
-        RoutedEventExtension.AddHandler(PointerPressedEvent, this.OnBackgroundPointerPressed, this.rootBorder);
+        PointerPressedEvent.AddHandler(this.OnBackgroundPointerPressed, this.rootBorder);
         this.PseudoClasses.Set(PC_Empty, this.SelectedItems?.Count == 0);
 
         if (this.selectAllItem is { } sai)
         {
-            ObservableExtension.Subscribe(sai.GetObservable(IsSelectedProperty),
-                isSelected =>
-                {
-                    if (this.updateInternal) return;
+            sai.GetObservable(IsSelectedProperty).Subscribe(isSelected =>
+            {
+                if (this.updateInternal) return;
 
-                    if (isSelected)
-                    {
-                        this.Selection.SelectAll();
-                    }
-                    else
-                    {
-                        this.Selection.Clear();
-                    }
-                });
+                if (isSelected)
+                {
+                    this.Selection.SelectAll();
+                }
+                else
+                {
+                    this.Selection.Clear();
+                }
+            });
         }
     }
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -125,13 +125,11 @@ public class MultiComboBox : SelectingItemsControl
 
         this.GetObservable(OverflowModeProperty).Subscribe(_ =>
         {
-            this.RaisePropertyChanged(ScrollbarVisibilityProperty, default, this.ScrollbarVisibility);
-            this.RaisePropertyChanged(EffectiveSelectedItemsPanelProperty, null!, this.EffectiveSelectedItemsPanel);
+            this.RaiseDirectPropertyChanged(ScrollbarVisibilityProperty);
+            this.RaiseDirectPropertyChanged(EffectiveSelectedItemsPanelProperty);
         });
-        this.GetObservable(SelectedItemTemplateProperty)
-            .Subscribe(_ => this.RaisePropertyChanged(EffectiveSelectedItemTemplateProperty, null!, this.EffectiveSelectedItemTemplate));
-        this.GetObservable(ItemTemplateProperty)
-            .Subscribe(_ => this.RaisePropertyChanged(EffectiveSelectedItemTemplateProperty, null!, this.EffectiveSelectedItemTemplate));
+        this.GetObservable(SelectedItemTemplateProperty).Subscribe(_ => this.RaiseDirectPropertyChanged(EffectiveSelectedItemTemplateProperty));
+        this.GetObservable(ItemTemplateProperty).Subscribe(_ => this.RaiseDirectPropertyChanged(EffectiveSelectedItemTemplateProperty));
     }
 
     public ITemplate<Panel>? SelectedItemsPanel
@@ -228,6 +226,12 @@ public class MultiComboBox : SelectingItemsControl
     };
 
     public IDataTemplate? EffectiveSelectedItemTemplate => this.SelectedItemTemplate ?? this.ItemTemplate;
+
+    private void RaiseDirectPropertyChanged<T>(DirectPropertyBase<T> property)
+    {
+        T val = this.GetValue(property);
+        this.RaisePropertyChanged(property, default!, val);
+    }
 
     private MultiComboBoxItem? GetMultiComboBoxItemContainer(object? item)
     {

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -128,6 +128,10 @@ public class MultiComboBox : SelectingItemsControl
             this.RaisePropertyChanged(ScrollbarVisibilityProperty, default, this.ScrollbarVisibility);
             this.RaisePropertyChanged(EffectiveSelectedItemsPanelProperty, null!, this.EffectiveSelectedItemsPanel);
         });
+        this.GetObservable(SelectedItemTemplateProperty)
+            .Subscribe(_ => this.RaisePropertyChanged(EffectiveSelectedItemTemplateProperty, null!, this.EffectiveSelectedItemTemplate));
+        this.GetObservable(ItemTemplateProperty)
+            .Subscribe(_ => this.RaisePropertyChanged(EffectiveSelectedItemTemplateProperty, null!, this.EffectiveSelectedItemTemplate));
     }
 
     public ITemplate<Panel>? SelectedItemsPanel

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml
@@ -39,6 +39,7 @@
           </Border.Transitions>
           <CheckBox
             Content="{TemplateBinding Content}"
+            ContentTemplate="{TemplateBinding ContentTemplate}"
             IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
             HorizontalAlignment="Stretch"
             HorizontalContentAlignment="Stretch"
@@ -97,6 +98,7 @@
           </Border.Transitions>
           <CheckBox
             Content="{TemplateBinding Content}"
+            ContentTemplate="{TemplateBinding ContentTemplate}"
             IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
             HorizontalAlignment="Stretch"
             HorizontalContentAlignment="Stretch"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBoxItem.axaml
@@ -45,6 +45,7 @@
 
             <CheckBox
               Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
               IsTabStop="False"
               Focusable="False"
               Margin="0"
@@ -131,6 +132,7 @@
 
             <CheckBox
               Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
               IsThreeState="True"
               IsTabStop="False"
               Focusable="False"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
@@ -32,6 +32,7 @@
 
           <CheckBox
             Content="{TemplateBinding Content}"
+            ContentTemplate="{TemplateBinding ContentTemplate}"
             IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
             Margin="4 0 6 0"
             IsTabStop="False"
@@ -95,6 +96,7 @@
 
           <CheckBox
             Content="{TemplateBinding Content}"
+            ContentTemplate="{TemplateBinding ContentTemplate}"
             IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
             Margin="4 0 6 0"
             Padding="0"


### PR DESCRIPTION
`ItemTemplate` is a regular functionnality of `ItemsControl`, but I didn't support it correctly in the original implementation of `MultiComboBox` due to forgetting to bind the `ContentTemplate` properly on the `ContentPresenter` of the items.
I also added a little bit of logic to use the `ItemTemplate` in the SelectedItem's template when a specific `SelectedItemTemplate` is not provided, so that by default, if you specify an `ItemTemplate`, the `ClosableTag`s will display the same template as the items unless overriden.

<img width="164" height="168" alt="image" src="https://github.com/user-attachments/assets/0c9ed7be-550d-4d5e-9835-1607e2a00fd6" />
