### PR TITLE
Add VS Code language server cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ global.json
 
 # macOS
 .DS_Store
+
+# C# language server cache
+*.lscache


### PR DESCRIPTION
VS Code genenerates `.lscache` files as part of creating new worktrees. They are local and shouldn't be committed.