### PR TITLE
[Controls] Fix EditableComboBox not showing initial SelectedItem

### DIFF
--- a/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
@@ -20,6 +20,8 @@ public partial class EditableComboBoxViewModel : ObservableValidator
 
     public EditableComboBoxViewModel()
     {
+        this.SelectedCountry = this.Countries[0];
+        
         this.ValidateAllProperties();
     }
 

--- a/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/EditableComboBoxViewModel.cs
@@ -21,6 +21,7 @@ public partial class EditableComboBoxViewModel : ObservableValidator
     public EditableComboBoxViewModel()
     {
         this.SelectedCountry = this.Countries[0];
+        this.selectedCountry2 = this.Countries2[^1];
         
         this.ValidateAllProperties();
     }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -420,6 +420,16 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         this.innerTextBox.Watermark = this.Watermark;
 
         this.FillItems();
+
+        // Sync Value from SelectedItem if it was bound before items were realized.
+        // OnPropertyChanged fires during XAML binding initialization (before OnInitialized),
+        // at which point realizedItems is still empty, causing it to set Value = null.
+        // FillItems() above has now populated realizedItems, so we can resolve it here.
+        if (this.Value == null && this.SelectedItem != null &&
+            this.realizedItems.TryGetValue(GetSourceKey(this.SelectedItem), out EditableComboBoxItem? preselected))
+        {
+            this.Value = preselected.Value;
+        }
     }
 
     protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
When `SelectedItem` is pre-set on a bound ViewModel, Avalonia fires the binding before `OnInitialized` — at which point `realizedItems` is still empty. `OnPropertyChanged` then sets `Value = null` instead of the item's display text, so the text box appears blank on load.

Fix: after `FillItems()` populates `realizedItems` in `OnInitialized`, sync `Value` from `SelectedItem` if it's still null.