### PR TITLE
[MacOS] Fix BoxShadows

### DIFF
--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -20,21 +20,28 @@
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4 much longer</ComboBoxItem>
         </ComboBox>
-        <EditableComboBox Grid.Column="4">
+        <MultiComboBox Grid.Column="4" Watermark="select...">
+          <MultiComboBoxItem IsSelected="True">Item 1</MultiComboBoxItem>
+          <MultiComboBoxItem IsEnabled="False">Item 2</MultiComboBoxItem>
+          <MultiComboBoxItem IsEnabled="False" IsSelected="True">Item 3</MultiComboBoxItem>
+          <MultiComboBoxItem>Item 4</MultiComboBoxItem>
+          <MultiComboBoxItem>Item 5</MultiComboBoxItem>
+        </MultiComboBox>
+        <EditableComboBox Grid.Column="5">
           <EditableComboBoxItem Value="Option 1" />
           <EditableComboBoxItem Value="Option 2" />
           <EditableComboBoxItem Value="Option 3" />
         </EditableComboBox>
-        <AutoCompleteBox Grid.Column="5" x:Name="Animals" FilterMode="Contains" Watermark="AutoComplete" />
-        <NumericUpDown Grid.Column="6" Value="0"
+        <AutoCompleteBox Grid.Column="6" x:Name="Animals" FilterMode="Contains" Watermark="AutoComplete" />
+        <NumericUpDown Grid.Column="7" Value="0"
                        Increment="1"
                        Watermark="mm" />
-        <CalendarDatePicker Grid.Column="7" />
-        <Button Grid.Column="8" Content="Button" />
-        <CheckBox Grid.Column="9" Content="Checkbox" IsChecked="True" />
-        <RadioButton Grid.Column="10" Content="RadioButton" IsChecked="True" />
+        <CalendarDatePicker Grid.Column="8" />
+        <Button Grid.Column="9" Content="Button" />
+        <CheckBox Grid.Column="10" Content="Checkbox" IsChecked="True" />
+        <RadioButton Grid.Column="11" Content="RadioButton" IsChecked="True" />
         <!-- Force larger container height to test if controls are affected (they shouldn't be) -->
-        <TextBlock Grid.Column="11" Text="🙂" FontSize="45" />
+        <TextBlock Grid.Column="12" Text="🙂" FontSize="45" />
       </Grid>
 
       <Grid RowDefinitions="*, *, *, *, *, *, *, *, *, *, *, *"
@@ -50,19 +57,26 @@
           <ComboBoxItem>Option 3</ComboBoxItem>
           <ComboBoxItem>Option 4</ComboBoxItem>
         </ComboBox>
-        <EditableComboBox Grid.Row="5">
+        <MultiComboBox Grid.Row="5" Watermark="select...">
+          <MultiComboBoxItem IsSelected="True">Item 1</MultiComboBoxItem>
+          <MultiComboBoxItem IsEnabled="False">Item 2</MultiComboBoxItem>
+          <MultiComboBoxItem IsEnabled="False" IsSelected="True">Item 3</MultiComboBoxItem>
+          <MultiComboBoxItem>Item 4</MultiComboBoxItem>
+          <MultiComboBoxItem>Item 5</MultiComboBoxItem>
+        </MultiComboBox>
+        <EditableComboBox Grid.Row="6">
           <EditableComboBoxItem Value="test1" />
           <EditableComboBoxItem Value="test2" />
           <EditableComboBoxItem Value="test3" />
         </EditableComboBox>
-        <AutoCompleteBox Grid.Row="6" x:Name="Animals2" FilterMode="Contains" Watermark="AutoComplete" />
-        <NumericUpDown Grid.Row="7" Value="0"
+        <AutoCompleteBox Grid.Row="7" x:Name="Animals2" FilterMode="Contains" Watermark="AutoComplete" />
+        <NumericUpDown Grid.Row="8" Value="0"
                        Increment="1"
                        Watermark="mm" />
-        <CalendarDatePicker Grid.Row="8" />
-        <Button Grid.Row="9" Content="Button" />
-        <CheckBox Grid.Row="10" Content="Checkbox" IsChecked="True" />
-        <RadioButton Grid.Row="11" Content="RadioButton" IsChecked="True" />
+        <CalendarDatePicker Grid.Row="9" />
+        <Button Grid.Row="10" Content="Button" />
+        <CheckBox Grid.Row="11" Content="Checkbox" IsChecked="True" />
+        <RadioButton Grid.Row="12" Content="RadioButton" IsChecked="True" />
       </Grid>
 
       <TextBlock Classes="h1" Text="StackPanels" Margin="0 20 0 0 " />
@@ -77,6 +91,13 @@
             <ComboBoxItem>Option 3</ComboBoxItem>
             <ComboBoxItem>Option 4</ComboBoxItem>
           </ComboBox>
+          <MultiComboBox Watermark="select...">
+            <MultiComboBoxItem IsSelected="True">Item 1</MultiComboBoxItem>
+            <MultiComboBoxItem IsEnabled="False">Item 2</MultiComboBoxItem>
+            <MultiComboBoxItem IsEnabled="False" IsSelected="True">Item 3</MultiComboBoxItem>
+            <MultiComboBoxItem>Item 4</MultiComboBoxItem>
+            <MultiComboBoxItem>Item 5</MultiComboBoxItem>
+          </MultiComboBox>
           <EditableComboBox IsEnabled="False">
             <EditableComboBoxItem Value="test1" />
             <EditableComboBoxItem Value="test2" />
@@ -102,6 +123,13 @@
             <ComboBoxItem>Option 3</ComboBoxItem>
             <ComboBoxItem>Option 4</ComboBoxItem>
           </ComboBox>
+          <MultiComboBox Watermark="select...">
+            <MultiComboBoxItem IsSelected="True">Item 1</MultiComboBoxItem>
+            <MultiComboBoxItem IsEnabled="False">Item 2</MultiComboBoxItem>
+            <MultiComboBoxItem IsEnabled="False" IsSelected="True">Item 3</MultiComboBoxItem>
+            <MultiComboBoxItem>Item 4</MultiComboBoxItem>
+            <MultiComboBoxItem>Item 5</MultiComboBoxItem>
+          </MultiComboBox>
           <EditableComboBox>
             <EditableComboBoxItem Value="test1" />
             <EditableComboBoxItem Value="test2" />

--- a/samples/SampleApp/DemoPages/ControlAlignment.axaml
+++ b/samples/SampleApp/DemoPages/ControlAlignment.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:sampleApp="clr-namespace:SampleApp"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SampleApp.DemoPages.ControlAlignment">
 
@@ -13,7 +14,14 @@
             Margin="10 0">
         <TextBlock Grid.Column="0">TextBlock</TextBlock>
         <TextBox Grid.Column="1" Watermark="TextBox" />
-        <TextBox Grid.Column="2" Height="22" MinHeight="22" MaxHeight="22">thin</TextBox>
+        <TextBox Grid.Column="2"
+                 Height="22" MinHeight="22" MaxHeight="22"
+                 IsVisible="{Binding Source={x:Static sampleApp:App.CurrentTheme}, 
+                       Path=Name,
+                       Converter={StaticResource EqualToComparisonConverter},
+                       ConverterParameter=Windows - DevExpress}">
+          thin
+        </TextBox>
         <ComboBox Grid.Column="3" SelectedIndex="2">
           <ComboBoxItem>Option 1</ComboBoxItem>
           <ComboBoxItem>Option 2</ComboBoxItem>
@@ -44,7 +52,7 @@
         <TextBlock Grid.Column="12" Text="🙂" FontSize="45" />
       </Grid>
 
-      <Grid RowDefinitions="*, *, *, *, *, *, *, *, *, *, *, *"
+      <Grid RowDefinitions="*, *, *, *, *, *, *, *, *, *, *, *, *"
             RowSpacing="5"
             Width="150"
             HorizontalAlignment="Left"
@@ -84,7 +92,13 @@
         <StackPanel Orientation="Horizontal" Margin="10 0" Spacing="10" VerticalAlignment="Top">
           <TextBlock>TextBlock</TextBlock>
           <TextBox Watermark="TextBox" />
-          <TextBox Height="22" MinHeight="22" MaxHeight="22">thin</TextBox>
+          <TextBox Height="22" MinHeight="22" MaxHeight="22"
+                   IsVisible="{Binding Source={x:Static sampleApp:App.CurrentTheme}, 
+                       Path=Name,
+                       Converter={StaticResource EqualToComparisonConverter},
+                       ConverterParameter=Windows - DevExpress}">
+            thin
+          </TextBox>
           <ComboBox SelectedIndex="2" IsEnabled="False">
             <ComboBoxItem>Option 1</ComboBoxItem>
             <ComboBoxItem>Option 2</ComboBoxItem>

--- a/samples/SampleApp/DemoPages/TextBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/TextBoxDemo.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:SampleApp.ViewModels"
+             xmlns:sampleApp="clr-namespace:SampleApp"
              x:DataType="vm:TextBoxViewModel"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="700"
              x:Class="SampleApp.DemoPages.TextBoxDemo">
@@ -42,7 +43,13 @@
           <Label>Error Indicator:</Label>
           <TextBox Watermark="Required Input" Text="{Binding RequiredInput}" />
 
-          <TextBox Height="22" MinHeight="22" MaxHeight="22">thin</TextBox>
+          <TextBox Height="22" MinHeight="22" MaxHeight="22"
+                   IsVisible="{Binding Source={x:Static sampleApp:App.CurrentTheme}, 
+                       Path=Name,
+                       Converter={StaticResource EqualToComparisonConverter},
+                       ConverterParameter=Windows - DevExpress}">
+            thin
+          </TextBox>
         </StackPanel>
       </StackPanel>
     </Border>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -71,6 +71,7 @@
 
       <BoxShadows x:Key="TextBoxBorderShadows">0 0.5 2.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
       <BoxShadows x:Key="ControlBorderBoxShadow">0 1 1.5 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
+      <BoxShadows x:Key="ButtonBorderBoxShadow">0 0.5 1 0 #4d000000, 0 0 0 0.5 #03000000</BoxShadows>
       <BoxShadows x:Key="ComboBoxDisabledBoxShadow">0 1 1.5 0 #26000000, 0 0 0 0.5 #08000000</BoxShadows>
       <BoxShadows x:Key="ToolTipBorderShadow">0 0 1 0 #66000000, 0 7 17 0 #30000000</BoxShadows>
       <Thickness x:Key="ButtonBorderThickness">0.6 0.6 0.6 1</Thickness>
@@ -315,7 +316,7 @@
   <SolidColorBrush x:Key="DefaultIconFillBrush" Color="{DynamicResource DefaultIconColor}" />
 
   <!-- Button Resources (& button-like parts of other controls) -->
-  <Thickness x:Key="ButtonPadding">10 1.4 10 2.6</Thickness>
+  <Thickness x:Key="ButtonPadding">10 0</Thickness>
   <FontWeight x:Key="ButtonFontWeight">400</FontWeight>
   <SolidColorBrush x:Key="ButtonBorderAccentBrush" Color="{DynamicResource ControlBorderAccentColor}" />
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -26,7 +26,7 @@
     <Setter Property="Background" Value="{DynamicResource ControlBackgroundHighBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ControlBorderRaisedBrush}" />
-    <Setter Property="BorderThickness" Value="{DynamicResource ButtonBorderThickness}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource ControlBorderThickness}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     <Setter Property="Padding" Value="{DynamicResource ButtonPadding}" />
     <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -41,9 +41,11 @@
         <Panel Name="ReservedSpaceForFocus"
                Margin="{StaticResource InputControlsSpaceForFocusBorder}">
           <Border Name="BackgroundElement"
+                  MinHeight="21"
                   Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
+                  BoxShadow="{DynamicResource ButtonBorderBoxShadow}"
                   CornerRadius="{TemplateBinding CornerRadius}" />
           <ContentPresenter Name="PART_ContentPresenter"
                             Content="{TemplateBinding Content}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -153,7 +153,6 @@
                 Margin="{TemplateBinding Padding}"
                 Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-
                 IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}"
                 Text="{TemplateBinding PlaceholderText}" />
               <ContentControl
@@ -174,7 +173,6 @@
                 ClickMode="Press"
                 Focusable="False"
                 IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}" />
-
             </Grid>
           </Border>
           <Border Name="FocusBorderElement"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -75,7 +75,7 @@
           <Border
             Name="border"
             Background="{TemplateBinding Background}"
-            BorderThickness="{DynamicResource ButtonBorderThickness}"
+            BorderThickness="{DynamicResource ControlBorderThickness}"
             BorderBrush="{DynamicResource ControlBorderRaisedBrush}"
             BoxShadow="{DynamicResource ControlBorderBoxShadow}"
             MinHeight="{TemplateBinding MinHeight}"


### PR DESCRIPTION
Some of the BoxShadows were broken at some point by applying mixed BorderThickness (limitation in Avalonia, that BoxShadow renders only with uniform BorderThickness)