### PR TITLE
Improve worktree setup instructions for AI agents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,26 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## ⚠️ REQUIRED: Session Pre-flight Check
+
+**Before starting any task**, run this check:
+
+```bash
+ls .claude/local/
+```
+
+If the output contains **only `README.md`** (no other files), or if `.vscode/` is missing, you **must** run the worktree setup script before doing anything else:
+
+```bash
+bash scripts/setup-worktree.sh
+```
+
+On Windows: `pwsh scripts/setup-worktree.ps1`
+
+This copies gitignored local config (personal commands, `.vscode/` settings) from the main worktree. Skipping it means you'll be missing developer-specific tooling and commands for this session.
+
+---
+
 # Repository Information
 
 ## Overview
@@ -55,18 +75,6 @@ samples/
         └── ide_connection.md                 # IDE integration guide
 ```
 
-### Worktree setup
-This repo uses git worktrees for parallel tasks. Gitignored local config (`.claude/local/`, `.github/skills/local/`, `.vscode/`) is **not** copied automatically to new worktrees.
-
-**If you are running in a worktree** and `.claude/local/` contains only `README.md` (or `.vscode/` is missing), run:
-```bash
-bash scripts/setup-worktree.sh
-```
-On Windows, use the PowerShell equivalent:
-```powershell
-pwsh scripts/setup-worktree.ps1
-```
-This copies local config from the main worktree without overwriting anything already present.
 
 ### File Placement Rules
 When creating or organizing files for Claude Code:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,25 @@
 # AI Assistant Guidelines
 
+## ⚠️ REQUIRED: Session Pre-flight Check
+
+**Before starting any task**, run this check:
+
+```bash
+ls .claude/local/
+```
+
+If the output contains **only `README.md`** (no other files), or if `.vscode/` is missing, you **must** run the worktree setup script before doing anything else:
+
+```bash
+bash scripts/setup-worktree.sh
+```
+
+On Windows: `pwsh scripts/setup-worktree.ps1`
+
+This copies gitignored local config (personal commands, `.vscode/` settings) from the main worktree. Skipping it means you'll be missing developer-specific tooling and commands for this session.
+
+---
+
 > **Note:** This file has been superseded by more comprehensive documentation in the `.claude/` directory.
 
 For detailed instructions on working with this repository as an AI assistant, please see:
@@ -24,8 +44,6 @@ Key AI assistant resources in `.claude/`:
 - **`commands/worksetup.md`** - Theme/tab/scale setup workflow for `samples/SampleApp/`
 - **`docs/`** - Process documentation and planning materials
 - **`local/`** - Personal commands and docs (gitignored, developer-specific — check if it exists)
-
-> **Worktree setup:** If `.claude/local/` only contains `README.md` (or `.vscode/` is missing), run `bash scripts/setup-worktree.sh` to copy local config from the main worktree. On Windows, use `pwsh scripts/setup-worktree.ps1` instead.
 
 Key Development Workflows:
 


### PR DESCRIPTION
## Summary

Moves the worktree pre-flight check to the top of both `AGENTS.md` and `.claude/CLAUDE.md` so AI agents cannot miss it.

## Problem

The worktree setup instruction (run `scripts/setup-worktree.sh` when `.claude/local/` is empty) was:
- Formatted as a `>` blockquote — visually a side-note, not an imperative
- Buried mid-document after the task context was already established
- Phrased as a passive conditional ("if you are running in a worktree…")

All three factors caused agents to skip it and jump straight to the task.

## Changes

- **`AGENTS.md`** and **`.claude/CLAUDE.md`**: Added a `## ⚠️ REQUIRED: Session Pre-flight Check` section at the very top, with unconditional imperative phrasing and an explanation of the consequence of skipping
- Removed the old buried blockquote versions to avoid duplication