### PR TITLE
[MacOS] Remove redundant code

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
@@ -157,17 +157,6 @@
       </Style>
     </Style>
 
-    <Style Selector="^:focus-visible">
-      <Style Selector="^">
-        <Setter Property="Tag" Value="True" />
-      </Style>
-    </Style>
-    <Style Selector="^:not(:focus-visible)">
-      <Style Selector="^">
-        <Setter Property="Tag" Value="False" />
-      </Style>
-    </Style>
-
     <Style Selector="^[Tag=expanded]">
       <Style Selector="^ /template/ Path#ExpandCollapseChevron">
         <Style.Animations>


### PR DESCRIPTION
Just a little leftover from failed attempts to pass the keyboard focus from the Button to the parent control ...