### PR TITLE
Add `local/` folders for personal AI assistant config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,8 @@ samples/
 │   ├── explain.md                            # /explain command
 │   ├── simplify.md                           # /simplify command
 │   └── worksetup.md                          # /worksetup command
+├── local/                                    # Personal commands & docs (gitignored, developer-specific)
+│   └── README.md                             # Describes the local/ convention
 └── docs/                                     # Claude-specific documentation
     └── processes/                            # Process documentation
         └── ide_connection.md                 # IDE integration guide
@@ -59,6 +61,7 @@ When creating or organizing files for Claude Code:
 - **Processes**: `.claude/docs/processes/` (e.g., workflow guides, troubleshooting)
 - **Planning**: `.claude/docs/planning/` (e.g., feature planning, design decisions)
 - **Commands**: `.claude/commands/` (slash commands only)
+- **Personal/local**: `.claude/local/` (developer-specific commands and docs — gitignored, check if it exists and consult its contents)
 
 **Never** create Claude-related files in the root-level `docs/` or other project directories - they belong exclusively in `.claude/`.
 
@@ -78,7 +81,7 @@ dotnet build src/Devolutions.AvaloniaControls
 ```bash
 # IMPORTANT: For proper theme detection, build first then run from bin directory
 # This ensures the app can detect the configured theme from App.axaml
-dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net10.0 && dotnet SampleApp.dll
+dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net9.0 && dotnet SampleApp.dll
 
 # Alternative: Use dotnet run (faster, but theme detection won't work)
 # This runs from repo root, causing app to fall back to OS-default theme
@@ -102,7 +105,7 @@ The SampleApp provides:
 - Those temporary runtime-selection lines are local-only setup state and should not be committed by default (follow `.claude/commands/commit.md`).
 
 **Note on Theme Detection:**
-The app's theme detection (`DetectDesignTheme()` in App.axaml.cs) expects the working directory to be `bin/Debug/net10.0/`. When running from the repo root via `dotnet run`, the detection fails and the app falls back to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is why building and running from the bin directory is required for proper theme detection configured via `/worksetup` command.
+The app's theme detection (`DetectDesignTheme()` in App.axaml.cs) expects the working directory to be `bin/Debug/net9.0/`. When running from the repo root via `dotnet run`, the detection fails and the app falls back to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is why building and running from the bin directory is required for proper theme detection configured via `/worksetup` command.
 
 ### Testing
 There are no automated tests in this repository. Testing is done manually via the SampleApp.
@@ -145,7 +148,7 @@ The `Devolutions.AvaloniaControls` package contains:
 - All themes support both light and dark modes
 
 ## Target Framework
-All projects target `.NET 10.0` and use Avalonia `11.3.x` packages.
+All projects target `.NET 9.0` and use Avalonia `11.3.x` packages.
 
 ## CI/CD
 The repository uses GitHub Actions for building and publishing NuGet packages. The workflow:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,7 +81,7 @@ dotnet build src/Devolutions.AvaloniaControls
 ```bash
 # IMPORTANT: For proper theme detection, build first then run from bin directory
 # This ensures the app can detect the configured theme from App.axaml
-dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net9.0 && dotnet SampleApp.dll
+dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net10.0 && dotnet SampleApp.dll
 
 # Alternative: Use dotnet run (faster, but theme detection won't work)
 # This runs from repo root, causing app to fall back to OS-default theme
@@ -105,7 +105,9 @@ The SampleApp provides:
 - Those temporary runtime-selection lines are local-only setup state and should not be committed by default (follow `.claude/commands/commit.md`).
 
 **Note on Theme Detection:**
-The app's theme detection (`DetectDesignTheme()` in App.axaml.cs) expects the working directory to be `bin/Debug/net9.0/`. When running from the repo root via `dotnet run`, the detection fails and the app falls back to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is why building and running from the bin directory is required for proper theme detection configured via `/worksetup` command.
+The app's theme detection (`DetectDesignTheme()` in App.axaml.cs) expects the working directory to be 
+`bin/Debug/net10.0/`. When running from the repo root via `dotnet run`, the detection fails and the app falls back 
+to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is why building and running from the bin directory is required for proper theme detection configured via `/worksetup` command.
 
 ### Testing
 There are no automated tests in this repository. Testing is done manually via the SampleApp.
@@ -148,7 +150,7 @@ The `Devolutions.AvaloniaControls` package contains:
 - All themes support both light and dark modes
 
 ## Target Framework
-All projects target `.NET 9.0` and use Avalonia `11.3.x` packages.
+All projects target `.NET 10.0` and use Avalonia `11.3.x` packages.
 
 ## CI/CD
 The repository uses GitHub Actions for building and publishing NuGet packages. The workflow:

--- a/.claude/local/README.md
+++ b/.claude/local/README.md
@@ -1,0 +1,11 @@
+# .claude/local/
+
+This folder is for **personal AI assistant configuration** that is specific to an individual developer's environment — SSH aliases, local VM details, personal workflows, etc.
+
+The contents of this folder are **gitignored** (except this README). Each developer can add their own commands, skill docs, and process notes here without affecting others.
+
+## Structure
+
+- `*.md` files here are treated as slash commands or documentation, just like files in `.claude/commands/` and `.claude/docs/`
+- Place any personal workflow skills (e.g. `/updateBaselines`) here
+- See `.github/skills/local/` for the corresponding skill registration files

--- a/.github/skills/local/README.md
+++ b/.github/skills/local/README.md
@@ -1,0 +1,7 @@
+# .github/skills/local/
+
+This folder is for **personal Copilot skill registrations** that are specific to an individual developer's environment.
+
+The contents of this folder are **gitignored** (except this README). Place your personal `SKILL.md` files here to register local slash commands with the Copilot CLI agent.
+
+The corresponding skill implementation docs live in `.claude/local/`.

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ global.json
 # macOS
 .DS_Store
 
-# C# language server cache
-*.lscache
+# Local AI assistant config (personal commands, VM-specific skills, etc.)
+.claude/local/*
+!.claude/local/README.md
+.github/skills/local/*
+!.github/skills/local/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ global.json
 # macOS
 .DS_Store
 
+# C# language server cache
+*.lscache
+
 # Local AI assistant config (personal commands, VM-specific skills, etc.)
 .claude/local/*
 !.claude/local/README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,17 @@ Key AI assistant resources in `.claude/`:
 - **`docs/`** - Process documentation and planning materials
 - **`local/`** - Personal commands and docs (gitignored, developer-specific — check if it exists)
 
+Key Development Workflows:
+
+- **Building/Running:**
+  `dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net10.0 && dotnet SampleApp.dll` (
+  Required for proper theme detection)
+- **Notifications:** Use non-blocking `osascript -e $'display dialog "..."' &` (with ANSI-C quoting and `&`) for
+  critical alerts.
+- **Accelerate Controls:** Requires `.env` with `AVALONIA_LICENSE_KEY=your_key_here` at repository root.
+- **Testing:** `dotnet test` (Use `UPDATE_BASELINES=true dotnet test` on macOS/Linux to update baseline screenshots if
+  visual changes are intentional).
+
 Testing references:
 - **`README.md`** (`# Testing`) - Current `dotnet test` filters and baseline update commands
 - **`tests/Devolutions.AvaloniaControls.VisualTests/`** - Baselines and diff outputs used by visual regression tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@
 For detailed instructions on working with this repository as an AI assistant, please see:
 
 **[`.claude/CLAUDE.md`](.claude/CLAUDE.md)** - Main documentation covering:
-
 - Repository overview and structure
 - Development commands and workflows
 - Architecture and design patterns
@@ -19,28 +18,14 @@ For detailed instructions on working with this repository as an AI assistant, pl
 For human developers, see the main [`README.md`](README.md) for getting started.
 
 Key AI assistant resources in `.claude/`:
-
-- **`CLAUDE.md`** - Primary instructions and project overview (check **User Notifications via Dialog** for required
-  `osascript` notification syntax)
+- **`CLAUDE.md`** - Primary instructions and project overview
 - **`commands/`** - Custom slash commands for theme switching, commits, etc.
-- **`commands/commit.md`** - Commit safety rules and `/worksetup` file exclusions (never force-push, use `[temp]` for
-  work-in-progress)
+- **`commands/commit.md`** - Commit safety rules and `/worksetup` file exclusions
 - **`commands/worksetup.md`** - Theme/tab/scale setup workflow for `samples/SampleApp/`
 - **`docs/`** - Process documentation and planning materials
-
-Key Development Workflows:
-
-- **Building/Running:**
-  `dotnet build samples/SampleApp/SampleApp.csproj && cd samples/SampleApp/bin/Debug/net10.0 && dotnet SampleApp.dll` (
-  Required for proper theme detection)
-- **Notifications:** Use non-blocking `osascript -e $'display dialog "..."' &` (with ANSI-C quoting and `&`) for
-  critical alerts.
-- **Accelerate Controls:** Requires `.env` with `AVALONIA_LICENSE_KEY=your_key_here` at repository root.
-- **Testing:** `dotnet test` (Use `UPDATE_BASELINES=true dotnet test` on macOS/Linux to update baseline screenshots if
-  visual changes are intentional).
+- **`local/`** - Personal commands and docs (gitignored, developer-specific — check if it exists)
 
 Testing references:
-
 - **`README.md`** (`# Testing`) - Current `dotnet test` filters and baseline update commands
 - **`tests/Devolutions.AvaloniaControls.VisualTests/`** - Baselines and diff outputs used by visual regression tests
 


### PR DESCRIPTION
Introduces a convention for developer-specific AI assistant configuration that stays out of the shared repo.

## What this adds

### `.claude/local/` and `.github/skills/local/`
Two gitignored folders for personal commands, skill registrations, and process docs tied to an individual developer's environment (SSH aliases, local VMs, personal workflows, etc.).

- Contents are gitignored via `.gitignore` — only the `README.md` in each folder is tracked
- `CLAUDE.md` and `AGENTS.md` updated to mention the `local/` folders so agents know to check them

## Why
Some AI assistant workflows (e.g. automated baseline screenshot updates across local VMs) are maintainer-specific and shouldn't be in the shared repo. This pattern allows each developer to keep any personal workflows or agent interaction preferences locally.