### PR TITLE
Bump minimum required version of Devolutions.AvaloniaControls to 2026.6.10

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Devolutions.AvaloniaTheme.DevExpress.csproj
@@ -50,7 +50,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.9,)" />
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.10,)" />
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
+++ b/src/Devolutions.AvaloniaTheme.Linux/Devolutions.AvaloniaTheme.Linux.csproj
@@ -48,7 +48,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.2,)" />
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.10,)" />
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Devolutions.AvaloniaTheme.MacOS.csproj
@@ -46,7 +46,7 @@
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">
         <!-- MAKE SURE TO BUMP THIS *if* A NEW CONTROL/CONVERTER/EXTENSION IS ADDED AND USED! -->
-        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.9,)" />
+        <PackageReference Include="Devolutions.AvaloniaControls" Version="[2026.6.10,)" />
     </ItemGroup>
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <ProjectReference Include="..\Devolutions.AvaloniaControls\Devolutions.AvaloniaControls.csproj" />


### PR DESCRIPTION
Bumps the minimum required version of `Devolutions.AvaloniaControls` that each theme depends on to `2026.6.10`.

## Changes
- `Devolutions.AvaloniaTheme.MacOS`: `[2026.6.9,)` → `[2026.6.10,)`
- `Devolutions.AvaloniaTheme.Linux`: `[2026.6.2,)` → `[2026.6.10,)`
- `Devolutions.AvaloniaTheme.DevExpress`: `[2026.6.9,)` → `[2026.6.10,)`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>