### PR TITLE
[SampleApp] Fix theme-switching to Fluent & Simple

### DIFF
--- a/samples/SampleApp/App.axaml
+++ b/samples/SampleApp/App.axaml
@@ -30,11 +30,13 @@
       <addons:DataGridFluentTheme />
       <addons:TreeDataGridFluentTheme />
       <addons:ColorPickerFluentTheme />
+      <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
       <local:SampleAppStyles />
     </Styles>
     <Styles x:Key="SimpleStyles">
       <actipro:ModernTheme AreNativeControlThemesEnabled="False" />
       <SimpleTheme />
+      <StyleInclude Source="avares://Devolutions.AvaloniaControls/DefaultControlTemplates.axaml" />
       <local:SampleAppStyles />
     </Styles>
     <actipro:ComparisonConverter x:Key="EqualToComparisonConverter" Operator="EqualTo" />

--- a/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
+++ b/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
@@ -32,5 +32,6 @@
     </ResourceDictionary>
 
     <StaticResource x:Key="{x:Type TabPane}" ResourceKey="{x:Type TabControl}" />
+    <StaticResource x:Key="TabPane_TabItem" ResourceKey="{x:Type TabItem}" />
   </Styles.Resources>
 </Styles>


### PR DESCRIPTION
Switching to the basic Avalonia themes has been broken for some time due to no Tab-Pane definition in those themes. Just fixed it, so I can investigate the intended behaviour for SplitButton keyboard navigation ...