### PR TITLE
Enable click-to-open behaviour on whole MultiComboBox

### DIFF
--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -35,6 +35,7 @@ public enum MultiComboBoxOverflowMode
 [TemplatePart("PART_SelectAllItem", typeof(MultiComboBoxSelectAllItem), IsRequired = false)]
 [TemplatePart("PART_FilterTextBox", typeof(TextBox), IsRequired = false)]
 [TemplatePart("PART_NoResultsText", typeof(TextBlock), IsRequired = false)]
+[TemplatePart("PART_Popup", typeof(Popup), IsRequired = true)]
 [TemplatePart("PART_ItemsListPresenter", typeof(ContentPresenter), IsRequired = true)]
 [TemplatePart(PART_BackgroundBorder, typeof(Border))]
 [PseudoClasses(PC_DropDownOpen, PC_Empty)]
@@ -152,8 +153,6 @@ public partial class MultiComboBox : SelectingItemsControl
     private TextBox? filterTextbox;
 
     private ContentPresenter? itemsListPresenter;
-
-    private Popup? popup;
 
     private MultiComboBoxSelectAllItem? selectAllItem;
 
@@ -608,7 +607,6 @@ public partial class MultiComboBox : SelectingItemsControl
         this.selectionScrollViewer = e.NameScope.Find<ScrollViewer>("PART_SelectionScrollViewer");
         this.selectAllItem = e.NameScope.Find<MultiComboBoxSelectAllItem>("PART_SelectAllItem");
         this.filterTextbox = e.NameScope.Find<TextBox>("PART_FilterTextBox");
-        this.popup = e.NameScope.Find<Popup>("PART_Popup");
 
         if (this.filterTextbox is { } partFilterTextBox)
         {
@@ -743,7 +741,7 @@ public partial class MultiComboBox : SelectingItemsControl
             return false;
         }
 
-        if (this.popup?.IsInsidePopup(source) == true)
+        if (source.GetVisualRoot() is PopupRoot)
         {
             return false;
         }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -746,7 +746,7 @@ public partial class MultiComboBox : SelectingItemsControl
             return false;
         }
 
-        return source.FindAncestorOfType<Button>() is null;
+        return source.FindAncestorOfType<Button>(includeSelf: true) is null;
     }
 
     private void OnSelectedItemsChanged(AvaloniaPropertyChangedEventArgs<IList?> args)

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -19,6 +19,7 @@ using Avalonia.Input;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Metadata;
+using Avalonia.VisualTree;
 using static Extensions.AvaloniaExtensions;
 using AvaloniaPropertyExtension = Irihi.Avalonia.Shared.Helpers.AvaloniaPropertyExtension;
 using ObservableExtension = Irihi.Avalonia.Shared.Helpers.ObservableExtension;
@@ -152,7 +153,7 @@ public partial class MultiComboBox : SelectingItemsControl
 
     private ContentPresenter? itemsListPresenter;
 
-    private Border? rootBorder;
+    private Popup? popup;
 
     private MultiComboBoxSelectAllItem? selectAllItem;
 
@@ -607,6 +608,7 @@ public partial class MultiComboBox : SelectingItemsControl
         this.selectionScrollViewer = e.NameScope.Find<ScrollViewer>("PART_SelectionScrollViewer");
         this.selectAllItem = e.NameScope.Find<MultiComboBoxSelectAllItem>("PART_SelectAllItem");
         this.filterTextbox = e.NameScope.Find<TextBox>("PART_FilterTextBox");
+        this.popup = e.NameScope.Find<Popup>("PART_Popup");
 
         if (this.filterTextbox is { } partFilterTextBox)
         {
@@ -616,9 +618,6 @@ public partial class MultiComboBox : SelectingItemsControl
 
         this.selectAllItem?.UpdateSelection();
 
-        RoutedEventExtension.RemoveHandler(PointerPressedEvent, this.OnBackgroundPointerPressed, this.rootBorder);
-        this.rootBorder = e.NameScope.Find<Border>(PART_BackgroundBorder);
-        RoutedEventExtension.AddHandler(PointerPressedEvent, this.OnBackgroundPointerPressed, this.rootBorder);
         this.PseudoClasses.Set(PC_Empty, this.SelectedItems?.Count == 0);
 
         if (this.selectAllItem is { } sai)
@@ -714,9 +713,42 @@ public partial class MultiComboBox : SelectingItemsControl
         }
     }
 
-    private void OnBackgroundPointerPressed(object? sender, PointerPressedEventArgs e)
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
+        base.OnPointerPressed(e);
+
+        if (e.Handled || !this.ShouldToggleDropDown(e))
+        {
+            return;
+        }
+
         this.SetCurrentValue(IsDropDownOpenProperty, !this.IsDropDownOpen);
+        e.Handled = true;
+    }
+
+    private bool ShouldToggleDropDown(PointerPressedEventArgs e)
+    {
+        if (!this.IsEffectivelyEnabled)
+        {
+            return false;
+        }
+
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return false;
+        }
+
+        if (e.Source is not Visual source)
+        {
+            return false;
+        }
+
+        if (this.popup?.IsInsidePopup(source) == true)
+        {
+            return false;
+        }
+
+        return source.FindAncestorOfType<Button>() is null;
     }
 
     private void OnSelectedItemsChanged(AvaloniaPropertyChangedEventArgs<IList?> args)

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
@@ -221,7 +221,8 @@
               HorizontalOffset="-6"
               VerticalOffset="0"
               IsLightDismissEnabled="True"
-              OverlayDismissEventPassThrough="True"
+              OverlayDismissEventPassThrough="False"
+              OverlayInputPassThroughElement="{Binding #PART_Root}"
               InheritsTransform="True">
               <Interaction.Behaviors>
                 <PositionedPopupBehavior

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -48,7 +48,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.23,)"/>
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.30,)"/>
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -47,7 +47,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.23,)"/>
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.30,)"/>
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -46,7 +46,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.23,)"/>
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.4.30,)"/>
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj"/>


### PR DESCRIPTION
Unlike normal ComboBoxes, the MultiComboBox can only be opened by clicking directly on the chevron (on the Mac and Linux themes clicking on the body worked is no selection was made yet). This lets the control handle all clicks and open the popup, except for clicks on a tag's **x** close button. 