### PR TITLE
Update automated worktree setup to copy .env file with Avalonia Pro license

### DIFF
--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -44,6 +44,8 @@ public partial class MainWindow : Window
 
 #if ENABLE_ACCELERATE
     this.AddTreeDataGridTab();
+#else
+    this.AddTreeDataGridInfoTab();
 #endif
 
 #if DEBUG
@@ -346,20 +348,43 @@ public partial class MainWindow : Window
 #if ENABLE_ACCELERATE
   private void AddTreeDataGridTab()
   {
+    TreeDataGridDemo demo = new();
+    demo.DataContext = new TreeDataGridViewModel();
+    this.InsertTreeDataGridTab(demo, isEnabled: true);
+  }
+#else
+  private void AddTreeDataGridInfoTab()
+  {
+    TextBlock placeholder = new()
+    {
+      Text = "TreeDataGrid requires Avalonia Pro.\n" +
+             "Add AVALONIA_LICENSE_KEY to a .env file at the repo root and rebuild.",
+      TextWrapping = Avalonia.Media.TextWrapping.Wrap,
+      HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Center,
+      VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+      Margin = new Thickness(24),
+    };
+    this.InsertTreeDataGridTab(placeholder, isEnabled: true);
+  }
+#endif
+
+  private void InsertTreeDataGridTab(Control content, bool isEnabled)
+  {
     TabControl? tabControl = this.FindControl<TabControl>("MainTabControl");
     if (tabControl == null) return;
 
-    TabItem tabItem = new();
     SampleItemHeader header = new()
     {
-      Title = "TreeDataGrid (Accelerate)",
+      Title = "TreeDataGrid (Avalonia Pro)",
       ApplicableTo = "Fluent, MacClassic, DevExpress, Linux",
     };
-    tabItem.Header = header;
 
-    TreeDataGridDemo demo = new();
-    demo.DataContext = new TreeDataGridViewModel();
-    tabItem.Content = demo;
+    TabItem tabItem = new()
+    {
+      Header = header,
+      Content = content,
+      IsEnabled = isEnabled,
+    };
 
     // Insert before "TreeView" to keep alphabetical order
     int insertIndex = -1;
@@ -381,5 +406,4 @@ public partial class MainWindow : Window
       tabControl.Items.Add(tabItem);
     }
   }
-#endif
 }

--- a/scripts/setup-worktree.ps1
+++ b/scripts/setup-worktree.ps1
@@ -1,5 +1,6 @@
 # Copies gitignored local config from the main worktree into the current worktree.
-# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/, and .vscode/.
+# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/,
+# .vscode/, and .env.
 #
 # Usage: pwsh scripts/setup-worktree.ps1
 

--- a/scripts/setup-worktree.ps1
+++ b/scripts/setup-worktree.ps1
@@ -65,6 +65,16 @@ function Copy-IfExists {
             }
         }
         Write-Host "✓ Copied $Src -> $Dst"
+    } elseif (Test-Path -PathType Leaf $Src) {
+        # File copy — never overwrite an existing destination.
+        if (Test-Path $Dst) {
+            Write-Host "  (skipped $Src - destination $Dst already exists)"
+        } else {
+            $targetDir = Split-Path $Dst -Parent
+            if ($targetDir) { New-Item -ItemType Directory -Force -Path $targetDir | Out-Null }
+            Copy-Item $Src $Dst
+            Write-Host "✓ Copied $Src -> $Dst"
+        }
     } else {
         Write-Host "  (skipped $Src - not found in main worktree)"
     }
@@ -73,6 +83,7 @@ function Copy-IfExists {
 Copy-IfExists (Join-Path $mainRepo ".claude/local")         ".claude/local"
 Copy-IfExists (Join-Path $mainRepo ".github/skills/local")  ".github/skills/local"
 Copy-IfExists (Join-Path $mainRepo ".vscode")               ".vscode"
+Copy-IfExists (Join-Path $mainRepo ".env")                  ".env"
 
 Write-Host ""
 Write-Host "Done. Local config is ready in this worktree."

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -51,6 +51,15 @@ copy_if_exists() {
       exit "$rc"
     fi
     echo "✓ Copied $src → $dst"
+  elif [ -f "$src" ]; then
+    # File copy — never overwrite an existing destination.
+    if [ -e "$dst" ]; then
+      echo "  (skipped $src — destination $dst already exists)"
+    else
+      mkdir -p "$(dirname "$dst")"
+      cp "$src" "$dst"
+      echo "✓ Copied $src → $dst"
+    fi
   else
     echo "  (skipped $src — not found in main worktree)"
   fi
@@ -59,6 +68,7 @@ copy_if_exists() {
 copy_if_exists "$MAIN_REPO/.claude/local"        ".claude/local"
 copy_if_exists "$MAIN_REPO/.github/skills/local" ".github/skills/local"
 copy_if_exists "$MAIN_REPO/.vscode"              ".vscode"
+copy_if_exists "$MAIN_REPO/.env"                 ".env"
 
 echo ""
 echo "Done. Local config is ready in this worktree."

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copies gitignored local config from the main worktree into the current worktree.
-# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/, and .vscode/.
+# Run this once after creating a new worktree to get .claude/local/, .github/skills/local/,
+# .vscode/, and .env.
 #
 # Usage: bash scripts/setup-worktree.sh
 


### PR DESCRIPTION
Update setup scripts to ensure the .env file is copied to the project root when working with worktrees.

Also adding a 'TreeDataGrid_Info_' tab to be shown in the absence of a licence (to signal the availability of Pro controls more clearly and to avoid the silent failure when an exsiting licence just cannot be read ... like in the worktree scenario). 