### PR TITLE
[EditableComboBox] Enable virtualization for inline EditableComboBoxItem items

### DIFF
--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
@@ -361,8 +361,8 @@
             </EditableComboBoxDataTemplate>
           </EditableComboBox.ItemTemplate>
           <EditableComboBox.InnerLeftContent>
-            <Border IsVisible="{Binding SelectedCountry, Converter={x:Static ObjectConverters.IsNotNull}}" DockPanel.Dock="Left" Background="Gray" CornerRadius="9" Width="18" Height="18">
-              <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding SelectedCountry.Code, FallbackValue={x:Null}}" Foreground="White" FontWeight="Bold" FontSize="8" />
+            <Border IsVisible="{Binding SelectedCountry2, Converter={x:Static ObjectConverters.IsNotNull}}" DockPanel.Dock="Left" Background="Gray" CornerRadius="9" Width="18" Height="18">
+              <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding SelectedCountry2.Code, FallbackValue={x:Null}}" Foreground="White" FontWeight="Bold" FontSize="8" />
             </Border>
           </EditableComboBox.InnerLeftContent>
         </EditableComboBox>

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -597,7 +597,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         else
         {
             this.filteredItems.Clear();
-            this.filteredItems.AddRange(this.ItemsView.Select(CloneIfInlineItem));
+            this.filteredItems.AddRange(this.ItemsView);
         }
 
         this.SyncCommittedSelectionState();
@@ -615,8 +615,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
                 {
                     string itemValue = this.GetValueForItem(item);
                     return string.IsNullOrEmpty(trimmedSearch) || itemValue.Contains(trimmedSearch, StringComparison.OrdinalIgnoreCase);
-                })
-                .Select(CloneIfInlineItem));
+                }));
     }
 
     private string? GetSelectedItemValue()
@@ -630,35 +629,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         return this.realizedItems.TryGetValue(GetSourceKey(selected), out string? value) ? value : selected.ToString();
     }
 
-    private static object GetSourceKey(object? item)
-    {
-        // For cloned EditableComboBoxItem instances, resolve to the original source item
-        // so that dictionary lookups match realizedItems keys (which use original items).
-        if (item is EditableComboBoxItem { OriginalSourceItem: { } originalItem } && !ReferenceEquals(item, originalItem))
-        {
-            return originalItem;
-        }
-
-        return item ?? NullSourceKey;
-    }
-
-    /// <summary>
-    /// Inline XAML EditableComboBoxItem items are Visuals that cannot be re-added to a panel
-    /// after removal. Clone them so that filtering (clear + re-add) works correctly.
-    /// Non-EditableComboBoxItem source objects are passed through unchanged (they get fresh
-    /// generated containers via NeedsContainerOverride).
-    /// </summary>
-    private static object? CloneIfInlineItem(object? item)
-    {
-        if (item is not EditableComboBoxItem comboBoxItem)
-        {
-            return item;
-        }
-        
-        EditableComboBoxItem clone = comboBoxItem.Clone();
-        clone.OriginalSourceItem ??= comboBoxItem;
-        return clone;
-    }
+    private static object GetSourceKey(object? item) => item ?? NullSourceKey;
 
     private string GetValueForItem(object? item)
     {
@@ -799,8 +770,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         this.syncingSelectedItemFromInnerCombo = true;
         try
         {
-            object? innerSelected = this.innerComboBox.SelectedIndex >= 0 ? this.innerComboBox.SelectedItem : null;
-            this.SelectedItem = innerSelected is EditableComboBoxItem comboBoxItem ? comboBoxItem.OriginalSourceItem : innerSelected;
+            this.SelectedItem = this.innerComboBox.SelectedIndex >= 0 ? this.innerComboBox.SelectedItem : null;
             this.SyncCommittedSelectionState();
         }
         finally

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBoxItem.cs
@@ -34,15 +34,6 @@ public class EditableComboBoxItem : TemplatedControl, ISelectable
 
     public EditableComboBoxItem() { }
 
-    public EditableComboBoxItem(EditableComboBoxItem toClone)
-    {
-        this.Value = toClone.Value;
-        this.Classes.AddRange(toClone.Classes);
-        this.OriginalSourceItem = toClone.OriginalSourceItem;
-
-        this.OnInitialized();
-    }
-
     public IDataTemplate? ContentTemplate
     {
         get => this.GetValue(ContentTemplateProperty);
@@ -75,24 +66,6 @@ public class EditableComboBoxItem : TemplatedControl, ISelectable
     }
 
     internal object? OriginalSourceItem { get; set; }
-
-    public EditableComboBoxItem Clone()
-    {
-        var clone = new EditableComboBoxItem(this)
-        {
-            Value = this.Value,
-            OriginalSourceItem = this.OriginalSourceItem,
-            DataContext = this.DataContext,
-            IsCommittedSelected = this.IsCommittedSelected,
-        };
-
-        if (this.IsSet(ContentTemplateProperty))
-        {
-            clone.ContentTemplate = this.ContentTemplate;
-        }
-
-        return clone;
-    }
 
     public override string ToString() =>
         this.Value;

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
@@ -140,8 +140,13 @@ public partial class EditableComboBox
                 Value = string.Empty,
             };
 
-        protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey) =>
-            this.NeedsContainer<EditableComboBoxItem>(item, out recycleKey);
+        protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
+        {
+            // Always generate containers, even for inline EditableComboBoxItem data.
+            // This enables VSP virtualization for all item types.
+            recycleKey = DefaultRecycleKey;
+            return true;
+        }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
@@ -239,22 +244,11 @@ public partial class EditableComboBox
             }
 
             editableComboBoxItem.Value = this.parent.GetValueForItem(item);
-            if (container != item)
+            editableComboBoxItem.OriginalSourceItem = item;
+            editableComboBoxItem.IsCommittedSelected = Equals(GetSourceKey(item), GetSourceKey(this.parent.SelectedItem));
+            if (this.parent.ItemTemplate != null)
             {
-                // Normal case: item is raw source data; populate the generated container.
-                editableComboBoxItem.OriginalSourceItem = item;
-                editableComboBoxItem.IsCommittedSelected = Equals(GetSourceKey(item), GetSourceKey(this.parent.SelectedItem));
-                if (this.parent.ItemTemplate != null)
-                {
-                    editableComboBoxItem.ContentTemplate = this.parent.ItemTemplate;
-                }
-            }
-            else
-            {
-                // We should consider supporting virtualization even with EditableComboBoxItem as items
-                // The entire containerization should be handled here (that is, in InnerComboBox) and cloning
-                // should be removed from EditableComboBox altogether
-                editableComboBoxItem.IsCommittedSelected = Equals(GetSourceKey(editableComboBoxItem.OriginalSourceItem), GetSourceKey(this.parent.SelectedItem));
+                editableComboBoxItem.ContentTemplate = this.parent.ItemTemplate;
             }
         }
 


### PR DESCRIPTION
## Summary
- Always generate containers in `InnerComboBox`, treating inline XAML `EditableComboBoxItem` instances as data rather than containers — this enables VSP recycling for all item types
- Remove the cloning workaround (`Clone()`, `CloneIfInlineItem`, clone constructor) that was needed when inline items were used directly as visuals