### PR TITLE
DevExpress theme - adjustments to the TreeDataGrid headers

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
@@ -107,7 +107,7 @@
                                 ContentTemplate="{TemplateBinding HeaderTemplate}"
                                 VerticalAlignment="Center"
                                 HorizontalAlignment="Stretch"
-                                Margin="0 0 4 0"
+                                Margin="0 0 2 0"
                                 Grid.Column="2" />
               <TextBlock x:Name="PART_InputGestureText"
                          Grid.Column="3"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeDataGrid.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TreeDataGrid.axaml
@@ -164,68 +164,85 @@
     <Setter Property="BorderBrush" Value="{DynamicResource TreeDataGridInnerGridBrush}" />
     <Setter Property="BorderThickness" Value="1" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="HeaderBorder"
-                Background="{TemplateBinding Background}"
-                BorderBrush="Transparent"
-                BorderThickness="0"
-                CornerRadius="{TemplateBinding CornerRadius}">
-          <DockPanel VerticalAlignment="Stretch">
-            <!-- Right separator + resizer -->
-            <Panel DockPanel.Dock="Right" TabIndex="2">
-              <Rectangle Fill="{TemplateBinding BorderBrush}"
-                         HorizontalAlignment="Right"
-                         Width="{TemplateBinding BorderThickness, 
+        <Panel ClipToBounds="False" ZIndex="9">
+          <Border Name="HeaderBorder"
+                  Background="{TemplateBinding Background}"
+                  BorderBrush="Transparent"
+                  BorderThickness="0"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  ClipToBounds="False"
+                  IsHitTestVisible="False">
+            <DockPanel VerticalAlignment="Stretch" ClipToBounds="False">
+              <!-- Sort icon (reusing DataGrid foreground) -->
+              <Path Name="SortIcon"
+                    DockPanel.Dock="Right"
+                    Fill="{TemplateBinding Foreground}"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Margin="1 0 3 0"
+                    Stretch="Uniform"
+                    Height="7"
+                    TabIndex="1"
+                    IsVisible="False"
+                    Data="{StaticResource TreeDataGridSortIconPath}" />
+
+              <!-- Header content -->
+              <ContentPresenter Name="PART_ContentPresenter"
+                                Content="{TemplateBinding Header}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                IsHitTestVisible="False"
+                                TabIndex="0">
+                <ContentPresenter.DataTemplates>
+                  <DataTemplate DataType="x:String">
+                    <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis" />
+                  </DataTemplate>
+                </ContentPresenter.DataTemplates>
+              </ContentPresenter>
+            </DockPanel>
+          </Border>
+          
+          <!-- hit-target, for the column itself, offset to the left for the Thumb overflow) -->
+          <Border Background="Transparent" Margin="6 0 0 0" />
+
+          <!-- Right separator + resizer -->
+          <Panel HorizontalAlignment="Right" TabIndex="2" ClipToBounds="False" Width="5" ZIndex="99">
+            <Rectangle Fill="{TemplateBinding BorderBrush}"
+                       HorizontalAlignment="Right"
+                       ZIndex="999"
+                       Width="{TemplateBinding BorderThickness, 
                                            Converter={x:Static DevoConverters.ThicknessNumericExtractor}, 
                                            ConverterParameter={x:Static ThicknessSide.Right}}" />
-              <Thumb Name="PART_Resizer"
-                     DockPanel.Dock="Right"
-                     Background="Transparent"
-                     Cursor="SizeWestEast"
-                     IsVisible="{TemplateBinding CanUserResize}"
-                     Width="5">
-                <Thumb.Template>
-                  <ControlTemplate>
-                    <Border Background="{TemplateBinding Background}" VerticalAlignment="Stretch" />
-                  </ControlTemplate>
-                </Thumb.Template>
-              </Thumb>
-            </Panel>
-
-            <!-- Sort icon (reusing DataGrid foreground) -->
-            <Path Name="SortIcon"
-                  DockPanel.Dock="Right"
-                  Fill="{TemplateBinding Foreground}"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Center"
-                  Stretch="Uniform"
-                  Height="7"
-                  TabIndex="1"
-                  IsVisible="False"
-                  Data="{StaticResource TreeDataGridSortIconPath}" />
-
-            <!-- Header content -->
-            <ContentPresenter Name="PART_ContentPresenter"
-                              Content="{TemplateBinding Header}"
-                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                              Padding="{TemplateBinding Padding}"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                              TabIndex="0">
-              <ContentPresenter.DataTemplates>
-                <DataTemplate DataType="x:String">
-                  <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis" />
-                </DataTemplate>
-              </ContentPresenter.DataTemplates>
-            </ContentPresenter>
-          </DockPanel>
-        </Border>
+            <!-- 
+              9px would be the proper width to be perfectly-centered.
+              HOWEVER, since mouse cursor's arrow tip is usually to the left, it actually "feel"
+              better to extend the hitbox more to the right
+            -->
+            <Thumb Name="PART_Resizer"
+                   Background="Transparent"
+                   ZIndex="9999"
+                   Cursor="SizeWestEast"
+                   IsVisible="{TemplateBinding CanUserResize}"
+                   HorizontalAlignment="Left"
+                   Width="11">
+              <Thumb.Template>
+                <ControlTemplate>
+                  <Border Background="{TemplateBinding Background}" VerticalAlignment="Stretch" />
+                </ControlTemplate>
+              </Thumb.Template>
+            </Thumb>
+          </Panel>
+        </Panel>
       </ControlTemplate>
     </Setter>
 
     <!-- Pointer states, matching your TreeDataGrid defaults -->
-    <Style Selector="^:pointerover /template/ Border#HeaderBorder">
+    <Style Selector="^:pointerover:not(:pressed) /template/ Border#HeaderBorder">
       <Setter Property="Background" Value="{DynamicResource TreeDataGridHeaderBackgroundPointerOverBrush}" />
       <Setter Property="BorderBrush" Value="{DynamicResource TreeDataGridHeaderBorderBrushPointerOverBrush}" />
       <Setter Property="TextBlock.Foreground" Value="{DynamicResource TreeDataGridHeaderForegroundPointerOverBrush}" />


### PR DESCRIPTION
- Same right padding when non-resizable
- Updated the "hitbox" of the header's borders to be more symetrical*

- (unrelated: small fix to MenuItem right margin

* actually slightly wider to the right but "feels" better