### PR TITLE
Revert "Update Nuget/login action to v1.0.1 supporting Node 24"

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -210,7 +210,7 @@ jobs:
           path: package
 
       - name: NuGet login (OIDC)
-        uses: NuGet/login@v1.0.1
+        uses: NuGet/login@v1
         id: nuget-login
         with:
           user: ${{ secrets.NUGET_BOT_USERNAME }}


### PR DESCRIPTION
Reverts Devolutions/avalonia-extensions#455

The change to `NuGet/login@v1.0.1` was not only unnecessary, since `v1` would automatically pick up the latest `v.1.x` - but at this specificity it might in fact prevent a potential later update to `v.1.2` or similar to be automatically used