### PR TITLE
[MacOS] Fix CheckBox :disabled:checked states & add :pressed state styling

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -64,7 +64,9 @@
                     Data="{DynamicResource CheckMarkPath}"
                     FlowDirection="LeftToRight"
                     Stretch="Fill"
-                    Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
+                    Fill="{WindowActiveBindingToggler 
+                        {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, ControlForegroundAccentHighBrush, ForegroundLowBrush}, 
+                        {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, ControlForegroundAccentInactiveHighBrush, ForegroundLowBrush}}" />
 
                   <Rectangle
                     Name="IndeterminateMark"
@@ -74,7 +76,9 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Stretch="Uniform"
-                    Fill="{WindowActiveResourceToggler ControlForegroundAccentHighBrush, ControlForegroundAccentInactiveHighBrush}" />
+                    Fill="{WindowActiveBindingToggler 
+                        {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, ControlForegroundAccentHighBrush, ForegroundLowBrush}, 
+                        {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, ControlForegroundAccentInactiveHighBrush, ForegroundLowBrush}}" />
                 </Panel>
               </Border>
             </Border>
@@ -150,7 +154,7 @@
         </Style>
         <Style Selector="^/template/ Path#CheckMark">
           <Setter Property="IsVisible" Value="True" />
-          <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+          <!-- Fill is handled within the template since the WindowActive toggler will always override styles -->
         </Style>
       </Style>
       <Style Selector="^:indeterminate">
@@ -159,7 +163,7 @@
         </Style>
         <Style Selector="^/template/ Rectangle#IndeterminateMark">
           <Setter Property="IsVisible" Value="True" />
-          <Setter Property="Fill" Value="{DynamicResource ForegroundLowBrush}" />
+          <!-- Fill is handled within the template since the WindowActive toggler will always override styles -->
         </Style>
       </Style>
     </Style>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -124,6 +124,16 @@
       </Style>
     </Style>
 
+    <!--  Pressed State  -->
+    <Style Selector="^:pressed">
+      <Style Selector="^ /template/ Border#ControlBorder">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxPressedBackgroundBrush}" />
+      </Style>
+      <Style Selector="^:checked /template/ Border#ControlBorder">
+        <Setter Property="Background" Value="{DynamicResource CheckBoxPressedCheckedBackgroundBrush}" />
+      </Style>
+    </Style>
+
     <!--  Disabled State  -->
     <Style Selector="^:disabled">
       <Setter Property="Background" Value="{DynamicResource ControlBackgroundDisabledHighBrush}" />


### PR DESCRIPTION
Just realized that the styling of a checked and disabled CheckBox broke way back when I added colour changes on Window-inactive ... 
Also, I never implemented the subtle mouseDown feedback on CheckBoxes. 

This fixes both.