### PR TITLE
Add ComboBox inner content attached properties

### DIFF
--- a/samples/SampleApp/DemoPages/ComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/ComboBoxDemo.axaml
@@ -20,7 +20,7 @@
     </StackPanel>
     <StackPanel Orientation="Horizontal">
       <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
-        <Grid ColumnDefinitions="Auto 190 190" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
+        <Grid ColumnDefinitions="Auto 240 240" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
           <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
             <Bold>ComboBox: </Bold>
           </TextBlock>
@@ -51,6 +51,26 @@
             <ComboBoxItem>Option 3</ComboBoxItem>
 
           </ComboBox>
+          <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" Margin="0 5 10 15">
+            - Inner content slots:
+            <LineBreak />
+            (attached properties)
+          </TextBlock>
+          <ComboBox Grid.Column="1" Grid.Row="4" PlaceholderText="Inner slots" VerticalAlignment="Top" Margin="10 0 20 20">
+            <ComboBoxItem>Option 1</ComboBoxItem>
+            <ComboBoxItem>Option 2</ComboBoxItem>
+            <ComboBoxItem>Option 3</ComboBoxItem>
+            <ComboBoxContent.InnerLeftContent>
+              <Border Width="16" Height="16" Background="Green" CornerRadius="8" VerticalAlignment="Center" />
+            </ComboBoxContent.InnerLeftContent>
+            <ComboBoxContent.InnerLeftOfDropDownArrowContent>
+              <Border Width="16" Height="16" Background="Orange" CornerRadius="8" VerticalAlignment="Center" />
+            </ComboBoxContent.InnerLeftOfDropDownArrowContent>
+            <ComboBoxContent.InnerRightContent>
+              <TextBlock Text="kg" Margin="2 0" VerticalAlignment="Center" />
+            </ComboBoxContent.InnerRightContent>
+          </ComboBox>
+
           <TextBlock Grid.Column="0" Grid.Row="5" VerticalAlignment="Top" Margin="0 5 10 15">
             - Scrolling options list:
             <LineBreak />

--- a/src/Devolutions.AvaloniaControls/AttachedProperties/ComboBoxContent.cs
+++ b/src/Devolutions.AvaloniaControls/AttachedProperties/ComboBoxContent.cs
@@ -1,0 +1,48 @@
+namespace Devolutions.AvaloniaControls.AttachedProperties;
+
+using System.Collections;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+
+public static class ComboBoxContent
+{
+    public static readonly AttachedProperty<IEnumerable> InnerLeftContentProperty =
+        AvaloniaProperty.RegisterAttached<ComboBox, IEnumerable>("InnerLeftContent", typeof(ComboBoxContent));
+
+    public static readonly AttachedProperty<IEnumerable> InnerLeftOfDropDownArrowContentProperty =
+        AvaloniaProperty.RegisterAttached<ComboBox, IEnumerable>("InnerLeftOfDropDownArrowContent", typeof(ComboBoxContent));
+
+    public static readonly AttachedProperty<IEnumerable> InnerRightContentProperty =
+        AvaloniaProperty.RegisterAttached<ComboBox, IEnumerable>("InnerRightContent", typeof(ComboBoxContent));
+
+    public static IEnumerable GetInnerLeftContent(ComboBox element) => GetOrCreate(element, InnerLeftContentProperty);
+
+    public static void SetInnerLeftContent(ComboBox element, IEnumerable value) => element.SetValue(InnerLeftContentProperty, value);
+
+    public static IEnumerable GetInnerLeftOfDropDownArrowContent(ComboBox element) =>
+        GetOrCreate(element, InnerLeftOfDropDownArrowContentProperty);
+
+    public static void SetInnerLeftOfDropDownArrowContent(ComboBox element, IEnumerable value) =>
+        element.SetValue(InnerLeftOfDropDownArrowContentProperty, value);
+
+    public static IEnumerable GetInnerRightContent(ComboBox element) => GetOrCreate(element, InnerRightContentProperty);
+
+    public static void SetInnerRightContent(ComboBox element, IEnumerable value) => element.SetValue(InnerRightContentProperty, value);
+
+    // Attached-property defaults are shared across all instances, which is not what we want for
+    // mutable collections. Lazily create a per-instance AvaloniaList<Control> on first read so
+    // XAML element-syntax (<ComboBoxContentSlots.InnerLeftContent>...</...>) can Add into it.
+    private static IEnumerable GetOrCreate(ComboBox element, AttachedProperty<IEnumerable> property)
+    {
+        if (element.GetValue(property) is { } existing)
+        {
+            return existing;
+        }
+
+        // ReSharper disable once CollectionNeverUpdated.Local
+        AvaloniaList<Control> list = [];
+        element.SetValue(property, list);
+        return list;
+    }
+}

--- a/src/Devolutions.AvaloniaControls/Properties/AssemblyInfo.cs
+++ b/src/Devolutions.AvaloniaControls/Properties/AssemblyInfo.cs
@@ -4,3 +4,4 @@ using Avalonia.Metadata;
 [assembly: XmlnsDefinition("https://github.com/avaloniaui", "Devolutions.AvaloniaControls.MarkupExtensions")]
 [assembly: XmlnsDefinition("https://github.com/avaloniaui", "Devolutions.AvaloniaControls.Controls")]
 [assembly: XmlnsDefinition("https://github.com/avaloniaui", "Devolutions.AvaloniaControls.Behaviors")]
+[assembly: XmlnsDefinition("https://github.com/avaloniaui", "Devolutions.AvaloniaControls.AttachedProperties")]

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ComboBox.axaml
@@ -126,6 +126,17 @@
                     MinWidth="{TemplateBinding MinWidth}"
                     MinHeight="{TemplateBinding MinHeight}" />
             <DockPanel HorizontalAlignment="Stretch">
+              <ItemsControl DockPanel.Dock="Right"
+                            Margin="0 0 4 0"
+                            VerticalAlignment="Center"
+                            ItemsSource="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}}"
+                            IsVisible="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+              </ItemsControl>
               <Border Name="DropDownGlyphBackground"
                       DockPanel.Dock="Right"
                       Background="Transparent"
@@ -144,6 +155,28 @@
                           Foreground="{TemplateBinding Foreground}"
                           Data="{StaticResource ChevronPath}" />
               </Border>
+              <ItemsControl DockPanel.Dock="Right"
+                            VerticalAlignment="Center"
+                            ItemsSource="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}}"
+                            IsVisible="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}"
+                            Margin="4 2 0 2">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+              </ItemsControl>
+              <ItemsControl DockPanel.Dock="Left"
+                            Margin="5 2 0 2"
+                            VerticalAlignment="Center"
+                            ItemsSource="{Binding (ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}}"
+                            IsVisible="{Binding (ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+              </ItemsControl>
 
               <TextBlock Name="PlaceholderTextBlock"
                          FontSize="{TemplateBinding FontSize}"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBox.axaml
@@ -139,10 +139,21 @@
               BorderThickness="{DynamicResource ButtonBorderThickness}"
               BorderBrush="{DynamicResource InputBorder}"
               CornerRadius="{TemplateBinding CornerRadius}">
-              <Grid ColumnDefinitions="*,Auto">
+              <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto">
+                <ItemsControl
+                  Grid.Column="0"
+                  Margin="10 2 0 2"
+                  ItemsSource="{Binding (ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
                 <TextBlock
                   Name="PlaceholderTextBlock"
-                  Grid.Column="0"
+                  Grid.Column="1"
                   Margin="{TemplateBinding Padding}"
                   Foreground="{TemplateBinding PlaceholderForeground}"
                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -157,7 +168,7 @@
                   </TextBlock.IsVisible>
                 </TextBlock>
                 <ContentControl
-                  Grid.Column="0"
+                  Grid.Column="1"
                   Margin="{TemplateBinding Padding}"
                   Foreground="{TemplateBinding Foreground}"
                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -167,7 +178,7 @@
                   IsVisible="{TemplateBinding IsEditable, Converter={x:Static BoolConverters.Not}}" />
                 <TextBox
                   Name="PART_EditableTextBox"
-                  Grid.Column="0"
+                  Grid.Column="1"
                   Classes="no-focus-border"
                   Padding="{TemplateBinding Padding}"
                   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -181,9 +192,20 @@
                   MinHeight="0"
                   FocusAdorner="{x:Null}"
                   IsVisible="{TemplateBinding IsEditable}" />
+                <ItemsControl
+                  Grid.Column="2"
+                  Margin="8 2 0 2"
+                  ItemsSource="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
                 <ToggleButton
                   Name="Toggle"
-                  Grid.Column="1"
+                  Grid.Column="3"
                   Theme="{StaticResource PopUpToggleButton}"
                   Width="16"
                   Height="16"
@@ -191,6 +213,17 @@
                   ClickMode="Press"
                   Focusable="False"
                   IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}" />
+                <ItemsControl
+                  Grid.Column="4"
+                  ItemsSource="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}"
+                  Margin="0 2 10 2">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
               </Grid>
             </Border>
             <Border Name="FocusBorderElement"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -2,7 +2,8 @@
   xmlns="https://github.com/avaloniaui"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design"
-  xmlns:system="clr-namespace:System;assembly=System.Runtime">
+  xmlns:system="clr-namespace:System;assembly=System.Runtime"
+  xmlns:attachedProperties="clr-namespace:Devolutions.AvaloniaControls.AttachedProperties;assembly=Devolutions.AvaloniaControls">
 
   <!-- 
     Un-comment to allow auto-completion;
@@ -197,10 +198,21 @@
               BorderBrush="{DynamicResource ComboBoxBorderBrush}"
               BoxShadow="{DynamicResource ComboBoxBoxShadow}"
               CornerRadius="{TemplateBinding CornerRadius}">
-              <Grid ColumnDefinitions="*,Auto">
+              <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto">
+                <ItemsControl
+                  Grid.Column="0"
+                  ItemsSource="{Binding (attachedProperties:ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (attachedProperties:ComboBoxContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}"
+                  Margin="8 2 0 2">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
                 <TextBlock
                   Name="PlaceholderTextBlock"
-                  Grid.Column="0"
+                  Grid.Column="1"
                   Margin="{TemplateBinding Padding}"
                   Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -214,7 +226,7 @@
                   </TextBlock.IsVisible>
                 </TextBlock>
                 <ContentControl
-                  Grid.Column="0"
+                  Grid.Column="1"
                   Margin="{TemplateBinding Padding}"
                   Foreground="{TemplateBinding Foreground}"
                   HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
@@ -223,7 +235,7 @@
                   ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
                   IsVisible="{TemplateBinding IsEditable, Converter={x:Static BoolConverters.Not}}" />
                 <TextBox Name="PART_EditableTextBox"
-                         Grid.Column="0"
+                         Grid.Column="1"
                          Theme="{StaticResource ComboBoxEditableTextBox}"
                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -235,9 +247,20 @@
                          MinHeight="0"
                          FocusAdorner="{x:Null}"
                          IsVisible="{TemplateBinding IsEditable}" />
+                <ItemsControl
+                  Grid.Column="2"
+                  ItemsSource="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (ComboBoxContent.InnerLeftOfDropDownArrowContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}"
+                  Margin="2">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
                 <ToggleButton
                   Name="Toggle"
-                  Grid.Column="1"
+                  Grid.Column="3"
                   Theme="{StaticResource PopUpToggleButton}"
                   Width="16"
                   Height="16"
@@ -245,6 +268,17 @@
                   ClickMode="Press"
                   Focusable="False"
                   IsChecked="{TemplateBinding IsDropDownOpen, Mode=TwoWay}" />
+                <ItemsControl
+                  Grid.Column="4"
+                  ItemsSource="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (ComboBoxContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}"
+                  Margin="0 2 4 2">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
               </Grid>
             </Border>
             <Border Name="FocusBorderElement"


### PR DESCRIPTION
## Summary

Adds three attached properties — `ComboBoxContent.InnerLeftContent`, `InnerLeftOfDropDownArrowContent`, and `InnerRightContent` — that let consumers decorate the standard Avalonia `ComboBox` with leading and trailing controls (icons, badges, action buttons) without subclassing it. Mirrors the slot API already exposed by `EditableComboBox`.

## How it works

- New `ComboBoxContent` class under `Devolutions.AvaloniaControls/AttachedProperties/`, registered in `AssemblyInfo` under the default Avalonia xmlns so themes and consumers can reference it unprefixed.
- Each theme's `ComboBox` `ControlTemplate` hosts three `ItemsControl`s bound to these attached properties via `TemplatedParent`. Visibility is driven by `DevoConverters.IsNullOrEmptyConverter`, matching the pattern `EditableComboBox` already uses.
- Per-theme template changes:
  - **MacOS / Linux** — `Grid` columns extended from `*,Auto` to `Auto,*,Auto,Auto,Auto`; existing `Grid.Column` references remapped.
  - **DevExpress** — `DockPanel` children reordered so `InnerRight`, dropdown glyph, and `InnerLeftOfDropDownArrow` stack correctly from the right edge.
- SampleApp `ComboBoxDemo` page gains a row demonstrating all three slots.