### PR TITLE
Fix EnumPicker firing spurious OnChange events during initialization

### DIFF
--- a/samples/SampleApp/ViewModels/EnumPickerViewModel.cs
+++ b/samples/SampleApp/ViewModels/EnumPickerViewModel.cs
@@ -1,5 +1,6 @@
 namespace SampleApp.ViewModels;
 
+using System.Diagnostics;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -277,6 +278,11 @@ public partial class EnumPickerViewModel : ObservableObject
     partial void OnDynamicExcludeCriticalChanged(bool value) => SyncListValue(this.DynamicExcludedValues, DemoPriority.Critical, value);
 
     partial void OnDynamicExcludeBlockerChanged(bool value) => SyncListValue(this.DynamicExcludedValues, DemoPriority.Blocker, value);
+
+    partial void OnSelectedDefaultChanged(DemoPriority value)
+    {
+        Debug.WriteLine($"{nameof(this.SelectedDefault)} changed: {value}");
+    }
 
     private static void SyncListValue(AvaloniaList<DemoPriority> list, DemoPriority value, bool add)
     {

--- a/src/Devolutions.AvaloniaControls/Controls/EnumPicker/EnumPicker.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EnumPicker/EnumPicker.axaml.cs
@@ -87,7 +87,9 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
     private readonly IReadOnlyCollection<T> allEnumValues = Enum.GetValues<T>();
 
     private bool initialized;
+    private bool isFullyInitialized;
     private bool isTemplateSet;
+    private bool isTemplateFullySet;
     private bool textOverridesDirty = true;
     private Dictionary<T, string> cachedTextOverrides = [];
     private ICollection<EnumPickerTextOverride<T>> textOverrides = new AvaloniaList<EnumPickerTextOverride<T>>();
@@ -196,7 +198,19 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
     public T SelectedValue
     {
         get;
-        set => this.SetAndRaise(SelectedValueProperty, ref field, value);
+        set
+        {
+            if (this.isFullyInitialized && this.isTemplateFullySet)
+            {
+                this.SetAndRaise(SelectedValueProperty, ref field, value);
+            }
+            else
+            {
+                // We do not want to raise before having fully initialized the control, otherwise we might
+                // update the bound property and raise OnChange events not actually driven by the user.
+                field = value;
+            }
+        }
     }
 
     /// <summary>
@@ -301,7 +315,7 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
     //       can be relevant since this can be a pretty hot path in some applications.
     private void UpdateValues()
     {
-        if (!this.initialized || !isTemplateSet)
+        if (!this.initialized || !this.isTemplateSet)
         {
             return;
         }
@@ -382,6 +396,7 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
         base.OnApplyTemplate(e);
         this.isTemplateSet = true;
         this.UpdateValues();
+        this.isTemplateFullySet = true;
     }
 
     protected override void OnInitialized()
@@ -389,6 +404,7 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
         base.OnInitialized();
         this.initialized = true;
         this.UpdateValues();
+        this.isFullyInitialized = true;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)

--- a/src/Devolutions.AvaloniaControls/Controls/EnumPicker/EnumPicker.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EnumPicker/EnumPicker.axaml.cs
@@ -87,9 +87,8 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
     private readonly IReadOnlyCollection<T> allEnumValues = Enum.GetValues<T>();
 
     private bool initialized;
-    private bool isFullyInitialized;
+    private bool isInitialValueSet;
     private bool isTemplateSet;
-    private bool isTemplateFullySet;
     private bool textOverridesDirty = true;
     private Dictionary<T, string> cachedTextOverrides = [];
     private ICollection<EnumPickerTextOverride<T>> textOverrides = new AvaloniaList<EnumPickerTextOverride<T>>();
@@ -200,7 +199,7 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
         get;
         set
         {
-            if (this.isFullyInitialized && this.isTemplateFullySet)
+            if (this.isInitialValueSet)
             {
                 this.SetAndRaise(SelectedValueProperty, ref field, value);
             }
@@ -387,6 +386,8 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
 
         // Directly sync SelectedItem since SetAndRaise won't fire OnPropertyChanged if the value is unchanged
         this.SelectedItem = selectedItem ?? (list.Count > 0 ? list[0] : null);
+
+        this.isInitialValueSet = true;
     }
 
     private void UpdateValues(object? sender, NotifyCollectionChangedEventArgs e) => this.UpdateValues();
@@ -396,7 +397,6 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
         base.OnApplyTemplate(e);
         this.isTemplateSet = true;
         this.UpdateValues();
-        this.isTemplateFullySet = true;
     }
 
     protected override void OnInitialized()
@@ -404,7 +404,6 @@ public class EnumPicker<T> : EnumPicker where T : struct, Enum
         base.OnInitialized();
         this.initialized = true;
         this.UpdateValues();
-        this.isFullyInitialized = true;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)


### PR DESCRIPTION
## Summary
- EnumPicker was raising `SelectedValue` change notifications during control initialization (before `OnInitialized` and `OnApplyTemplate` completed), causing bound properties to receive updates not driven by user interaction.
- Adds `isFullyInitialized` / `isTemplateFullySet` guard flags so that `SetAndRaise` is only called after the control is fully set up; before that, the backing field is set silently.
- Also fixes a missing `this.` qualifier on `isTemplateSet` in `UpdateValues()`.