### PR TITLE
Update Nuget/login action to v1.0.1 supporting Node 24

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -210,7 +210,7 @@ jobs:
           path: package
 
       - name: NuGet login (OIDC)
-        uses: NuGet/login@v1
+        uses: NuGet/login@v1.0.1
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_BOT_USERNAME }}


### PR DESCRIPTION
Nuget/login has been updated to support Node 24

Merged fix: https://github.com/NuGet/login/pull/22
Tagged: https://github.com/NuGet/login/actions