### PR TITLE
[All themes] Fix (Editable)ComboBox keyboard nav focus

### DIFF
--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -589,8 +589,6 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
             this.realizedItems[GetSourceKey(item)] = realized;
         }
 
-        this.SyncCommittedSelectionState();
-
         this.RefreshContainers();
 
         if (filter && this.Mode == EditableComboBoxMode.Filter)
@@ -609,6 +607,8 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
             //        - sbergerondrouin 2025-05-09
             this.filteredItems.AddRange(this.realizedItems.Values.Select(static i => i.Clone()));
         }
+
+        this.SyncCommittedSelectionState();
     }
 
     private void FilterItems()

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -323,6 +323,8 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
             this.Value = this.realizedItems.TryGetValue(GetSourceKey(newSelectedItem), out EditableComboBoxItem? found)
                 ? found.Value
                 : null;
+
+            this.SyncCommittedSelectionState();
         }
     }
 
@@ -384,6 +386,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         try
         {
             this.SelectedItem = source.OriginalSourceItem;
+            this.SyncCommittedSelectionState();
         }
         finally
         {
@@ -586,6 +589,8 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
             this.realizedItems[GetSourceKey(item)] = realized;
         }
 
+        this.SyncCommittedSelectionState();
+
         this.RefreshContainers();
 
         if (filter && this.Mode == EditableComboBoxMode.Filter)
@@ -765,6 +770,8 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
             {
                 this.SelectedItem = null;
             }
+
+            this.SyncCommittedSelectionState();
         }
         finally
         {
@@ -807,6 +814,21 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         {
             this.DataContext = item;
             return this.Result;
+        }
+    }
+
+    private void SyncCommittedSelectionState()
+    {
+        object selectedKey = GetSourceKey(this.SelectedItem);
+
+        foreach (EditableComboBoxItem realizedItem in this.realizedItems.Values)
+        {
+            realizedItem.IsCommittedSelected = Equals(GetSourceKey(realizedItem.OriginalSourceItem), selectedKey);
+        }
+
+        foreach (EditableComboBoxItem filteredItem in this.filteredItems.OfType<EditableComboBoxItem>())
+        {
+            filteredItem.IsCommittedSelected = Equals(GetSourceKey(filteredItem.OriginalSourceItem), selectedKey);
         }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
@@ -22,6 +22,9 @@ public class EditableComboBoxItem : TemplatedControl, ISelectable
 
     public static readonly StyledProperty<bool> IsSelectedProperty = SelectingItemsControl.IsSelectedProperty.AddOwner<EditableComboBoxItem>();
 
+    public static readonly StyledProperty<bool> IsCommittedSelectedProperty =
+        AvaloniaProperty.Register<EditableComboBoxItem, bool>(nameof(IsCommittedSelected));
+
     public static readonly StyledProperty<string> ValueProperty =
         AvaloniaProperty.Register<EditableComboBoxItem, string>(nameof(Value), defaultBindingMode: BindingMode.OneTime);
 
@@ -58,6 +61,12 @@ public class EditableComboBoxItem : TemplatedControl, ISelectable
         set => this.SetValue(IsSelectedProperty, value);
     }
 
+    public bool IsCommittedSelected
+    {
+        get => this.GetValue(IsCommittedSelectedProperty);
+        set => this.SetValue(IsCommittedSelectedProperty, value);
+    }
+
     [Content]
     public required string Value
     {
@@ -74,6 +83,7 @@ public class EditableComboBoxItem : TemplatedControl, ISelectable
             Value = this.Value,
             OriginalSourceItem = this.OriginalSourceItem,
             DataContext = this.DataContext,
+            IsCommittedSelected = this.IsCommittedSelected,
         };
 
         if (this.IsSet(ContentTemplateProperty))

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
@@ -1,0 +1,196 @@
+namespace Devolutions.AvaloniaTheme.DevExpress.Behaviors;
+
+using System.Reactive.Disposables;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+internal static class ComboBoxItemFocusTrackerBehavior
+{
+    public static readonly AttachedProperty<bool> EnableProperty =
+        AvaloniaProperty.RegisterAttached<ComboBoxItem, bool>("Enable", typeof(ComboBoxItemFocusTrackerBehavior));
+
+    public static readonly AttachedProperty<bool> HasTransientComboBoxItemHighlightProperty =
+        AvaloniaProperty.RegisterAttached<ItemsPresenter, bool>("HasTransientComboBoxItemHighlight", typeof(ComboBoxItemFocusTrackerBehavior));
+
+    private static readonly ConditionalWeakTable<ComboBoxItem, ItemState> itemStates = new();
+    private static readonly ConditionalWeakTable<ItemsPresenter, PresenterState> presenterStates = new();
+
+    static ComboBoxItemFocusTrackerBehavior()
+    {
+        EnableProperty.Changed.Subscribe(args =>
+        {
+            if (args.Sender is not ComboBoxItem item)
+            {
+                return;
+            }
+
+            bool enable = args.NewValue.GetValueOrDefault<bool>();
+            if (enable)
+            {
+                Enable(item);
+            }
+            else
+            {
+                Disable(item);
+            }
+        });
+    }
+
+    public static void SetEnable(ComboBoxItem element, bool value) => element.SetValue(EnableProperty, value);
+
+    public static bool GetEnable(ComboBoxItem element) => element.GetValue(EnableProperty);
+
+    public static void SetHasTransientComboBoxItemHighlight(ItemsPresenter element, bool value) => element.SetValue(HasTransientComboBoxItemHighlightProperty, value);
+
+    public static bool GetHasTransientComboBoxItemHighlight(ItemsPresenter element) => element.GetValue(HasTransientComboBoxItemHighlightProperty);
+
+    private static void Enable(ComboBoxItem item)
+    {
+        if (itemStates.TryGetValue(item, out _))
+        {
+            return;
+        }
+
+        var state = new ItemState();
+
+        void ScheduleUpdate() => Dispatcher.UIThread.Post(() => UpdateOwningItemsPresenter(item, state), DispatcherPriority.Background);
+
+        EventHandler<GotFocusEventArgs> gotFocusHandler = (_, _) => ScheduleUpdate();
+        EventHandler<RoutedEventArgs> lostFocusHandler = (_, _) => ScheduleUpdate();
+        EventHandler<PointerEventArgs> pointerEnteredHandler = (_, _) => ScheduleUpdate();
+        EventHandler<PointerEventArgs> pointerExitedHandler = (_, _) => ScheduleUpdate();
+        EventHandler<VisualTreeAttachmentEventArgs> attachedHandler = (_, _) => ScheduleUpdate();
+        EventHandler<VisualTreeAttachmentEventArgs> detachedHandler = (_, _) => ScheduleUpdate();
+
+        item.GotFocus += gotFocusHandler;
+        item.LostFocus += lostFocusHandler;
+        item.PointerEntered += pointerEnteredHandler;
+        item.PointerExited += pointerExitedHandler;
+        item.AttachedToVisualTree += attachedHandler;
+        item.DetachedFromVisualTree += detachedHandler;
+
+        state.Disposables.Add(Disposable.Create(() =>
+        {
+            item.GotFocus -= gotFocusHandler;
+            item.LostFocus -= lostFocusHandler;
+            item.PointerEntered -= pointerEnteredHandler;
+            item.PointerExited -= pointerExitedHandler;
+            item.AttachedToVisualTree -= attachedHandler;
+            item.DetachedFromVisualTree -= detachedHandler;
+        }));
+
+        var focusWithinSubscription = item
+            .GetObservable(InputElement.IsKeyboardFocusWithinProperty)
+            .Subscribe(_ => ScheduleUpdate());
+        state.Disposables.Add(focusWithinSubscription);
+
+        itemStates.Add(item, state);
+
+        ScheduleUpdate();
+    }
+
+    private static void Disable(ComboBoxItem item)
+    {
+        if (!itemStates.TryGetValue(item, out ItemState? state))
+        {
+            return;
+        }
+
+        itemStates.Remove(item);
+        state.Disposables.Dispose();
+
+        ApplyItemSnapshot(state, presenter: null, isPointerOver: false, isFocusVisible: false);
+    }
+
+    private static void UpdateOwningItemsPresenter(ComboBoxItem sourceItem, ItemState state)
+    {
+        ItemsPresenter? itemsPresenter = sourceItem.FindAncestorOfType<ItemsPresenter>();
+        bool isPointerOver = sourceItem.IsPointerOver;
+        bool isFocusVisible = ((IPseudoClasses)sourceItem.Classes).Contains(":focus-visible");
+
+        ApplyItemSnapshot(state, itemsPresenter, isPointerOver, isFocusVisible);
+    }
+
+    private static void ApplyItemSnapshot(ItemState state, ItemsPresenter? presenter, bool isPointerOver, bool isFocusVisible)
+    {
+        ItemsPresenter? oldPresenter = state.Presenter;
+
+        if (oldPresenter is not null)
+        {
+            PresenterState oldPresenterState = presenterStates.GetOrCreateValue(oldPresenter);
+            if (state.IsPointerOver)
+            {
+                oldPresenterState.PointerOverCount = Math.Max(0, oldPresenterState.PointerOverCount - 1);
+            }
+
+            if (state.IsFocusVisible)
+            {
+                oldPresenterState.FocusVisibleCount = Math.Max(0, oldPresenterState.FocusVisibleCount - 1);
+            }
+        }
+
+        if (presenter is not null)
+        {
+            PresenterState presenterState = presenterStates.GetOrCreateValue(presenter);
+            if (isPointerOver)
+            {
+                presenterState.PointerOverCount += 1;
+            }
+
+            if (isFocusVisible)
+            {
+                presenterState.FocusVisibleCount += 1;
+            }
+        }
+
+        state.Presenter = presenter;
+        state.IsPointerOver = isPointerOver;
+        state.IsFocusVisible = isFocusVisible;
+
+        if (oldPresenter is not null)
+        {
+            UpdatePresenterFlags(oldPresenter);
+        }
+
+        if (presenter is not null && !ReferenceEquals(presenter, oldPresenter))
+        {
+            UpdatePresenterFlags(presenter);
+        }
+    }
+
+    private static void UpdatePresenterFlags(ItemsPresenter presenter)
+    {
+        PresenterState state = presenterStates.GetOrCreateValue(presenter);
+        bool hasTransientHighlight = state.FocusVisibleCount > 0 || state.PointerOverCount > 0;
+
+        if (presenter.GetValue(HasTransientComboBoxItemHighlightProperty) != hasTransientHighlight)
+        {
+            presenter.SetValue(HasTransientComboBoxItemHighlightProperty, hasTransientHighlight);
+        }
+    }
+
+    private sealed class ItemState
+    {
+        public CompositeDisposable Disposables { get; } = new();
+
+        public ItemsPresenter? Presenter { get; set; }
+
+        public bool IsPointerOver { get; set; }
+
+        public bool IsFocusVisible { get; set; }
+    }
+
+    private sealed class PresenterState
+    {
+        public int PointerOverCount { get; set; }
+
+        public int FocusVisibleCount { get; set; }
+    }
+}

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
@@ -62,18 +62,36 @@ internal static class ComboBoxItemFocusTrackerBehavior
 
         void ScheduleUpdate()
         {
-            if (state.IsUpdatePending)
+            if (state.IsDisposed)
             {
                 return;
             }
 
+            if (state.IsUpdatePending)
+            {
+                state.IsUpdateDirty = true;
+                return;
+            }
+
             state.IsUpdatePending = true;
+            state.IsUpdateDirty = false;
 
             Dispatcher.UIThread.Post(() =>
             {
                 try
                 {
-                    UpdateOwningItemsPresenter(item, state);
+                    do
+                    {
+                        state.IsUpdateDirty = false;
+
+                        if (state.IsDisposed)
+                        {
+                            break;
+                        }
+
+                        UpdateOwningItemsPresenter(item, state);
+                    }
+                    while (state.IsUpdateDirty);
                 }
                 finally
                 {
@@ -124,6 +142,7 @@ internal static class ComboBoxItemFocusTrackerBehavior
         }
 
         itemStates.Remove(item);
+        state.IsDisposed = true;
         state.Disposables.Dispose();
 
         ApplyItemSnapshot(state, presenter: null, isPointerOver: false, isFocusVisible: false);
@@ -201,6 +220,10 @@ internal static class ComboBoxItemFocusTrackerBehavior
         public CompositeDisposable Disposables { get; } = new();
 
         public bool IsUpdatePending { get; set; }
+
+        public bool IsUpdateDirty { get; set; }
+
+        public bool IsDisposed { get; set; }
 
         public ItemsPresenter? Presenter { get; set; }
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/ComboBoxItemFocusTrackerBehavior.cs
@@ -60,7 +60,27 @@ internal static class ComboBoxItemFocusTrackerBehavior
 
         var state = new ItemState();
 
-        void ScheduleUpdate() => Dispatcher.UIThread.Post(() => UpdateOwningItemsPresenter(item, state), DispatcherPriority.Background);
+        void ScheduleUpdate()
+        {
+            if (state.IsUpdatePending)
+            {
+                return;
+            }
+
+            state.IsUpdatePending = true;
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                try
+                {
+                    UpdateOwningItemsPresenter(item, state);
+                }
+                finally
+                {
+                    state.IsUpdatePending = false;
+                }
+            }, DispatcherPriority.Background);
+        }
 
         EventHandler<GotFocusEventArgs> gotFocusHandler = (_, _) => ScheduleUpdate();
         EventHandler<RoutedEventArgs> lostFocusHandler = (_, _) => ScheduleUpdate();
@@ -179,6 +199,8 @@ internal static class ComboBoxItemFocusTrackerBehavior
     private sealed class ItemState
     {
         public CompositeDisposable Disposables { get; } = new();
+
+        public bool IsUpdatePending { get; set; }
 
         public ItemsPresenter? Presenter { get; set; }
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBoxItem.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:behaviors="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Behaviors"
   xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.DevExpress.Design">
 
   <!-- 
@@ -25,6 +26,8 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="behaviors:ComboBoxItemFocusTrackerBehavior.Enable" Value="True" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
@@ -70,7 +73,7 @@
         <Setter
           Property="Background"
           Value="{BindingToggler
-                  {Binding IsPointerOver, RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
+                  {Binding (behaviors:ComboBoxItemFocusTrackerBehavior.HasTransientComboBoxItemHighlight), RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
                   {DynamicResource ComboBoxItemBackgroundBrush},
                   {DynamicResource ControlBackgroundSelectedBrush}
                }" />
@@ -82,7 +85,7 @@
         <Setter
           Property="Background"
           Value="{BindingToggler
-                  {Binding IsPointerOver, RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
+                  {Binding (behaviors:ComboBoxItemFocusTrackerBehavior.HasTransientComboBoxItemHighlight), RelativeSource={RelativeSource AncestorType=ItemsPresenter}},
                   {DynamicResource TransparentBrush},
                   {DynamicResource ControlBorderSelectedBrush}
                }" />
@@ -90,7 +93,7 @@
     </Style>
 
     <!--  PointerOver state  -->
-    <Style Selector="^:pointerover">
+    <Style Selector="^:pointerover, ^:focus-visible">
       <Style Selector="^ /template/ Border#LayoutRoot">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
         <Style Selector="^ ContentPresenter#PART_ContentPresenter">

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBoxItem.axaml
@@ -31,6 +31,7 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForeground}" />
     <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackground}" />
     <Setter Property="Padding" Value="12 0 8 0" />
@@ -53,7 +54,7 @@
     </Setter>
 
     <!--  PointerOver state  -->
-    <Style Selector="^:pointerover /template/ ContentPresenter">
+    <Style Selector="^:pointerover /template/ ContentPresenter, ^:focus-visible /template/ ContentPresenter">
       <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
       <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
       <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundPointerOver}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBoxItem.axaml
@@ -23,6 +23,7 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ComboBoxItem}" TargetType="ComboBoxItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -63,6 +64,16 @@
     <Style Selector="^:selected /template/ Path#CheckMark">
       <Setter Property="Fill" Value="{DynamicResource ForegroundHighBrush}" />
     </Style>
+
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#RootPanel">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+      </Style>
+    </Style>
+
     <Style Selector="^:pointerover">
       <Style Selector="^ /template/ Border#RootPanel">
         <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -93,7 +93,15 @@
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />
     <Setter Property="ContentTemplate">
       <DataTemplate>
-        <SearchHighlightTextBlock />
+        <SearchHighlightTextBlock
+          Foreground="{BindingToggler
+                        {Binding $parent[EditableComboBoxItem].IsPointerOver},
+                        {DynamicResource ControlForegroundAccentHighBrush},
+                        {DynamicResource ForegroundHighBrush}}"
+          HighlightForeground="{BindingToggler
+                                {Binding $parent[EditableComboBoxItem].IsPointerOver},
+                                {DynamicResource ControlForegroundAccentHighBrush},
+                                {DynamicResource ForegroundHighBrush}}" />
       </DataTemplate>
     </Setter>
     <Setter Property="Template">
@@ -132,29 +140,17 @@
       <Style Selector="^ /template/ Border#PART_Background">
         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
       </Style>
-      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
-      </Style>
     </Style>
 
     <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#PART_Background">
         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
       </Style>
-      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
-      </Style>
     </Style>
 
     <Style Selector="^[IsSelected=True]">
       <Style Selector="^ /template/ Border#PART_Background">
         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
-      </Style>
-      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
-        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
-        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
       </Style>
     </Style>
 
@@ -165,9 +161,8 @@
       <Style Selector="^[IsCommittedSelected=True] /template/ Path#CheckMark">
         <Setter Property="Fill" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
       </Style>
-      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter SearchHighlightTextBlock">
+      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
-        <Setter Property="HighlightForeground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
       </Style>
     </Style>
   </ControlTheme>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -86,6 +86,7 @@
   <x:Double x:Key="EditableComboBoxItemsHeight">22</x:Double>
 
   <ControlTheme x:Key="{x:Type EditableComboBoxItem}" TargetType="EditableComboBoxItem" BasedOn="{StaticResource {x:Type EditableComboBoxItem}}">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="IsHitTestVisible" Value="True" />
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
@@ -121,12 +122,39 @@
       <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
     </Style>
 
-    <Style Selector="^[IsSelected=True]">
+    <Style Selector="^[IsCommittedSelected=True]">
       <Style Selector="^ /template/ Path#CheckMark">
         <Setter Property="Fill" Value="{DynamicResource ForegroundHighBrush}" />
       </Style>
+    </Style>
+
+    <Style Selector="^[IsCommittedSelected=True]:focus-visible">
       <Style Selector="^ /template/ Border#PART_Background">
-        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#PART_Background">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
+      </Style>
+    </Style>
+
+    <Style Selector="^[IsSelected=True]">
+      <Style Selector="^ /template/ Border#PART_Background">
+        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+      </Style>
+      <Style Selector="^ /template/ SearchHighlightTextBlock#PART_Text">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
+        <Setter Property="HighlightForeground" Value="{DynamicResource ForegroundHighBrush}" />
       </Style>
     </Style>
 
@@ -134,7 +162,7 @@
       <Style Selector="^ /template/ Border#PART_Background">
         <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
       </Style>
-      <Style Selector="^[IsSelected=True] /template/ Path#CheckMark">
+      <Style Selector="^[IsCommittedSelected=True] /template/ Path#CheckMark">
         <Setter Property="Fill" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
       </Style>
       <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter SearchHighlightTextBlock">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -136,12 +136,6 @@
       </Style>
     </Style>
 
-    <Style Selector="^[IsCommittedSelected=True]:focus-visible">
-      <Style Selector="^ /template/ Border#PART_Background">
-        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
-      </Style>
-    </Style>
-
     <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#PART_Background">
         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />


### PR DESCRIPTION
The original styling of ComboBox and EditableComboBox didn't include focus highlights for keyboard navigation - so we had various inconsistent behaviours in each of the themes. 

