### PR TITLE
[DevExpress] TreeDataGrid - Fix indentation of non-expandable items

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -94,6 +94,13 @@ The SampleApp provides:
     - F10 opens classic Avalonia Dev Tools
   - otherwise F12 opens classic Avalonia Dev Tools
 
+### Runtime Tab Convention (SampleApp)
+- Some tabs are inserted at runtime and are not statically present in `samples/SampleApp/MainWindow.axaml`.
+- Dynamic insertion points are marked by comments like `<!-- TabItem "..." inserted here through code-behind ... -->`.
+- Runtime tabs should be added from appropriately named methods in `samples/SampleApp/MainWindow.axaml.cs` using the `Add...Tab()` pattern (for example, `AddTreeDataGridTab()`).
+- `/worksetup` may temporarily force runtime tab selection in those methods for local development.
+- Those temporary runtime-selection lines are local-only setup state and should not be committed by default (follow `.claude/commands/commit.md`).
+
 **Note on Theme Detection:**
 The app's theme detection (`DetectDesignTheme()` in App.axaml.cs) expects the working directory to be `bin/Debug/net9.0/`. When running from the repo root via `dotnet run`, the detection fails and the app falls back to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is why building and running from the bin directory is required for proper theme detection configured via `/worksetup` command.
 

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -25,6 +25,7 @@ The `/worksetup` command modifies these files for local development only:
 - `samples/SampleApp/App.axaml` (theme selection in Application.Styles block)
 - `samples/SampleApp/MainWindow.axaml` (TabItem IsSelected attributes)
 - `samples/SampleApp/ViewModels/MainWindowViewModel.cs` (SelectedScale initialization)
+- `samples/SampleApp/MainWindow.axaml.cs` (temporary runtime tab selection in dynamic tab insertion methods like `Add...Tab()`)
 
 **Master branch defaults** (never change these):
 - Theme: All themes commented out (automatically selects platform-appropriate theme)
@@ -37,12 +38,17 @@ The `/worksetup` command modifies these files for local development only:
   ```
 - Tab: `IsSelected="True"` on Overview tab only
 - Scale: `this.SelectedScale = this.AvailableScales[0];` (System Default)
+- Runtime dynamic tabs: no temporary forced selection lines in `Add...Tab()` insertion methods unless intentionally committing feature behavior
 
 **Pre-commit workflow**:
 1. Check if App.axaml, MainWindow.axaml, or MainWindowViewModel.cs have changes
+   - Also check `MainWindow.axaml.cs` for temporary `/worksetup` runtime tab-selection lines in dynamic insertion methods (for example, `AddTreeDataGridTab()`)
 2. If they do, verify they match the master defaults above
 3. If they DON'T match defaults:
    - First, run `/worksetup Default Overview` to restore defaults (all themes commented, Overview tab, Default scale)
+   - For runtime-only dynamic tab worksetup, remove temporary selection lines in the relevant `Add...Tab()` method:
+     - `tabItem.IsSelected = true;`
+     - `tabControl.SelectedItem = tabItem;`
    - Create a commit with those restorations if needed: `[SampleApp] Restore default theme, tab, and scale`
    - Then reapply user's development settings (but don't commit them)
 4. Exclude these files from commits unless:
@@ -58,6 +64,7 @@ M samples/SampleApp/ViewModels/MainWindowViewModel.cs
 ```
 
 Check the actual diff. If changes are only theme toggles, IsSelected attributes, or SelectedScale array index, SKIP these files from the commit.
+If `MainWindow.axaml.cs` changes are only temporary runtime tab-selection lines used by `/worksetup` in dynamic insertion methods, SKIP those too.
 </worksetup_exclusion>
 
 <input_processing>

--- a/.claude/commands/worksetup.md
+++ b/.claude/commands/worksetup.md
@@ -1,12 +1,12 @@
 ---
-description: "/worksetup [theme] [tabTitle?] [scale?] [projectPlan?] - Switch theme, navigate to tab, set scale, and optionally load project plan"
+description: "/worksetup [theme] [tabTitle?] [scale?] [projectPlan?] - Switch theme, navigate to tab (including runtime-only tabs), set scale, and optionally load project plan"
 ---
 
 You are being asked to switch the active theme, navigate to a specific tab in the SampleApp, and optionally set the UI scale.
 
 The user will provide one to four arguments:
 1. **theme**: One of 'MacOS', 'MacOSClassic' (or 'Classic'), 'MacOSLiquidGlass' (or 'LiquidGlass'), 'DevExpress', 'Linux', or 'Default'
-2. **tabTitle**: (optional) The title of a TabItem (e.g., 'Button', 'TextBox', 'DataGrid', 'Control Alignment'),
+2. **tabTitle**: (optional) The title of a TabItem (e.g., 'Button', 'TextBox', 'DataGrid', 'Control Alignment', 'TreeDataGrid'), including tabs inserted dynamically at runtime
    Default: 'Overview'
 3. **scale**: (optional) UI scale percentage (e.g., '100%', '150%', '200%', '300%', '400%')
    Default: 'Default' (system default)
@@ -89,8 +89,8 @@ Target state for MacOS Classic (forced):
 
 Use the Edit tool to make these changes. Be careful to preserve exact formatting and indentation.
 
-### Step 4: Find matching TabItem in MainWindow.axaml
-File: `samples/SampleApp/MainWindow.axaml`
+### Step 4: Find matching tab target (static or runtime)
+Files: `samples/SampleApp/MainWindow.axaml`, `samples/SampleApp/MainWindow.axaml.cs`
 
 Search for TabItems with matching titles:
 - Look for `<controls:SampleItemHeader Title="..." />` elements
@@ -100,7 +100,14 @@ Search for TabItems with matching titles:
 
 If multiple matches found, prefer exact match first, then shortest match.
 
-### Step 5: Update TabItem IsSelected attributes
+Runtime-only matching rules:
+- Detect dynamic tab placeholders from comments in `MainWindow.axaml` like: `<!-- TabItem "..." inserted here through code-behind ... -->`.
+- For each detected dynamic tab, resolve its insertion method in `MainWindow.axaml.cs` (prefer `Add{TabName}Tab()`; fallback to best name match containing the tab name).
+- If the requested tab matches a dynamic tab target, use the runtime selection path (Step 5B) instead of static XAML selection.
+- Do not fail just because the tab is not statically present in `MainWindow.axaml` when a runtime path exists.
+- Example: `TreeDataGrid` may be inserted at runtime by `AddTreeDataGridTab()` and shown as `TreeDataGrid (Accelerate)`.
+
+### Step 5A: Update static TabItem IsSelected attributes
 In MainWindow.axaml:
 - Remove ALL existing `IsSelected="True"` attributes from all TabItems
 - Add `IsSelected="True"` ONLY to the matched TabItem
@@ -116,6 +123,17 @@ Example change for Button tab:
   <demoPages:ButtonDemo />
 </TabItem>
 ```
+
+Skip Step 5A when Step 4 selected a runtime-only tab target.
+
+### Step 5B: Update runtime tab selection in code-behind
+File: `samples/SampleApp/MainWindow.axaml.cs`
+
+For runtime-only tab selection, update the resolved dynamic tab insertion method (for example, `AddTreeDataGridTab()`):
+- Ensure the inserted tab is selected at runtime by setting:
+  - `tabItem.IsSelected = true;`
+  - `tabControl.SelectedItem = tabItem;`
+- Do not add `IsSelected="True"` changes in `MainWindow.axaml` for this case.
 
 ### Step 6: Update UI Scale (if provided)
 File: `samples/SampleApp/ViewModels/MainWindowViewModel.cs`
@@ -160,7 +178,7 @@ Use the Edit tool to make this change. Be careful to preserve exact formatting a
 
 ### Step 7: Error handling
 - If theme invalid: Report valid options
-- If no matching tab: List all available tab titles from MainWindow.axaml
+- If no matching tab (including dynamic tab targets): List all available static tab titles from MainWindow.axaml and all dynamic tab titles inferred from insertion comments (include examples such as `TreeDataGrid` / `TreeDataGrid (Accelerate)` when present)
 - If multiple ambiguous matches: Ask user to be more specific
 - If scale invalid: Report valid options (100%, 125%, 150%, 175%, 200%, 225%, 250%, 275%, 300%, 400%, or Default)
 
@@ -168,6 +186,7 @@ Use the Edit tool to make this change. Be careful to preserve exact formatting a
 After successful changes, inform the user:
 - Which theme was activated
 - Which tab was selected
+- Whether tab selection was applied in `MainWindow.axaml` (static) or `MainWindow.axaml.cs` (runtime)
 - Which scale was set (if provided)
 - Remind them they can run: `dotnet run --project samples/SampleApp/SampleApp.csproj`
 

--- a/samples/SampleApp/DemoPages/TreeDataGridDemo.axaml
+++ b/samples/SampleApp/DemoPages/TreeDataGridDemo.axaml
@@ -3,7 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:SampleApp.ViewModels"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="750"
              x:Class="SampleApp.DemoPages.TreeDataGridDemo"
              x:DataType="vm:TreeDataGridViewModel">
 
@@ -23,25 +23,25 @@
   <StackPanel Orientation="Horizontal" Spacing="50">
     <StackPanel Orientation="Vertical" Spacing="20">
       <TextBlock Text="Row Selection" Classes="section-title" FontSize="18" />
-      
+
       <TextBlock Text="Flat mode" Classes="section-title" />
       <TreeDataGrid Source="{Binding RowSelectionSource}"
                     CanUserResizeColumns="True"
                     CanUserSortColumns="True"
                     MaxHeight="300" />
-      
+
       <TextBlock Text="Tree Mode" Classes="section-title" Margin="0 20 0 0" />
       <TreeDataGrid Source="{Binding TreeRowSelectionSource}" />
     </StackPanel>
-    
+
     <StackPanel Orientation="Vertical" Spacing="20">
       <TextBlock Text="Cell Selection" Classes="section-title" FontSize="18" />
-      
+
       <TextBlock Text="Flat mode" Classes="section-title" />
-      <TreeDataGrid Classes="no-grid-lines no-alternating-rows" 
+      <TreeDataGrid Classes="no-grid-lines no-alternating-rows"
                     Source="{Binding CellSelectionSource}"
                     MaxHeight="300" />
-      
+
       <TextBlock Text="Tree Mode" Classes="section-title" Margin="0 20 0 0" />
       <TreeDataGrid Classes="grid-lines alternating-rows" Source="{Binding TreeCellSelectionSource}" />
     </StackPanel>

--- a/samples/SampleApp/DemoPages/TreeDataGridDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/TreeDataGridDemo.axaml.cs
@@ -41,7 +41,9 @@ public partial class TreeDataGridDemo : UserControl
   {
       return new HierarchicalExpanderColumn<NetworkNode>(
           new TemplateColumn<NetworkNode>("Name", template),
-          node => node.Children
+          node => node.Children,
+          hasChildrenSelector: node => node.Children.Count > 0,
+          isExpandedSelector: node => node.IsExpanded
       );
   }
 }

--- a/samples/SampleApp/ViewModels/TreeDataGridViewModel.cs
+++ b/samples/SampleApp/ViewModels/TreeDataGridViewModel.cs
@@ -15,11 +15,12 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 public class NetworkNode
 {
-    public string Name { get; set; } = string.Empty;
-    public string Type { get; set; } = string.Empty; // "Folder", "Computer", "User"
-    public string IPAddress { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
-    public string LastSeen { get; set; } = string.Empty;
+  public string Name { get; set; } = string.Empty;
+  public string Type { get; set; } = string.Empty; // "Folder", "Computer", "User"
+  public bool IsExpanded { get; set; }
+  public string IPAddress { get; set; } = string.Empty;
+  public string Status { get; set; } = string.Empty;
+  public string LastSeen { get; set; } = string.Empty;
 
     public string IconPath => Type switch
     {
@@ -31,14 +32,15 @@ public class NetworkNode
 
     public ObservableCollection<NetworkNode> Children { get; } = new();
 
-    public NetworkNode(string name, string type, string ip = "", string status = "", string lastSeen = "")
-    {
-        this.Name = name;
-        this.Type = type;
-        this.IPAddress = ip;
-        this.Status = status;
-        this.LastSeen = lastSeen;
-    }
+  public NetworkNode(string name, string type, string ip = "", string status = "", string lastSeen = "")
+  {
+    this.Name = name;
+    this.Type = type;
+    this.IsExpanded = type == "Folder" && name != "Workstations";
+    this.IPAddress = ip;
+    this.Status = status;
+    this.LastSeen = lastSeen;
+  }
 }
 
 public class TreeDataGridViewModel : ObservableObject

--- a/samples/SampleApp/ViewModels/TreeDataGridViewModel.cs
+++ b/samples/SampleApp/ViewModels/TreeDataGridViewModel.cs
@@ -79,7 +79,8 @@ public class TreeDataGridViewModel : ObservableObject
                         new NetworkNode("DESKTOP-A", "Computer", "10.0.0.5", "Offline", "2 days ago"),
                         new NetworkNode("DESKTOP-B", "Computer", "10.0.0.6", "Online", "Just now"),
                     }
-                }
+                },
+                new NetworkNode("OddOneOut", "Unknown", "192.168.1.150", "Online", "Just now")
             }
         },
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeDataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeDataGrid.axaml
@@ -380,13 +380,14 @@
                 CornerRadius="{TemplateBinding CornerRadius}"
                 Padding="{TemplateBinding Indent, Converter={x:Static conv:IndentConverter.Instance}}">
           <DockPanel>
-              <ToggleButton DockPanel.Dock="Left" 
-                            Theme="{StaticResource TreeDataGridExpandCollapseChevron}"
+  <Border DockPanel.Dock="Left" Width="22">
+              <ToggleButton Theme="{StaticResource TreeDataGridExpandCollapseChevron}"
                             Focusable="False"
                             Width="22"
                             IsChecked="{TemplateBinding IsExpanded, Mode=TwoWay}"
                             IsVisible="{TemplateBinding ShowExpander}"
                             Margin="0 0 -6 0" />
+            </Border>
             <Decorator Name="PART_Content" />
           </DockPanel>
         </Border>


### PR DESCRIPTION
Non-expandable nodes didn't reserve the space otherwise taken up by the chevron, leading to less indentation than their siblings.

This contains a commit [[SampleApp] Expand example trees for better regression testing](https://github.com/Devolutions/avalonia-extensions/commit/3755a8dbac68b50e0b22670b3e40cc01fb3146be) - however, testing currently doesn't even work for TreeDataGrid (because it's a Pro control and its demo page is dynamically inserted into the MainWindow and currently not found by the test detector) -> to be fixed in a separate PR ...
