### PR TITLE
[EditableComboBox] Fix inner slot interactivity and text cursor in macOS and DevExpress themes

### DIFF
--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
@@ -19,7 +19,7 @@
       </EditableComboBox>
     </StackPanel>
     <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
-      <Grid ColumnDefinitions="Auto 240" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
+      <Grid ColumnDefinitions="Auto 240 Auto" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
         <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
           <Bold>Preferred Usage Pattern: </Bold>
         </TextBlock>
@@ -153,19 +153,21 @@
           Grid.Column="1" Grid.Row="9"
           VerticalAlignment="Top"
           Mode="Filter"
-          Margin="10 0 20 20">
+          Margin="10 0 10 20">
           <EditableComboBoxItem>Option 1</EditableComboBoxItem>
 
           <EditableComboBox.InnerLeftContent>
-            <Border Width="12" Height="12" Background="Green" />
+            <Button Command="{Binding GreenCommand}"><Border Width="8" Height="8" Background="Green" /></Button>
           </EditableComboBox.InnerLeftContent>
           <EditableComboBox.InnerLeftOfDropDownArrowContent>
-            <Border Width="12" Height="12" Background="Orange" />
+            <Button Command="{Binding OrangeCommand}"><Border Width="8" Height="8" Background="Orange" /></Button>
           </EditableComboBox.InnerLeftOfDropDownArrowContent>
           <EditableComboBox.InnerRightContent>
-            <Border Width="12" Height="12" Background="Red" />
+            <Button Command="{Binding RedCommand}"><Border Width="8" Height="8" Background="Red" /></Button>
           </EditableComboBox.InnerRightContent>
         </EditableComboBox>
+        
+        <Border Grid.Column="2" Grid.Row="9" Width="12" Height="12" Margin="0 0 20 20" Background="{Binding SelectedBrush}" />
 
         <TextBlock Grid.Column="0" Grid.Row="10" VerticalAlignment="Top" Margin="0 5 10 15">
           - Required error:<LineBreak />

--- a/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
@@ -1,6 +1,7 @@
 namespace SampleApp.ViewModels;
 
 using System.ComponentModel.DataAnnotations;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -88,6 +89,27 @@ public partial class EditableComboBoxViewModel : ObservableValidator
 
     [RelayCommand]
     private void ClearCountry() => this.ProgrammaticSelectedCountry = null;
+
+    [ObservableProperty]
+    private IBrush selectedBrush = Brushes.Transparent;
+    
+    [RelayCommand]
+    private void Green()
+    {
+        this.SelectedBrush = Brushes.Green;
+    }
+
+    [RelayCommand]
+    private void Orange()
+    {
+        this.SelectedBrush = Brushes.Orange;
+    }
+
+    [RelayCommand]
+    private void Red()
+    {
+        this.SelectedBrush = Brushes.Red;
+    }
 }
 
 public record Country(string Name, string Code, bool OverrideToString = true)

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
@@ -184,7 +184,8 @@
     </Style>
   </ControlTheme>
 
-  <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}" TargetType="EditableComboBox+InnerTextBox">
+  <ControlTheme x:Key="{x:Type EditableComboBox+InnerTextBox}" TargetType="EditableComboBox+InnerTextBox"
+                BasedOn="{StaticResource  {x:Type EditableComboBox+InnerTextBox}}">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="BorderBrush" Value="Transparent" />
     <Setter Property="BorderThickness" Value="0" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -197,6 +197,7 @@
 
               <Border
                 Name="BorderHighlightElement"
+                IsHitTestVisible="False"
                 Background="Transparent"
                 BorderBrush="{DynamicResource ControlBorderRaisedBrush}"
                 BorderThickness="{TemplateBinding BorderThickness, 


### PR DESCRIPTION
## Summary

- **macOS**: Buttons (and other interactive controls) placed in `InnerLeft`, `InnerLeftOfDropDownArrow`, and `InnerRight` slots were unclickable. The `BorderHighlightElement` (a decorative raised-border overlay with `ZIndex=1` and `Background=Transparent`) was sitting on top of the inner slot Grid in a Panel, intercepting all pointer events. Fixed by adding `IsHitTestVisible="False"` to that border.
- **DevExpress**: The `InnerTextBox` ControlTheme override was missing `BasedOn`, causing it to completely replace — rather than extend — the base theme. This silently dropped the `Cursor="IBeam"` setter from the base, resulting in the arrow cursor showing over the text area instead of the text beam cursor. Fixed by adding `BasedOn="{StaticResource {x:Type EditableComboBox+InnerTextBox}}"`.
- **SampleApp**: Updated the inner slots demo to use actual `Button` controls (with commands) instead of plain `Border` elements, making it possible to visually verify click behavior.