### PR TITLE
[MultiComboBox] Fix memory leaks, enable virtualization, and align SelectedItems with ComboBox

### DIFF
--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -82,7 +82,13 @@
           SelectAllText="Select All"
           AllSelectedText="All"
           FilterText="Find an option..."
-          ItemsSource="{Binding LotOfItems}" />
+          ItemsSource="{Binding LotOfItems}">
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Text}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
 
         <Separator Margin="-10 10" />
 
@@ -161,7 +167,8 @@
           HorizontalAlignment="Left"
           Watermark="100 inline items"
           SelectAllText="Select All"
-          ShowFilter="True">
+          ShowFilter="True"
+          SelectedItems="{Binding InlineSelectedItems}">
           <MultiComboBox.ItemsPanel>
             <ItemsPanelTemplate>
               <VirtualizingStackPanel />
@@ -269,6 +276,7 @@
           <MultiComboBoxItem>Inline 99</MultiComboBoxItem>
           <MultiComboBoxItem>Inline 100</MultiComboBoxItem>
         </MultiComboBox>
+        <TextBlock Text="{Binding InlineSelectedItemsText, StringFormat='Selection: {0}'}" ToolTip.Tip="{Binding InlineSelectedItemsText}" />
 
         <Separator Margin="-10 10" />
 
@@ -278,13 +286,20 @@
           Watermark="1000 bound items"
           SelectAllText="Select All"
           ShowFilter="True"
-          ItemsSource="{Binding LotOfItems}">
+          ItemsSource="{Binding LotOfItems}"
+          SelectedItems="{Binding LotOfItemsSelectedItems}">
           <MultiComboBox.ItemsPanel>
             <ItemsPanelTemplate>
               <VirtualizingStackPanel />
             </ItemsPanelTemplate>
           </MultiComboBox.ItemsPanel>
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding Text}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
         </MultiComboBox>
+        <TextBlock Text="{Binding LotOfItemsSelectedItemsText, StringFormat='Selection: {0}'}" ToolTip.Tip="{Binding LotOfItemsSelectedItemsText}" />
       </StackPanel>
     </StackPanel>
   </Border>

--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -154,6 +154,138 @@
           ItemsSource="{Binding Items}"
           Watermark="Required" />
       </StackPanel>
+
+      <StackPanel Width="200" HorizontalAlignment="Left" Spacing="10">
+        <TextBlock>100 Inline Items (virtualization test)</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          Watermark="100 inline items"
+          SelectAllText="Select All"
+          ShowFilter="True">
+          <MultiComboBox.ItemsPanel>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </MultiComboBox.ItemsPanel>
+          <MultiComboBoxItem>Inline 1</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 1</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 2</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 3</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 4</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 5</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 6</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 7</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 8</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 9</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 10</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 11</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 12</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 13</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 14</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 15</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 16</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 17</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 18</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 19</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 20</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 21</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 22</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 23</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 24</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 25</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 26</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 27</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 28</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 29</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 30</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 31</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 32</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 33</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 34</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 35</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 36</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 37</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 38</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 39</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 40</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 41</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 42</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 43</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 44</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 45</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 46</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 47</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 48</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 49</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 50</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 51</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 52</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 53</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 54</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 55</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 56</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 57</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 58</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 59</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 60</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 61</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 62</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 63</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 64</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 65</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 66</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 67</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 68</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 69</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 70</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 71</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 72</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 73</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 74</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 75</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 76</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 77</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 78</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 79</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 80</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 81</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 82</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 83</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 84</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 85</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 86</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 87</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 88</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 89</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 90</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 91</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 92</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 93</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 94</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 95</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 96</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 97</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 98</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 99</MultiComboBoxItem>
+          <MultiComboBoxItem>Inline 100</MultiComboBoxItem>
+        </MultiComboBox>
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>1000 Bound Items (virtualization test)</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          Watermark="1000 bound items"
+          SelectAllText="Select All"
+          ShowFilter="True"
+          ItemsSource="{Binding LotOfItems}">
+          <MultiComboBox.ItemsPanel>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </MultiComboBox.ItemsPanel>
+        </MultiComboBox>
+      </StackPanel>
     </StackPanel>
   </Border>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -85,7 +85,7 @@
           ItemsSource="{Binding LotOfItems}">
           <MultiComboBox.ItemTemplate>
             <DataTemplate>
-              <TextBlock Text="{Binding Text}" />
+              <SearchHighlightTextBlock Content="{Binding Text}" />
             </DataTemplate>
           </MultiComboBox.ItemTemplate>
         </MultiComboBox>
@@ -295,7 +295,7 @@
           </MultiComboBox.ItemsPanel>
           <MultiComboBox.ItemTemplate>
             <DataTemplate>
-              <TextBlock Text="{Binding Text}" />
+              <SearchHighlightTextBlock Content="{Binding Text}" />
             </DataTemplate>
           </MultiComboBox.ItemTemplate>
         </MultiComboBox>

--- a/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Devolutions.AvaloniaControls.Controls;
 
 public enum MultiComboBoxDemoEnum
 {
@@ -14,6 +15,15 @@ public enum MultiComboBoxDemoEnum
 
 public partial class MultiComboBoxViewModel : ObservableValidator
 {
+    public class Item
+    {
+        public required int Value { get; init; }
+        
+        public string Text => $"Option {this.Value}";
+
+        public override string ToString() => $"<{nameof(Item)} ({this.Text})>";
+    }
+    
     [ObservableProperty]
     private MultiComboBoxDemoEnum[] enumValues = Enum.GetValues<MultiComboBoxDemoEnum>();
 
@@ -21,26 +31,17 @@ public partial class MultiComboBoxViewModel : ObservableValidator
     private string[] items = ["item 1", "item 2", "item 3"];
 
     [ObservableProperty]
-    private ObservableCollection<string> lotOfItems = [];
-
-    [ObservableProperty]
     [Required]
     [MinLength(1)]
     [NotifyDataErrorInfo]
     private AvaloniaList<string> requiredValues = [];
 
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(SelectedEnumValuesText))]
-    private AvaloniaList<MultiComboBoxDemoEnum> selectedEnumValues = [MultiComboBoxDemoEnum.EnumA];
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(SelectedText))]
-    private AvaloniaList<string> selectedItems = ["item 2"];
-
     public MultiComboBoxViewModel()
     {
         this.SelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedText));
         this.SelectedEnumValues.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedEnumValuesText));
+        this.LotOfItemsSelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.LotOfItemsSelectedItemsText));
+        this.InlineSelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.InlineSelectedItemsText));
 
         // Trigger validation when collection changes
         this.RequiredValues.CollectionChanged += (_, _) =>
@@ -50,11 +51,25 @@ public partial class MultiComboBoxViewModel : ObservableValidator
 
         for (var i = 1; i <= 1000; ++i)
         {
-            this.lotOfItems.Add("Option " + i);
+            this.LotOfItems.Add(new Item { Value = i });
         }
 
         this.ValidateAllProperties();
     }
+
+    public AvaloniaList<MultiComboBoxItem> InlineSelectedItems { get; } = [];
+    
+    public string InlineSelectedItemsText => this.InlineSelectedItems.Count > 0 ? string.Join(", ", this.InlineSelectedItems) : "None";
+    
+    public AvaloniaList<Item> LotOfItems { get; } = [];
+    
+    public AvaloniaList<Item> LotOfItemsSelectedItems { get; } = [];
+    
+    public string LotOfItemsSelectedItemsText => this.LotOfItemsSelectedItems.Count > 0 ? string.Join(", ", this.LotOfItemsSelectedItems) : "None";
+
+    public AvaloniaList<MultiComboBoxDemoEnum> SelectedEnumValues { get; } = [MultiComboBoxDemoEnum.EnumA];
+
+    public AvaloniaList<string> SelectedItems { get; } = ["item 2"];
 
     public string SelectedText => this.SelectedItems.Count > 0 ? string.Join(", ", this.SelectedItems) : "None";
 

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
@@ -142,8 +142,6 @@ public partial class EditableComboBox
 
         protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
         {
-            // Always generate containers, even for inline EditableComboBoxItem data.
-            // This enables VSP virtualization for all item types.
             recycleKey = DefaultRecycleKey;
             return true;
         }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -34,7 +34,7 @@ public partial class MultiComboBox
             base.ClearContainerForItemOverride(element);
             if (element is MultiComboBoxItem multiComboBoxItem)
             {
-                // Suppress OnSelectionChanged — container lifecycle must never mutate SelectedItems.
+                multiComboBoxItem.DataContext = null;
                 multiComboBoxItem.BeginUpdate();
                 multiComboBoxItem.ClearValue(MultiComboBoxItem.IsSelectedProperty);
                 multiComboBoxItem.EndUpdate();
@@ -57,15 +57,14 @@ public partial class MultiComboBox
             // (consistent with how ComboBox returns ComboBoxItem for inline items).
             if (item is MultiComboBoxItem sourceItem)
             {
-                multiComboBoxItem.Content = sourceItem.Content;
                 multiComboBoxItem.DataContext = sourceItem;
+                multiComboBoxItem.Content = sourceItem.Content;
                 multiComboBoxItem.ContentTemplate ??= sourceItem.ContentTemplate ?? this.ItemTemplate;
                 multiComboBoxItem.IsEnabled = sourceItem.IsEnabled;
             }
 
-            // Suppress OnSelectionChanged — this is a programmatic sync, not user interaction.
-            multiComboBoxItem.BeginUpdate();
             bool isSelected = this.parent.SelectedItems?.Contains(multiComboBoxItem.DataContext ?? item) ?? false;
+            multiComboBoxItem.BeginUpdate();
             multiComboBoxItem.IsSelected = isSelected;
             multiComboBoxItem.EndUpdate();
         }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -52,13 +52,13 @@ public partial class MultiComboBox
                 return;
             }
 
-            // For inline MultiComboBoxItem data, unwrap Content/DataContext.
-            // base sets container.Content = item (the MultiComboBoxItem object) — override to the inner Content.
-            // DataContext must match SelectedItems entries (which contain Content values, not MultiComboBoxItem objects).
+            // For inline MultiComboBoxItem data, unwrap Content for display but keep DataContext
+            // pointing to the MultiComboBoxItem itself — matching what goes into SelectedItems
+            // (consistent with how ComboBox returns ComboBoxItem for inline items).
             if (item is MultiComboBoxItem sourceItem)
             {
                 multiComboBoxItem.Content = sourceItem.Content;
-                multiComboBoxItem.DataContext = sourceItem.Content;
+                multiComboBoxItem.DataContext = sourceItem;
                 multiComboBoxItem.ContentTemplate ??= sourceItem.ContentTemplate ?? this.ItemTemplate;
                 multiComboBoxItem.IsEnabled = sourceItem.IsEnabled;
             }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -23,27 +23,51 @@ public partial class MultiComboBox
 
         protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
         {
-            recycleKey = item;
-            return item is not MultiComboBoxItem;
+            // Always generate containers, even for inline MultiComboBoxItem data.
+            // This enables VSP virtualization for all item types.
+            recycleKey = DefaultRecycleKey;
+            return true;
+        }
+
+        protected override void ClearContainerForItemOverride(Control element)
+        {
+            base.ClearContainerForItemOverride(element);
+            if (element is MultiComboBoxItem multiComboBoxItem)
+            {
+                // Suppress OnSelectionChanged — container lifecycle must never mutate SelectedItems.
+                multiComboBoxItem.BeginUpdate();
+                multiComboBoxItem.ClearValue(MultiComboBoxItem.IsSelectedProperty);
+                multiComboBoxItem.EndUpdate();
+                multiComboBoxItem.ClearValue(ContentControl.ContentTemplateProperty);
+                multiComboBoxItem.ClearValue(IsEnabledProperty);
+            }
         }
 
         protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
         {
-            if (item is MultiComboBoxItem containerItem)
-            {
-                container.DataContext = containerItem.Content;
-                containerItem.ContentTemplate ??= this.ItemTemplate;
-            }
-
             base.PrepareContainerForItemOverride(container, item, index);
 
-            // Sync selection state from parent
-            if (container is MultiComboBoxItem multiComboBoxItem)
+            if (container is not MultiComboBoxItem multiComboBoxItem)
             {
-                // Check if this item is selected in parent
-                bool isSelected = this.parent.SelectedItems?.Contains(multiComboBoxItem.DataContext ?? item) ?? false;
-                multiComboBoxItem.IsSelected = isSelected;
+                return;
             }
+
+            // For inline MultiComboBoxItem data, unwrap Content/DataContext.
+            // base sets container.Content = item (the MultiComboBoxItem object) — override to the inner Content.
+            // DataContext must match SelectedItems entries (which contain Content values, not MultiComboBoxItem objects).
+            if (item is MultiComboBoxItem sourceItem)
+            {
+                multiComboBoxItem.Content = sourceItem.Content;
+                multiComboBoxItem.DataContext = sourceItem.Content;
+                multiComboBoxItem.ContentTemplate ??= sourceItem.ContentTemplate ?? this.ItemTemplate;
+                multiComboBoxItem.IsEnabled = sourceItem.IsEnabled;
+            }
+
+            // Suppress OnSelectionChanged — this is a programmatic sync, not user interaction.
+            multiComboBoxItem.BeginUpdate();
+            bool isSelected = this.parent.SelectedItems?.Contains(multiComboBoxItem.DataContext ?? item) ?? false;
+            multiComboBoxItem.IsSelected = isSelected;
+            multiComboBoxItem.EndUpdate();
         }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -35,11 +35,12 @@ public partial class MultiComboBox
             if (element is MultiComboBoxItem multiComboBoxItem)
             {
                 multiComboBoxItem.DataContext = null;
+                multiComboBoxItem.ClearValue(ContentControl.ContentProperty);
+                multiComboBoxItem.ClearValue(ContentControl.ContentTemplateProperty);
+                multiComboBoxItem.ClearValue(IsEnabledProperty);
                 multiComboBoxItem.BeginUpdate();
                 multiComboBoxItem.ClearValue(MultiComboBoxItem.IsSelectedProperty);
                 multiComboBoxItem.EndUpdate();
-                multiComboBoxItem.ClearValue(ContentControl.ContentTemplateProperty);
-                multiComboBoxItem.ClearValue(IsEnabledProperty);
             }
         }
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -61,7 +61,7 @@ public partial class MultiComboBox
                 multiComboBoxItem.DataContext = sourceItem;
                 multiComboBoxItem.Content = sourceItem.Content;
                 multiComboBoxItem.ContentTemplate ??= sourceItem.ContentTemplate ?? this.ItemTemplate;
-                multiComboBoxItem.IsEnabled = sourceItem.IsEnabled;
+                multiComboBoxItem[!IsEnabledProperty] = sourceItem[!IsEnabledProperty];
             }
 
             bool isSelected = this.parent.SelectedItems?.Contains(multiComboBoxItem.DataContext ?? item) ?? false;

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -59,8 +59,8 @@ public partial class MultiComboBox
             if (item is MultiComboBoxItem sourceItem)
             {
                 multiComboBoxItem.DataContext = sourceItem;
-                multiComboBoxItem.Content = sourceItem.Content;
-                multiComboBoxItem.ContentTemplate ??= sourceItem.ContentTemplate ?? this.ItemTemplate;
+                multiComboBoxItem[!ContentControl.ContentProperty] = sourceItem[!ContentControl.ContentProperty];
+                multiComboBoxItem[!ContentControl.ContentTemplateProperty] = sourceItem[!ContentControl.ContentTemplateProperty];
                 multiComboBoxItem[!IsEnabledProperty] = sourceItem[!IsEnabledProperty];
             }
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -23,8 +23,6 @@ public partial class MultiComboBox
 
         protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
         {
-            // Always generate containers, even for inline MultiComboBoxItem data.
-            // This enables VSP virtualization for all item types.
             recycleKey = DefaultRecycleKey;
             return true;
         }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -60,7 +60,7 @@ public partial class MultiComboBox
             {
                 multiComboBoxItem.DataContext = sourceItem;
                 multiComboBoxItem[!ContentControl.ContentProperty] = sourceItem[!ContentControl.ContentProperty];
-                multiComboBoxItem[!ContentControl.ContentTemplateProperty] = sourceItem[!ContentControl.ContentTemplateProperty];
+                multiComboBoxItem.ContentTemplate = sourceItem.ContentTemplate ?? this.ItemTemplate;
                 multiComboBoxItem[!IsEnabledProperty] = sourceItem[!IsEnabledProperty];
             }
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
@@ -88,8 +88,7 @@
       <DataTemplate>
         <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}"
-          Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
+          Content="{Binding}" />
       </DataTemplate>
     </Setter>
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml
@@ -86,9 +86,9 @@
     <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
     <Setter Property="ItemTemplate">
       <DataTemplate>
-        <SearchHighlightTextBlock 
+        <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}" 
+          Content="{Binding}"
           Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
       </DataTemplate>
     </Setter>
@@ -169,9 +169,9 @@
                 HorizontalWheelBehavior.Enable="True"
                 Margin="1">
                 <u:MultiComboBoxSelectedItemList
+                  Name="PART_SelectedItemsList"
                   VerticalAlignment="Center"
                   ItemTemplate="{TemplateBinding EffectiveSelectedItemTemplate}"
-                  ItemsSource="{TemplateBinding SelectedItems}"
                   RemoveCommand="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Remove}"
                   ItemsPanel="{TemplateBinding EffectiveSelectedItemsPanel}" />
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -158,6 +158,8 @@ public partial class MultiComboBox : SelectingItemsControl
 
     private MultiComboBoxSelectAllItem? selectAllItem;
 
+    private ItemsControl? selectedItemsList;
+
     private ScrollViewer? selectionScrollViewer;
 
     private bool updateInternal;
@@ -405,29 +407,12 @@ public partial class MultiComboBox : SelectingItemsControl
 
     public void Remove(object? o)
     {
-        if (o is not StyledElement s) return;
+        if (o is not Control chip || this.selectedItemsList is null) return;
 
-        object? displayData = s.DataContext;
-
-        // displayData comes from DisplaySelectedItems (unwrapped Content for inline items).
-        // Find the corresponding entry in SelectedItems.
-        object? itemToRemove = null;
-        if (this.SelectedItems is not null)
+        int index = this.selectedItemsList.IndexFromContainer(chip);
+        if (index >= 0 && index < (this.SelectedItems?.Count ?? 0))
         {
-            foreach (object? si in this.SelectedItems)
-            {
-                object? displayValue = si is MultiComboBoxItem mcbi ? mcbi.Content : si;
-                if (Equals(displayValue, displayData))
-                {
-                    itemToRemove = si;
-                    break;
-                }
-            }
-        }
-
-        if (itemToRemove is not null)
-        {
-            this.SelectedItems?.Remove(itemToRemove);
+            this.SelectedItems?.RemoveAt(index);
         }
     }
 
@@ -609,9 +594,10 @@ public partial class MultiComboBox : SelectingItemsControl
             this.itemsListPresenter.Content = this.innerList;
         }
 
-        if (e.NameScope.Find<ItemsControl>("PART_SelectedItemsList") is { } selectedItemsList)
+        this.selectedItemsList = e.NameScope.Find<ItemsControl>("PART_SelectedItemsList");
+        if (this.selectedItemsList is not null)
         {
-            selectedItemsList.ItemsSource = this.displaySelectedItems;
+            this.selectedItemsList.ItemsSource = this.displaySelectedItems;
         }
 
         this.selectionScrollViewer = e.NameScope.Find<ScrollViewer>("PART_SelectionScrollViewer");

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -640,14 +640,7 @@ public partial class MultiComboBox : SelectingItemsControl
 
         // Re-populate filtered items based on current filter
         this.FilteredItems.Clear();
-
-        foreach (object? item in this.ItemsView)
-        {
-            if (!hasFilterText || this.ItemMatchesFilter(item, filterText))
-            {
-                this.FilteredItems.Add(item);
-            }
-        }
+        this.FilteredItems.AddRange(hasFilterText ? this.ItemsView.Where(item =>  this.ItemMatchesFilter(item, filterText)) :  this.ItemsView);
     }
 
     private bool ItemMatchesFilter(object? item, string? filterText)

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -37,6 +37,7 @@ public enum MultiComboBoxOverflowMode
 [TemplatePart("PART_NoResultsText", typeof(TextBlock), IsRequired = false)]
 [TemplatePart("PART_Popup", typeof(Popup), IsRequired = true)]
 [TemplatePart("PART_ItemsListPresenter", typeof(ContentPresenter), IsRequired = true)]
+[TemplatePart("PART_SelectedItemsList", typeof(ItemsControl), IsRequired = true)]
 [TemplatePart(PART_BackgroundBorder, typeof(Border))]
 [PseudoClasses(PC_DropDownOpen, PC_Empty)]
 public partial class MultiComboBox : SelectingItemsControl
@@ -588,17 +589,12 @@ public partial class MultiComboBox : SelectingItemsControl
         base.OnApplyTemplate(e);
 
         // Store reference to ContentPresenter and set inner control
-        this.itemsListPresenter = e.NameScope.Find<ContentPresenter>("PART_ItemsListPresenter");
-        if (this.itemsListPresenter is not null)
-        {
-            this.itemsListPresenter.Content = this.innerList;
-        }
+        this.itemsListPresenter = e.NameScope.Get<ContentPresenter>("PART_ItemsListPresenter");
+        this.itemsListPresenter.Content = this.innerList;
 
-        this.selectedItemsList = e.NameScope.Find<ItemsControl>("PART_SelectedItemsList");
-        if (this.selectedItemsList is not null)
-        {
-            this.selectedItemsList.ItemsSource = this.displaySelectedItems;
-        }
+
+        this.selectedItemsList = e.NameScope.Get<ItemsControl>("PART_SelectedItemsList");
+        this.selectedItemsList.ItemsSource = this.displaySelectedItems;
 
         this.selectionScrollViewer = e.NameScope.Find<ScrollViewer>("PART_SelectionScrollViewer");
         this.selectAllItem = e.NameScope.Find<MultiComboBoxSelectAllItem>("PART_SelectAllItem");
@@ -819,10 +815,8 @@ public partial class MultiComboBox : SelectingItemsControl
         this.displaySelectedItems.Clear();
         if (this.SelectedItems is null) return;
 
-        foreach (object? item in this.SelectedItems)
-        {
-            this.displaySelectedItems.Add(item is MultiComboBoxItem comboBoxItem ? comboBoxItem.Content : item);
-        }
+        this.displaySelectedItems.AddRange(this.SelectedItems.OfType<object?>()
+            .Select(item => item is MultiComboBoxItem comboBoxItem ? comboBoxItem.Content : item));
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -400,7 +400,7 @@ public partial class MultiComboBox : SelectingItemsControl
     {
         if (item is null) return null;
         // Containers are now managed by innerItemsList, not the parent
-        return item as MultiComboBoxItem ?? this.innerList.ContainerFromItem(item) as MultiComboBoxItem;
+        return this.innerList.ContainerFromItem(item) as MultiComboBoxItem;
     }
 
     public void Remove(object? o)
@@ -442,7 +442,17 @@ public partial class MultiComboBox : SelectingItemsControl
 
         foreach (object? item in this.Items)
         {
+            this.GetMultiComboBoxItemContainer(item)?.BeginUpdate();
+        }
+        
+        foreach (object? item in this.Items)
+        {
             this.SelectedItems.Add(item);
+        }
+
+        foreach (object? item in this.Items)
+        {
+            this.GetMultiComboBoxItemContainer(item)?.EndUpdate();
         }
 
         this.selectAllItem?.EndUpdate();

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -645,34 +645,11 @@ public partial class MultiComboBox : SelectingItemsControl
         // Re-populate filtered items based on current filter
         this.FilteredItems.Clear();
 
-        // IEnumerable source = this.ItemsSource ?? this.Items;
         foreach (object? item in this.ItemsView)
         {
             if (!hasFilterText || this.ItemMatchesFilter(item, filterText))
             {
-                // If we have concrete `MultiComboBoxItem` instances, they are owned by us 
-                // ("us" being `MultiComboBox` because we are a `ItemsControl`).
-                //
-                // ItemsControl must own their containers.
-                // We don't realize unrealized container, so the inner `InnerMultiComboBoxList` can realize
-                // and own them without problem.
-                //
-                // However, if we own concrete instances, we must send clones to the InnerMultiComboBoxList,
-                // so we clone and bind them.
-                if (item is MultiComboBoxItem containerItem)
-                {
-                    this.FilteredItems.Add(new MultiComboBoxItem
-                    {
-                        [!ContentControl.ContentProperty] = containerItem[!ContentControl.ContentProperty],
-                        [!ContentControl.ContentTemplateProperty] = containerItem[!ContentControl.ContentTemplateProperty],
-                        [!IsEnabledProperty] = containerItem[!IsEnabledProperty],
-                        IsSelected = containerItem.IsSelected,
-                    });
-                }
-                else
-                {
-                    this.FilteredItems.Add(item);
-                }
+                this.FilteredItems.Add(item);
             }
         }
     }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -150,6 +150,8 @@ public partial class MultiComboBox : SelectingItemsControl
 
     private readonly InnerMultiComboBoxList innerList;
 
+    private readonly AvaloniaList<object?> displaySelectedItems = [];
+
     private TextBox? filterTextbox;
 
     private ContentPresenter? itemsListPresenter;
@@ -342,6 +344,7 @@ public partial class MultiComboBox : SelectingItemsControl
 
     public IDataTemplate? EffectiveSelectedItemTemplate => this.SelectedItemTemplate ?? this.ItemTemplate;
 
+    /// <summary>
     public bool? IsAllSelected
     {
         get
@@ -403,19 +406,29 @@ public partial class MultiComboBox : SelectingItemsControl
 
     public void Remove(object? o)
     {
-        if (o is StyledElement s)
+        if (o is not StyledElement s) return;
+
+        object? displayData = s.DataContext;
+
+        // displayData comes from DisplaySelectedItems (unwrapped Content for inline items).
+        // Find the corresponding entry in SelectedItems.
+        object? itemToRemove = null;
+        if (this.SelectedItems is not null)
         {
-            object? data = s.DataContext;
-            this.SelectedItems?.Remove(data);
-            object? item = this.Items.FirstOrDefault(a => ReferenceEquals(a, data));
-            if (item is not null)
+            foreach (object? si in this.SelectedItems)
             {
-                Control? container = this.ContainerFromItem(item);
-                if (container is MultiComboBoxItem t)
+                object? displayValue = si is MultiComboBoxItem mcbi ? mcbi.Content : si;
+                if (Equals(displayValue, displayData))
                 {
-                    t.IsSelected = false;
+                    itemToRemove = si;
+                    break;
                 }
             }
+        }
+
+        if (itemToRemove is not null)
+        {
+            this.SelectedItems?.Remove(itemToRemove);
         }
     }
 
@@ -435,15 +448,8 @@ public partial class MultiComboBox : SelectingItemsControl
 
         foreach (object? item in this.Items)
         {
-            if (this.GetMultiComboBoxItemContainer(item) is MultiComboBoxItem multiComboBoxItem)
-            {
-                this.SelectedItems.Add(multiComboBoxItem.DataContext);
-                multiComboBoxItem.Select();
-            }
-            else
-            {
-                this.SelectedItems.Add(item);
-            }
+            this.SelectedItems.Add(item);
+            this.GetMultiComboBoxItemContainer(item)?.Select();
         }
 
         foreach (object? item in this.Items)
@@ -604,6 +610,11 @@ public partial class MultiComboBox : SelectingItemsControl
             this.itemsListPresenter.Content = this.innerList;
         }
 
+        if (e.NameScope.Find<ItemsControl>("PART_SelectedItemsList") is { } selectedItemsList)
+        {
+            selectedItemsList.ItemsSource = this.displaySelectedItems;
+        }
+
         this.selectionScrollViewer = e.NameScope.Find<ScrollViewer>("PART_SelectionScrollViewer");
         this.selectAllItem = e.NameScope.Find<MultiComboBoxSelectAllItem>("PART_SelectAllItem");
         this.filterTextbox = e.NameScope.Find<TextBox>("PART_FilterTextBox");
@@ -679,10 +690,9 @@ public partial class MultiComboBox : SelectingItemsControl
                     isCleared = true;
                 }
 
-                multiComboBoxItem.DataContext = multiComboBoxItem.Content;
                 if (multiComboBoxItem.IsSelected)
                 {
-                    this.SelectedItems?.Add(multiComboBoxItem.DataContext);
+                    this.SelectedItems?.Add(multiComboBoxItem);
                 }
             }
         }
@@ -737,7 +747,9 @@ public partial class MultiComboBox : SelectingItemsControl
         {
             @new.CollectionChanged += this.OnSelectedItemsCollectionChanged;
         }
-        
+
+        this.SyncDisplaySelectedItems();
+
         // Re-subscribe to validation when SelectedItems changes
         // This ensures we track the correct property in the DataContext
         this.SubscribeToDataContextValidation();
@@ -748,8 +760,9 @@ public partial class MultiComboBox : SelectingItemsControl
     
     private void DoOnSelectedItemsCollectionChanged()
     {
+        this.SyncDisplaySelectedItems();
         this.ApplyCurrentSelectionState();
-        
+
         // Trigger validation automatically when collection mutates
         // This works with any INotifyDataErrorInfo implementation
         this.TriggerCollectionValidation();
@@ -801,7 +814,8 @@ public partial class MultiComboBox : SelectingItemsControl
         if (this.updateInternal) return;
         this.PseudoClasses.Set(PC_Empty, this.SelectedItems?.Count is null or 0);
 
-        // Containers are now managed by innerItemsList
+        // Update only realized containers — inline data items in ItemsView are not displayed
+        // and their DataContext may not match SelectedItems (it inherits from the parent control).
         Controls? containers = this.innerList.Presenter?.Panel?.Children;
         if (containers is not null)
         {
@@ -814,16 +828,19 @@ public partial class MultiComboBox : SelectingItemsControl
             }
         }
 
-        foreach (object? item in this.ItemsView)
-        {
-            if (item is MultiComboBoxItem i)
-            {
-                i.UpdateSelection();
-            }
-        }
-
         this.selectAllItem?.UpdateSelection();
         this.RaiseDirectPropertyChanged(IsAllSelectedProperty);
+    }
+
+    private void SyncDisplaySelectedItems()
+    {
+        this.displaySelectedItems.Clear();
+        if (this.SelectedItems is null) return;
+
+        foreach (object? item in this.SelectedItems)
+        {
+            this.displaySelectedItems.Add(item is MultiComboBoxItem mcbi ? mcbi.Content : item);
+        }
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -429,7 +429,7 @@ public partial class MultiComboBox : SelectingItemsControl
         {
             this.GetMultiComboBoxItemContainer(item)?.BeginUpdate();
         }
-        
+
         foreach (object? item in this.Items)
         {
             this.SelectedItems.Add(item);
@@ -828,7 +828,7 @@ public partial class MultiComboBox : SelectingItemsControl
 
         foreach (object? item in this.SelectedItems)
         {
-            this.displaySelectedItems.Add(item is MultiComboBoxItem mcbi ? mcbi.Content : item);
+            this.displaySelectedItems.Add(item is MultiComboBoxItem comboBoxItem ? comboBoxItem.Content : item);
         }
     }
 

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -344,7 +344,6 @@ public partial class MultiComboBox : SelectingItemsControl
 
     public IDataTemplate? EffectiveSelectedItemTemplate => this.SelectedItemTemplate ?? this.ItemTemplate;
 
-    /// <summary>
     public bool? IsAllSelected
     {
         get
@@ -443,26 +442,16 @@ public partial class MultiComboBox : SelectingItemsControl
 
         foreach (object? item in this.Items)
         {
-            this.GetMultiComboBoxItemContainer(item)?.BeginUpdate();
-        }
-
-        foreach (object? item in this.Items)
-        {
             this.SelectedItems.Add(item);
-            this.GetMultiComboBoxItemContainer(item)?.Select();
-        }
-
-        foreach (object? item in this.Items)
-        {
-            this.GetMultiComboBoxItemContainer(item)?.EndUpdate();
         }
 
         this.selectAllItem?.EndUpdate();
 
+        this.SyncDisplaySelectedItems();
         this.PseudoClasses.Set(PC_Empty, this.SelectedItems?.Count is null or 0);
         this.selectAllItem?.UpdateSelection();
 
-        // Containers are now managed by innerItemsList
+        // Update realized containers — unrealized ones will be synced in PrepareContainerForItemOverride.
         Controls? containers = this.innerList.Presenter?.Panel?.Children;
         if (containers is not null)
         {
@@ -760,7 +749,11 @@ public partial class MultiComboBox : SelectingItemsControl
     
     private void DoOnSelectedItemsCollectionChanged()
     {
-        this.SyncDisplaySelectedItems();
+        if (!this.updateInternal)
+        {
+            this.SyncDisplaySelectedItems();
+        }
+
         this.ApplyCurrentSelectionState();
 
         // Trigger validation automatically when collection mutates

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
@@ -43,6 +43,8 @@ public class MultiComboBoxItem : ContentControl
         set => this.SetValue(FilterValueProperty, value);
     }
 
+    public override string ToString() => $"{nameof(MultiComboBoxItem)} ({this.Content})";
+
     internal void Select()
     {
         this.SetValue(IsSelectedProperty, true);

--- a/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/SearchHighlightTextBlock.axaml.cs
@@ -85,6 +85,13 @@ public class SearchHighlightTextBlock : ContentControl
           .Subscribe(value => this.Content = value));
       }
     }
+
+    if (this.FindAncestorOfType<MultiComboBoxItem>() is { } multiComboBoxItem)
+    {
+        this.bindings.Add(multiComboBoxItem
+            .GetObservable(MultiComboBoxItem.FilterValueProperty)
+            .Subscribe(value => this.Search = value));
+    }
   }
 
   protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
@@ -92,9 +92,9 @@
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="ItemTemplate">
       <DataTemplate>
-        <SearchHighlightTextBlock 
+        <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}" 
+          Content="{Binding}"
           Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
       </DataTemplate>
     </Setter>
@@ -171,9 +171,9 @@
                   HorizontalWheelBehavior.Enable="True"
                   VerticalScrollBarVisibility="Disabled">
                   <u:MultiComboBoxSelectedItemList
+                    Name="PART_SelectedItemsList"
                     VerticalAlignment="Center"
                     ItemTemplate="{TemplateBinding EffectiveSelectedItemTemplate}"
-                    ItemsSource="{TemplateBinding SelectedItems}"
                     RemoveCommand="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Remove}"
                     ItemsPanel="{TemplateBinding EffectiveSelectedItemsPanel}" />
                 </SmallScrollViewer>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBox.axaml
@@ -94,8 +94,7 @@
       <DataTemplate>
         <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}"
-          Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
+          Content="{Binding}" />
       </DataTemplate>
     </Setter>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -85,7 +85,7 @@
       <DataTemplate>
         <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}" 
+          Content="{Binding}"
           Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
       </DataTemplate>
     </Setter>
@@ -177,9 +177,9 @@
                   HorizontalWheelBehavior.Enable="True"
                   VerticalScrollBarVisibility="Disabled">
                   <u:MultiComboBoxSelectedItemList
+                    Name="PART_SelectedItemsList"
                     VerticalAlignment="Center"
                     ItemTemplate="{TemplateBinding EffectiveSelectedItemTemplate}"
-                    ItemsSource="{TemplateBinding SelectedItems}"
                     RemoveCommand="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Remove}"
                     ItemsPanel="{TemplateBinding EffectiveSelectedItemsPanel}" />
                 </SmallScrollViewer>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -85,8 +85,7 @@
       <DataTemplate>
         <SearchHighlightTextBlock
           x:DataType="sys:Object"
-          Content="{Binding}"
-          Search="{Binding $parent[MultiComboBoxItem].FilterValue}" />
+          Content="{Binding}" />
       </DataTemplate>
     </Setter>
 


### PR DESCRIPTION
## Summary

- **Fix memory leaks**: Remove `ApplyFilter` cloning that created new `MultiComboBoxItem`
  instances (with binding references) on every dropdown open, filter change, and collection change
- **Enable virtualization**: Always-wrap containerization (`NeedsContainerOverride` returns true
  with `DefaultRecycleKey`) so inline items go through VSP recycling like bound items
- **Container lifecycle**: Add `ClearContainerForItemOverride` to clean stale state, and
  `BeginUpdate`/`EndUpdate` guards in Prepare/Clear to prevent container lifecycle from
  mutating `SelectedItems`
- **Align SelectedItems with ComboBox**: Inline items now populate `SelectedItems` as
  `MultiComboBoxItem` objects (matching how `ComboBox` returns `ComboBoxItem`). An internal
  `displaySelectedItems` collection unwraps Content for chip display via `PART_SelectedItemsList`
- **Demo**: Add 100-inline and 1000-bound item test cases for virtualization verification