### PR TITLE
Add automated baseline update workflow (/updateBaselines skill)

### DIFF
--- a/.claude/commands/updateBaselines.md
+++ b/.claude/commands/updateBaselines.md
@@ -1,0 +1,246 @@
+---
+description: "/updateBaselines - Run visual regression tests and update baseline screenshots across Mac, Windows, and Linux VMs, then open a draft PR"
+---
+
+You are the **baseline update specialist**. Your job is to run the visual regression tests, update screenshot baselines on all platforms (Mac, Windows, Linux) via SSH, and open a draft PR — all in one automated workflow.
+
+**Before starting**: Read `.claude/docs/processes/baseline-vm-setup.md` to verify SSH aliases and VM repo paths are configured.
+
+---
+
+## Step 1: VM readiness check
+
+Show this message and wait for the user to press Enter (empty reply) before continuing:
+
+> **Before I start, please make sure:**
+> - ✅ Windows VM is running
+> - ✅ Linux VM is running  
+> - ✅ WARP is **disconnected** on both VMs (the Parallels subnet is not excluded from the managed WARP policy — WARP will block SSH)
+>
+> Type **Y** when ready, or anything else to cancel.
+
+If the user types Y (or y), continue to Step 2. If they type anything else, stop and wait for their instruction.
+
+---
+
+## Step 2: Verify SSH connectivity
+
+Check both VMs are reachable:
+```bash
+ssh -o ConnectTimeout=10 -o PasswordAuthentication=no baseline-win "echo win-ok" && \
+ssh -o ConnectTimeout=10 -o PasswordAuthentication=no baseline-linux "echo linux-ok"
+```
+
+If either fails:
+- Check the VM is running and WARP is off
+- Refer to `.claude/docs/processes/baseline-vm-setup.md` for troubleshooting
+
+---
+
+## Step 3: Verify SSH config aliases exist
+
+1. Check that `~/.ssh/config` contains entries for `baseline-win` and `baseline-linux`:
+   ```bash
+   grep -A3 "baseline-win\|baseline-linux" ~/.ssh/config
+   ```
+2. If the aliases are missing, stop and tell the user to follow the setup guide at `.claude/docs/processes/baseline-vm-setup.md`.
+
+---
+
+## Step 4: Determine PR range for title and description
+
+**Find the latest merged PR (y):**
+```bash
+gh pr list --repo Devolutions/avalonia-extensions --state merged --limit 1 --json number,title --jq '.[0]'
+```
+
+**Find the last "Baseline updates" PR to determine x (first PR after it):**
+```bash
+gh pr list --repo Devolutions/avalonia-extensions --state merged --limit 20 --json number,title --jq '.[] | "\(.number) \(.title)"'
+```
+
+Find the most recent PR whose title starts with "Baseline updates". The first PR after that is `x`. Store:
+- `LAST_PR` = y (latest merged PR number) — used for the branch name `baseline-updates-{LAST_PR}`
+- `FIRST_PR` = x (first PR after the last baseline update PR)
+- `PR_RANGE_TITLE` = "Baseline updates for changes in PR #x - #y" (or just "#y" if x == y)
+
+**For each PR in the range x..y, get source file changes (excluding baselines):**
+```bash
+gh pr view {PR_NUMBER} --repo Devolutions/avalonia-extensions --json number,title,files \
+  --jq '"#\(.number) \(.title)\n  src: \([.files[].path | select(startswith("src/") or startswith("samples/"))] | join(", "))"'
+```
+
+Store this data — you'll use it in Step 11 to attribute baseline changes to likely PRs.
+
+---
+
+## Step 5: Ensure we're on master with latest changes
+
+```bash
+git checkout master && git pull origin master
+```
+
+If there are uncommitted changes on the current branch, stop and warn the user before switching.
+
+---
+
+## Step 6: Create the baseline-updates branch
+
+From the main repo (not a worktree), create the branch from the current master commit:
+
+```bash
+git checkout -b baseline-updates-{PR_NUMBER}
+git push -u origin baseline-updates-{PR_NUMBER}
+```
+
+Push immediately so Windows and Linux can fetch it.
+
+---
+
+## Step 7: Run tests on Mac (read-only first pass)
+
+Run from the main repo directory:
+
+```bash
+dotnet test --no-build
+```
+
+Capture the output. Check if all tests passed.
+
+- **If all tests passed**: No Mac baselines need updating — skip to Step 9 (Windows).
+- **If any tests failed**: Continue to Step 8.
+
+---
+
+## Step 8: Update baselines on Mac
+
+```bash
+UPDATE_BASELINES=true dotnet test --no-build
+```
+
+After this runs, check what changed:
+```bash
+git diff --name-only HEAD -- tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/macOS/
+```
+
+If files changed, commit them:
+```bash
+git add tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/macOS/
+git commit -m "baseline updates (Mac)"
+git push origin baseline-updates-{PR_NUMBER}
+```
+
+If no files changed (the baselines were already current despite a test failure — can happen with flaky rendering), skip the commit and continue.
+
+---
+
+## Step 9: Update baselines on Windows VM
+
+Run as **separate sequential PowerShell commands** over SSH (not chained with `&&` — PowerShell doesn't support that):
+
+```bash
+ssh baseline-win "powershell -Command \"cd C:/git/avalonia-extensions; git fetch origin; git checkout baseline-updates-{PR_NUMBER}; git pull origin baseline-updates-{PR_NUMBER}\""
+ssh baseline-win "powershell -Command \"\$env:UPDATE_BASELINES='true'; dotnet test -C C:/git/avalonia-extensions 2>&1 | Select-Object -Last 5\""
+ssh baseline-win "powershell -Command \"cd C:/git/avalonia-extensions; git add tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/Windows/; git commit -m 'baseline updates (Win)'; git push origin baseline-updates-{PR_NUMBER}\""
+```
+
+Key notes:
+- `dotnet test` takes ~3-4 minutes on Windows — wait for it
+- If `git status` shows no changes, skip the commit
+- The `core.sshCommand` is already configured in `~/.gitconfig` for the SSH session user to use `C:/Users/amalchowperryman.VDEVOLUTIONS533/.ssh/id_rsa_local`
+
+If the SSH command fails:
+- Verify SSH connectivity: `ssh -o ConnectTimeout=10 baseline-win "echo connected"`
+- Verify git works: `ssh baseline-win "powershell -Command \"git -C C:/git/avalonia-extensions status\""`
+
+---
+
+## Step 10: Update baselines on Linux VM
+
+```bash
+ssh baseline-linux "cd /home/parallels/git/avalonia-extensions && git fetch origin && git checkout baseline-updates-{PR_NUMBER} && git pull origin baseline-updates-{PR_NUMBER}"
+ssh baseline-linux "cd /home/parallels/git/avalonia-extensions && UPDATE_BASELINES=true dotnet test 2>&1 | tail -5"
+ssh baseline-linux "cd /home/parallels/git/avalonia-extensions && git add tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/Linux/ && git commit -m 'baseline updates (Linux)' && git push origin baseline-updates-{PR_NUMBER}"
+```
+
+---
+
+## Step 11: Open a draft PR with smart description
+
+**Title**: `Baseline updates for changes in PR #{FIRST_PR} - #{LAST_PR}`  
+(If FIRST_PR == LAST_PR, use just `Baseline updates for changes in PR #{LAST_PR}`)
+
+**Description**: Build it from the data collected in Step 4 and the actual baseline changes across all 3 platforms. Structure:
+
+```markdown
+Automated baseline screenshot updates for PRs merged since last baseline update.
+
+## PRs in range
+
+| PR | Title |
+|----|-------|
+| #x | ... |
+...
+
+## Changed baselines
+
+For each distinct screenshot that changed, group by demo name and note:
+- Which platforms/themes it changed on
+- The most likely PR cause: look for PRs that modified `src/.../{DemoName}.axaml` or a 
+  related theme file (e.g. ComboBox.axaml for ComboBoxDemo.png). If no clear match, 
+  note "likely rendering drift".
+
+---
+_Commits: [list only platforms that had actual changes]_
+```
+
+```bash
+gh pr create \
+  --draft \
+  --base master \
+  --head baseline-updates-{LAST_PR} \
+  --title "{PR_RANGE_TITLE}" \
+  --body "{BODY}"
+```
+
+Capture the PR URL from the output.
+
+---
+
+## Step 12: Notify completion
+
+```bash
+osascript -e $'display dialog "✅ Baseline Update Complete\n\nDraft PR created with 3 commits:\n  • baseline updates (Mac)\n  • baseline updates (Win)\n  • baseline updates (Linux)\n\n{PR_URL}" buttons {"OK"} default button "OK" with title "GitHub Copilot"' &
+```
+
+Replace `{PR_URL}` with the actual PR URL from Step 11.
+
+Also mention in the notification if any platform had no changes (baselines already current).
+
+---
+
+## Error handling
+
+| Situation | Action |
+|-----------|--------|
+| SSH connection refused | Tell user to start SSH server on that VM (see setup doc) |
+| `git checkout` fails on VM | The branch may not be pushed yet — ensure Step 8 succeeded |
+| `dotnet test` fails to run on VM | Check that .NET SDK is installed on the VM |
+| No changes after `UPDATE_BASELINES` | Tests may have all passed — re-examine test output |
+| Windows PowerShell path issues | Use forward slashes in git commands; PowerShell accepts both |
+
+---
+
+## Notes
+
+- The `macOS/`, `Windows/`, and `Linux/` subdirectories under `Baseline/` are platform-specific. Each platform only updates its own directory.
+- If a VM is offline or SSH fails, make a note in the PR description and continue with the available platforms.
+- The Windows SSH command uses PowerShell by default when OpenSSH is installed on Windows 10+.
+- To switch back to the previous branch after completing, check git log or ask the user which branch they want to be on.
+
+## Known false positives / recurring patterns
+
+| Screenshot | Pattern | Notes |
+|------------|---------|-------|
+| `ToggleSwitchDemo_dark` (Windows, MacClassic) | Occasional small pixel drift | Known rendering instability on Windows. Safe to update baseline. No theme change needed. |
+

--- a/.claude/commands/updateBaselines.md
+++ b/.claude/commands/updateBaselines.md
@@ -27,8 +27,7 @@ If the user types Y (or y), continue to Step 2. If they type anything else, stop
 
 Check both VMs are reachable:
 ```bash
-ssh -o ConnectTimeout=10 -o PasswordAuthentication=no baseline-win "echo win-ok" && \
-ssh -o ConnectTimeout=10 -o PasswordAuthentication=no baseline-linux "echo linux-ok"
+ssh baseline-win "echo win-ok" && ssh baseline-linux "echo linux-ok"
 ```
 
 If either fails:
@@ -99,10 +98,10 @@ Push immediately so Windows and Linux can fetch it.
 
 ## Step 7: Run tests on Mac (read-only first pass)
 
-Run from the main repo directory:
+Run from the main repo directory. Use an **async bash session** to avoid approval issues with the `UPDATE_BASELINES` env var prefix:
 
 ```bash
-dotnet test --no-build
+cd /path/to/avalonia-extensions && dotnet test
 ```
 
 Capture the output. Check if all tests passed.
@@ -114,8 +113,11 @@ Capture the output. Check if all tests passed.
 
 ## Step 8: Update baselines on Mac
 
+Use an **async bash session** (the inline `VAR=value` env syntax is not auto-approved; `export` in an async shell avoids this):
+
 ```bash
-UPDATE_BASELINES=true dotnet test --no-build
+# Start async shell, then:
+cd /path/to/avalonia-extensions && export UPDATE_BASELINES=true && dotnet test
 ```
 
 After this runs, check what changed:
@@ -140,11 +142,13 @@ Run as **separate sequential PowerShell commands** over SSH (not chained with `&
 
 ```bash
 ssh baseline-win "powershell -Command \"cd C:/git/avalonia-extensions; git fetch origin; git checkout baseline-updates-{PR_NUMBER}; git pull origin baseline-updates-{PR_NUMBER}\""
-ssh baseline-win "powershell -Command \"\$env:UPDATE_BASELINES='true'; dotnet test -C C:/git/avalonia-extensions 2>&1 | Select-Object -Last 5\""
+ssh baseline-win "powershell -Command \"Get-Process -Name dotnet,SampleApp -ErrorAction SilentlyContinue | Stop-Process -Force; Start-Sleep 2; cd C:/git/avalonia-extensions; \$env:UPDATE_BASELINES='true'; dotnet test; Remove-Item env:UPDATE_BASELINES 2>&1 | Select-Object -Last 5\""
 ssh baseline-win "powershell -Command \"cd C:/git/avalonia-extensions; git add tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/Windows/; git commit -m 'baseline updates (Win)'; git push origin baseline-updates-{PR_NUMBER}\""
 ```
 
 Key notes:
+- SampleApp/Rider must be stopped first to release locked DLLs — the `Stop-Process` handles this
+- `Remove-Item env:UPDATE_BASELINES` **must** run after the test — unlike Mac/Linux, Windows persists the env var in the session if not explicitly removed
 - `dotnet test` takes ~3-4 minutes on Windows — wait for it
 - If `git status` shows no changes, skip the commit
 - The `core.sshCommand` is already configured in `~/.gitconfig` for the SSH session user to use `C:/Users/amalchowperryman.VDEVOLUTIONS533/.ssh/id_rsa_local`

--- a/.claude/docs/processes/baseline-vm-setup.md
+++ b/.claude/docs/processes/baseline-vm-setup.md
@@ -1,0 +1,146 @@
+# Baseline VM SSH Setup
+
+This document configures the SSH connections needed for the `/updateBaselines` command to run visual regression tests on the Windows and Linux VMs.
+
+**Update this file** when VM details change. The `/updateBaselines` command reads the repo paths from here.
+
+---
+
+## SSH Aliases Required
+
+The `/updateBaselines` command expects two SSH aliases in `~/.ssh/config`:
+- `baseline-win` → Windows VM
+- `baseline-linux` → Linux VM
+
+---
+
+## VM Configuration
+
+### Windows VM
+
+| Field | Value |
+|-------|-------|
+| SSH alias | `baseline-win` |
+| Hostname/IP | `10.211.55.3` (Parallels Ethernet adapter) |
+| Username | `amalchowperryman` |
+| Repo path | `C:\git\avalonia-extensions` |
+
+**Windows repo path**: `C:\git\avalonia-extensions`
+
+### Linux VM
+
+| Field | Value |
+|-------|-------|
+| SSH alias | `baseline-linux` |
+| Hostname/IP | `10.211.55.4` (Parallels Ethernet adapter) |
+| Username | `parallels` |
+| Repo path | `/home/parallels/git/avalonia-extensions` |
+
+**Linux repo path**: `/home/parallels/git/avalonia-extensions`
+
+---
+
+## Setup Steps
+
+### 1. Set up SSH keys (if not already done)
+
+If you don't have an SSH key yet:
+```bash
+ssh-keygen -t ed25519 -C "baseline-updates" -f ~/.ssh/id_baseline
+```
+
+Copy the public key to each VM:
+```bash
+# For Linux VM:
+ssh-copy-id -i ~/.ssh/id_baseline.pub username@linux-vm-host
+
+# For Windows VM (run from PowerShell on the Windows VM):
+# Add the contents of ~/.ssh/id_baseline.pub to C:\Users\username\.ssh\authorized_keys
+```
+
+### 2. Configure `~/.ssh/config`
+
+Add entries like these to `~/.ssh/config` (create the file if it doesn't exist):
+
+```
+Host baseline-win
+    HostName 10.211.55.3
+    User amalchowperryman
+    IdentityFile ~/.ssh/id_rsa
+
+Host baseline-linux
+    HostName 10.211.55.4
+    User parallels
+    IdentityFile ~/.ssh/id_rsa
+```
+
+✅ These entries have already been added to `~/.ssh/config`.
+
+### 3. Enable SSH server on each VM
+
+**Windows (OpenSSH):**
+- Run in PowerShell as Administrator:
+  ```powershell
+  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+  Start-Service sshd
+  Set-Service -Name sshd -StartupType Automatic
+  ```
+- Windows Firewall rule is created automatically.
+
+**Linux:**
+- Usually SSH is already running. If not:
+  ```bash
+  sudo systemctl enable --now ssh
+  ```
+
+### 4. Update the repo paths in this file
+
+Replace the `PLACEHOLDER_*` values above with the actual paths where the `avalonia-extensions` repo is cloned on each VM.
+
+### 5. Test connectivity
+
+```bash
+ssh baseline-win "echo 'Windows VM connected'"
+ssh baseline-linux "echo 'Linux VM connected'"
+```
+
+### 6. Test a git command on each VM
+
+```bash
+ssh baseline-win "cd 'C:\\path\\to\\repo' && git status"
+ssh baseline-linux "cd /path/to/repo && git status"
+```
+
+### 7. Verify .NET is available on each VM
+
+```bash
+ssh baseline-win "dotnet --version"
+ssh baseline-linux "dotnet --version"
+```
+
+---
+
+## Quick Connectivity Check
+
+Run this to verify everything is ready before using `/updateBaselines`:
+
+```bash
+echo "Testing Windows VM..." && ssh baseline-win "echo OK" && \
+echo "Testing Linux VM..." && ssh baseline-linux "echo OK" && \
+echo "All VMs reachable ✅"
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `Connection refused` | SSH server is not running — start it (see Step 3 above) |
+| `Permission denied` | SSH key not authorized — re-run `ssh-copy-id` or check `authorized_keys` |
+| `Host not found` | VM hostname/IP changed — update `~/.ssh/config` |
+| `Operation timed out` | **Most likely: WARP is connected on the VM.** Disconnect WARP before running `/updateBaselines`. The Parallels subnet (`10.211.55.0/24`) is not in the managed WARP exclusion list and WARP will silently block inbound SSH. |
+| `git: command not found` on VM | Git not on PATH for SSH sessions; try full path `/usr/bin/git` or configure `.bashrc` |
+| `git: detected dubious ownership` on Windows | Run: `git config --global --add safe.directory C:/git/avalonia-extensions` (one-time fix) |
+| `unable to resolve user` on Windows | The local Windows account is disabled. Run: `net user amalchowperryman /active:yes` |
+| Windows PowerShell not default shell | Set PowerShell as default: `New-ItemProperty HKLM:\SOFTWARE\OpenSSH -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force` |

--- a/.github/skills/update-baselines/SKILL.md
+++ b/.github/skills/update-baselines/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: update-baselines
+description: Updates visual regression test baseline screenshots across Mac, Windows, and Linux platforms, then creates a draft PR. Use when the user asks to update baselines or types /updateBaselines.
+allowed-tools: shell
+---
+
+When asked to update baselines or run the baseline update workflow, follow the complete step-by-step instructions in `.claude/commands/updateBaselines.md`.
+
+Key facts about this repository's visual regression tests:
+
+- Baseline screenshots are stored in `tests/Devolutions.AvaloniaControls.VisualTests/Screenshots/Baseline/`
+- They are organized by platform: `macOS/`, `Windows/`, `Linux/`
+- Run tests: `dotnet test`
+- Update baselines (Mac/Linux): `UPDATE_BASELINES=true dotnet test`
+- Update baselines (Windows PowerShell): `$env:UPDATE_BASELINES="true"; dotnet test; Remove-Item env:UPDATE_BASELINES`
+- SSH aliases for VMs: `baseline-win` (Windows) and `baseline-linux` (Linux)
+- VM paths and SSH config setup: `.claude/docs/processes/baseline-vm-setup.md`


### PR DESCRIPTION
Adds the `/updateBaselines` Copilot CLI skill and supporting documentation for automated visual regression baseline updates across Mac, Windows, and Linux.

## What this adds

### `.claude/commands/updateBaselines.md`
The main skill invoked by `/updateBaselines`. Orchestrates the full workflow:
1. VM readiness check + SSH connectivity verification
2. Determines PR range for branch name, PR title, and description
3. Checks out master, creates `baseline-updates-{PR}` branch
4. Runs tests + updates baselines on Mac (async shell approach for env var handling)
5. Runs tests + updates baselines on Windows via SSH (stops SampleApp first, cleans up env var after)
6. Runs tests + updates baselines on Linux via SSH
7. Opens a draft PR with smart description attributing changes to likely source PRs

### `.github/skills/update-baselines/SKILL.md`
Skill registration file so the command is discoverable as `/updateBaselines`.

### `.claude/docs/processes/baseline-vm-setup.md`
One-time SSH setup guide for the Windows and Linux VMs (key generation, `~/.ssh/config` aliases, Windows registry locale settings, etc.).

## Auto-approve list
For fully hands-free operation, add to `chat.tools.terminal.autoApprove`:
```json
"ssh baseline-win": true,
"ssh baseline-linux": true,
"cd": true,
"git pull": true,
```