### PR TITLE
[MacOS] Fix EditableComboBox popup sizing and Filter-mode leak

### DIFF
--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
@@ -375,7 +375,6 @@
                           ItemsSource="{Binding LargeItemsList}"
                           AllowCustomValue="False"
                           Mode="Filter"
-                          MaxDropDownHeight="200"
                           VerticalAlignment="Top"
                           Margin="10 0 20 0" />
         <TextBlock Grid.Column="1" Grid.Row="22" Margin="10 4 20 15"

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml
@@ -562,7 +562,6 @@
 
     <Setter Property="Padding" Value="10 0 0 0" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
-    <Setter Property="MaxDropDownHeight" Value="504" />
     <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxBorderBrush}" />
     <Setter Property="BorderThickness" Value="{DynamicResource EditableComboBoxBorderThickness}" />
     <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -94,7 +94,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
         AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownWidth), 500);
 
     public static readonly StyledProperty<double> MaxDropDownHeightProperty =
-        AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownHeight), 200);
+        AvaloniaProperty.Register<EditableComboBox, double>(nameof(MaxDropDownHeight), 504);
 
     public static readonly StyledProperty<EditableComboBoxMode> ModeProperty =
         AvaloniaProperty.Register<EditableComboBox, EditableComboBoxMode>(nameof(Mode));

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -164,7 +164,8 @@
   <ControlTheme x:Key="{x:Type EditableComboBox+InnerComboBox}"
                 TargetType="EditableComboBox+InnerComboBox">
     <Setter Property="FocusAdorner" Value="{x:Null}" />
-    <Setter Property="MaxDropDownHeight" Value="504" />
+    <Setter Property="MaxDropDownHeight"
+            Value="{Binding MaxDropDownHeight, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
     <Setter Property="Foreground"
             Value="{Binding Foreground, RelativeSource={RelativeSource FindAncestor, AncestorType=EditableComboBox}, Mode=OneWay}" />
     <Setter Property="Background"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -326,7 +326,6 @@
                       IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">
                       <ItemsPresenter
                         Name="PART_ItemsPresenter"
-                        Margin="{DynamicResource AutoCompleteListPadding}"
                         ItemsPanel="{TemplateBinding ItemsPanel}">
                         <ItemsPresenter.Styles>
                           <Style Selector="StackPanel">


### PR DESCRIPTION
## Summary
- **MaxDropDownHeight binding**: The macOS `InnerComboBox` theme hardcoded `MaxDropDownHeight="504"`, so `MaxDropDownHeight` set on the outer `EditableComboBox` was ignored. Now bound through to the outer control, matching DevExpress/Linux behavior.
- **Filter-mode container ghosting**: When interacting with the dropdown of an `EditableComboBox` in `Mode="Filter"` (e.g. scrolling and changing the selection), stale `EditableComboBoxItem`s were left rendered at the top of the popup and accumulated over time. Removing `Margin="{DynamicResource AutoCompleteListPadding}"` on the popup's `ItemsPresenter` fixes it. That resource is undefined anywhere in the codebase, so the setter was a no-op visually — exact mechanism isn't fully confirmed, but it appears the dangling `DynamicResource` subscription was interfering with VSP recycling during the `Clear()` / `AddRange()` cycle that `ApplyFilter` runs on each interaction.