### PR TITLE
Add setup-worktree scripts to copy local config into new worktrees

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,10 @@ This repo uses git worktrees for parallel tasks. Gitignored local config (`.clau
 ```bash
 bash scripts/setup-worktree.sh
 ```
+On Windows, use the PowerShell equivalent:
+```powershell
+pwsh scripts/setup-worktree.ps1
+```
 This copies local config from the main worktree without overwriting anything already present.
 
 ### File Placement Rules

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,6 +55,15 @@ samples/
         └── ide_connection.md                 # IDE integration guide
 ```
 
+### Worktree setup
+This repo uses git worktrees for parallel tasks. Gitignored local config (`.claude/local/`, `.github/skills/local/`, `.vscode/`) is **not** copied automatically to new worktrees.
+
+**If you are running in a worktree** and `.claude/local/` contains only `README.md` (or `.vscode/` is missing), run:
+```bash
+bash scripts/setup-worktree.sh
+```
+This copies local config from the main worktree without overwriting anything already present.
+
 ### File Placement Rules
 When creating or organizing files for Claude Code:
 - **Documentation**: `.claude/docs/` (e.g., planning docs, architecture notes, process guides)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Key AI assistant resources in `.claude/`:
 - **`docs/`** - Process documentation and planning materials
 - **`local/`** - Personal commands and docs (gitignored, developer-specific — check if it exists)
 
-> **Worktree setup:** If `.claude/local/` only contains `README.md` (or `.vscode/` is missing), run `bash scripts/setup-worktree.sh` to copy local config from the main worktree.
+> **Worktree setup:** If `.claude/local/` only contains `README.md` (or `.vscode/` is missing), run `bash scripts/setup-worktree.sh` to copy local config from the main worktree. On Windows, use `pwsh scripts/setup-worktree.ps1` instead.
 
 Key Development Workflows:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Key AI assistant resources in `.claude/`:
 - **`docs/`** - Process documentation and planning materials
 - **`local/`** - Personal commands and docs (gitignored, developer-specific — check if it exists)
 
+> **Worktree setup:** If `.claude/local/` only contains `README.md` (or `.vscode/` is missing), run `bash scripts/setup-worktree.sh` to copy local config from the main worktree.
+
 Key Development Workflows:
 
 - **Building/Running:**

--- a/scripts/setup-worktree.ps1
+++ b/scripts/setup-worktree.ps1
@@ -7,7 +7,13 @@ $ErrorActionPreference = "Stop"
 
 # Derive main worktree from the shared .git dir — robust against spaces in paths
 # and always finds the correct main worktree regardless of listing order.
+# Note: $ErrorActionPreference = 'Stop' does NOT catch failures in external commands
+# like git; we must check $LASTEXITCODE explicitly after every git call.
 $gitCommonDir = (git rev-parse --git-common-dir).Trim()
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "git rev-parse --git-common-dir failed. Are you inside a git repository?"
+    exit 1
+}
 # In the main worktree git returns ".git" (relative); resolve to an absolute path.
 if (-not [System.IO.Path]::IsPathRooted($gitCommonDir)) {
     $gitCommonDir = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $gitCommonDir))
@@ -19,9 +25,21 @@ if (-not $mainRepo) {
     exit 1
 }
 
+# Get the current worktree root via git instead of Get-Location — correct even when
+# the script is invoked from a subdirectory, and ensures destination paths are right.
+$currentWorktreeRaw = (git rev-parse --show-toplevel).Trim()
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "git rev-parse --show-toplevel failed. Are you inside a git repository?"
+    exit 1
+}
+
 # Normalise both paths (resolve symlinks, strip trailing separators) before comparing.
 $mainRepo        = (Resolve-Path $mainRepo).Path.TrimEnd('\', '/')
-$currentWorktree = (Resolve-Path (Get-Location)).Path.TrimEnd('\', '/')
+$currentWorktree = (Resolve-Path $currentWorktreeRaw).Path.TrimEnd('\', '/')
+
+# Change to the worktree root so all relative destination paths are correct
+# regardless of which subdirectory the script was invoked from.
+Set-Location $currentWorktree
 
 if ($mainRepo -eq $currentWorktree) {
     Write-Host "Already in the main worktree - nothing to copy."
@@ -34,9 +52,10 @@ Write-Host ""
 
 function Copy-IfExists {
     param([string]$Src, [string]$Dst)
-    if (Test-Path $Src) {
+    if (Test-Path -PathType Container $Src) {
         New-Item -ItemType Directory -Force -Path $Dst | Out-Null
-        Get-ChildItem -Path $Src -Recurse -File | ForEach-Object {
+        # -Force includes hidden files/directories (e.g. dotfiles inside .vscode/).
+        Get-ChildItem -Path $Src -Recurse -File -Force | ForEach-Object {
             $relative = $_.FullName.Substring($Src.Length).TrimStart('\', '/')
             $target = Join-Path $Dst $relative
             if (-not (Test-Path $target)) {

--- a/scripts/setup-worktree.ps1
+++ b/scripts/setup-worktree.ps1
@@ -1,0 +1,59 @@
+# Copies gitignored local config from the main worktree into the current worktree.
+# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/, and .vscode/.
+#
+# Usage: pwsh scripts/setup-worktree.ps1
+
+$ErrorActionPreference = "Stop"
+
+# Derive main worktree from the shared .git dir — robust against spaces in paths
+# and always finds the correct main worktree regardless of listing order.
+$gitCommonDir = (git rev-parse --git-common-dir).Trim()
+# In the main worktree git returns ".git" (relative); resolve to an absolute path.
+if (-not [System.IO.Path]::IsPathRooted($gitCommonDir)) {
+    $gitCommonDir = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $gitCommonDir))
+}
+$mainRepo = Split-Path $gitCommonDir -Parent
+
+if (-not $mainRepo) {
+    Write-Error "Could not determine main worktree path."
+    exit 1
+}
+
+# Normalise both paths (resolve symlinks, strip trailing separators) before comparing.
+$mainRepo        = (Resolve-Path $mainRepo).Path.TrimEnd('\', '/')
+$currentWorktree = (Resolve-Path (Get-Location)).Path.TrimEnd('\', '/')
+
+if ($mainRepo -eq $currentWorktree) {
+    Write-Host "Already in the main worktree - nothing to copy."
+    exit 0
+}
+
+Write-Host "Main worktree: $mainRepo"
+Write-Host "Current worktree: $currentWorktree"
+Write-Host ""
+
+function Copy-IfExists {
+    param([string]$Src, [string]$Dst)
+    if (Test-Path $Src) {
+        New-Item -ItemType Directory -Force -Path $Dst | Out-Null
+        Get-ChildItem -Path $Src -Recurse -File | ForEach-Object {
+            $relative = $_.FullName.Substring($Src.Length).TrimStart('\', '/')
+            $target = Join-Path $Dst $relative
+            if (-not (Test-Path $target)) {
+                $targetDir = Split-Path $target -Parent
+                New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+                Copy-Item $_.FullName $target
+            }
+        }
+        Write-Host "✓ Copied $Src -> $Dst"
+    } else {
+        Write-Host "  (skipped $Src - not found in main worktree)"
+    }
+}
+
+Copy-IfExists (Join-Path $mainRepo ".claude/local")         ".claude/local"
+Copy-IfExists (Join-Path $mainRepo ".github/skills/local")  ".github/skills/local"
+Copy-IfExists (Join-Path $mainRepo ".vscode")               ".vscode"
+
+Write-Host ""
+Write-Host "Done. Local config is ready in this worktree."

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copies gitignored local config from the main worktree into the current worktree.
+# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/, and .vscode/.
+#
+# Usage: bash scripts/setup-worktree.sh
+
+set -e
+
+MAIN_REPO=$(git worktree list --porcelain | awk 'NR==1{print $2}')
+
+if [ -z "$MAIN_REPO" ]; then
+  echo "Error: could not determine main worktree path." >&2
+  exit 1
+fi
+
+if [ "$MAIN_REPO" = "$(pwd)" ]; then
+  echo "Already in the main worktree — nothing to copy."
+  exit 0
+fi
+
+echo "Main worktree: $MAIN_REPO"
+echo "Current worktree: $(pwd)"
+echo ""
+
+copy_if_exists() {
+  local src="$1"
+  local dst="$2"
+  if [ -d "$src" ]; then
+    mkdir -p "$dst"
+    cp -rn "$src/." "$dst/" || true
+    echo "✓ Copied $src → $dst"
+  else
+    echo "  (skipped $src — not found in main worktree)"
+  fi
+}
+
+copy_if_exists "$MAIN_REPO/.claude/local"        ".claude/local"
+copy_if_exists "$MAIN_REPO/.github/skills/local" ".github/skills/local"
+copy_if_exists "$MAIN_REPO/.vscode"              ".vscode"
+
+echo ""
+echo "Done. Local config is ready in this worktree."

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -6,20 +6,31 @@
 
 set -e
 
-MAIN_REPO=$(git worktree list --porcelain | awk 'NR==1{print $2}')
+# Derive main worktree from the shared .git dir — robust against spaces in paths
+# and always finds the correct main worktree regardless of listing order.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir)
+# In the main worktree git returns ".git" (relative); resolve to an absolute path.
+if [[ "$GIT_COMMON_DIR" != /* ]]; then
+  GIT_COMMON_DIR="$(pwd -P)/$GIT_COMMON_DIR"
+fi
+MAIN_REPO=$(dirname "$GIT_COMMON_DIR")
 
 if [ -z "$MAIN_REPO" ]; then
   echo "Error: could not determine main worktree path." >&2
   exit 1
 fi
 
-if [ "$MAIN_REPO" = "$(pwd)" ]; then
+# Normalise both paths (resolve symlinks, strip trailing slashes) before comparing.
+MAIN_REPO=$(cd "$MAIN_REPO" && pwd -P)
+CURRENT_WORKTREE=$(pwd -P)
+
+if [ "$MAIN_REPO" = "$CURRENT_WORKTREE" ]; then
   echo "Already in the main worktree — nothing to copy."
   exit 0
 fi
 
 echo "Main worktree: $MAIN_REPO"
-echo "Current worktree: $(pwd)"
+echo "Current worktree: $CURRENT_WORKTREE"
 echo ""
 
 copy_if_exists() {
@@ -27,7 +38,14 @@ copy_if_exists() {
   local dst="$2"
   if [ -d "$src" ]; then
     mkdir -p "$dst"
-    cp -rn "$src/." "$dst/" || true
+    # cp -n exits 1 on macOS/BSD when some destination files already existed and were
+    # skipped — that is not an error. Exit codes > 1 indicate genuine I/O failures.
+    local rc=0
+    cp -rn "$src/." "$dst/" || rc=$?
+    if [ "$rc" -gt 1 ]; then
+      echo "  ✗ Failed to copy $src → $dst" >&2
+      exit "$rc"
+    fi
     echo "✓ Copied $src → $dst"
   else
     echo "  (skipped $src — not found in main worktree)"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -20,9 +20,13 @@ if [ -z "$MAIN_REPO" ]; then
   exit 1
 fi
 
-# Normalise both paths (resolve symlinks, strip trailing slashes) before comparing.
+# Normalise the main worktree path (resolve symlinks).
 MAIN_REPO=$(cd "$MAIN_REPO" && pwd -P)
-CURRENT_WORKTREE=$(pwd -P)
+
+# Get the current worktree root via git instead of pwd — correct even when the
+# script is invoked from a subdirectory, and ensures destination paths are right.
+CURRENT_WORKTREE=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
+cd "$CURRENT_WORKTREE"
 
 if [ "$MAIN_REPO" = "$CURRENT_WORKTREE" ]; then
   echo "Already in the main worktree — nothing to copy."


### PR DESCRIPTION
Git worktrees don't inherit gitignored files, so personal config (`.claude/local/`, `.github/skills/local/`, `.vscode/`) is absent in newly created worktrees.

## What this adds

### `scripts/setup-worktree.sh` (macOS / Linux)
Copies gitignored local config from the main worktree into the current worktree. Uses `git rev-parse --git-common-dir` to find the main worktree path — no hardcoded paths, works on any machine, handles spaces in paths.

```bash
bash scripts/setup-worktree.sh
```

### `scripts/setup-worktree.ps1` (Windows)
PowerShell equivalent for Windows machines.

```powershell
pwsh scripts/setup-worktree.ps1
```

Both scripts:
- Determine the main worktree path robustly via `git rev-parse --git-common-dir`
- Normalise paths before comparing (resolves symlinks / trailing separators)
- Are safe to re-run: existing files are never overwritten
- Copy: `.claude/local/`, `.github/skills/local/`, `.vscode/`

### Updated `CLAUDE.md` and `AGENTS.md`
Both files now instruct agents to run the appropriate script (bash or PowerShell) if they find themselves in a worktree with missing local config.
