### PR TITLE
[DevExpress] Fix EditableComboBox right border clipping at fractional DPI

### DIFF
--- a/samples/SampleApp/DemoPages/ComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/ComboBoxDemo.axaml
@@ -18,9 +18,10 @@
         <ComboBoxItem>Option 4</ComboBoxItem>
       </ComboBox>
     </StackPanel>
-    <StackPanel Orientation="Horizontal">
-      <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
-        <Grid ColumnDefinitions="Auto 240 240" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
+    <!-- Outer grid + GridSplitter lets you resize the demo container (and thus the ComboBoxes) at runtime, to compare against EditableComboBox -->
+    <Grid ColumnDefinitions="500 Auto * Auto">
+      <Border Grid.Column="0" Margin="20" Padding="20" Background="{DynamicResource LayoutBackgroundLowBrush}">
+        <Grid ColumnDefinitions="Auto * Auto" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
           <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
             <Bold>ComboBox: </Bold>
           </TextBlock>
@@ -139,9 +140,10 @@
           <ComboBox Grid.Column="1" Grid.Row="12" ItemsSource="{Binding LargeItemsList}" MaxDropDownHeight="200" VerticalAlignment="Top" Margin="10 0 20 0" />
         </Grid>
       </Border>
+      <GridSplitter Grid.Column="1" Width="6" ResizeDirection="Columns" Background="Gray" />
 
       <!-- Transparency Test Area -->
-      <StackPanel Margin="20" Spacing="20">
+      <StackPanel Grid.Column="3" Margin="20" Spacing="20">
         <TextBlock FontWeight="Bold">Transparency Test</TextBlock>
         <StackPanel Spacing="5">
           <ComboBox PlaceholderText="Options"
@@ -160,6 +162,6 @@
           </StackPanel>
         </StackPanel>
       </StackPanel>
-    </StackPanel>
+    </Grid>
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/EditableComboBoxDemo.axaml
@@ -18,8 +18,10 @@
         <EditableComboBoxItem>Option 2</EditableComboBoxItem>
       </EditableComboBox>
     </StackPanel>
-    <Border Margin="20" Padding="20" HorizontalAlignment="Left" Background="{DynamicResource LayoutBackgroundLowBrush}">
-      <Grid ColumnDefinitions="Auto 240 Auto" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
+    <!-- Outer grid + GridSplitter lets you resize the demo container (and thus the EditableComboBoxes) at runtime -->
+    <Grid Margin="20" ColumnDefinitions="500 Auto *">
+      <Border Grid.Column="0" Padding="20" Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <Grid ColumnDefinitions="Auto * Auto" RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto">
         <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Top" Margin="0 5 10 15">
           <Bold>Preferred Usage Pattern: </Bold>
         </TextBlock>
@@ -380,6 +382,9 @@
         <TextBlock Grid.Column="1" Grid.Row="22" Margin="10 4 20 15"
                    Text="{Binding SelectedLargeItem, StringFormat='{}Selected: {0}'}" />
       </Grid>
-    </Border>
+      </Border>
+      <GridSplitter Grid.Column="1" Width="6" ResizeDirection="Columns"
+                    Background="Gray" />
+    </Grid>
   </StackPanel>
 </UserControl>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/EditableComboBox.axaml
@@ -294,11 +294,16 @@
     <Setter Property="PlaceholderForeground" Value="{DynamicResource ComboBoxPlaceHolderForeground}" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" HorizontalAlignment="Stretch">
+        <Panel>
+          <!--
+            BorderElement / BottomBorderElement are direct children of this Panel (sized to the full
+            control bounds) rather than children spanning a Grid with a '*' column. A column-spanning
+            border is arranged to the sum of the independently layout-rounded column widths, which at
+            fractional DPI can fall ~1px short of the control width and clip the right border edge.
+            This mirrors how ComboBox.axaml lays out its BorderElement.
+          -->
           <Border
             Name="BorderElement"
-            Grid.Column="0"
-            Grid.ColumnSpan="5"
             Background="{TemplateBinding Background}"
             BorderBrush="{TemplateBinding BorderBrush}"
             BorderThickness="{TemplateBinding BorderThickness}"
@@ -307,8 +312,6 @@
             MinHeight="{TemplateBinding MinHeight}" />
           <Border
             Name="BottomBorderElement"
-            Grid.Column="0"
-            Grid.ColumnSpan="5"
             Background="Transparent"
             Margin="1 0"
             BorderBrush="{DynamicResource TextBoxBottomBorderBrush}"
@@ -316,6 +319,7 @@
             CornerRadius="{TemplateBinding CornerRadius}"
             MinWidth="{TemplateBinding MinWidth}"
             MinHeight="{TemplateBinding MinHeight}" />
+          <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" HorizontalAlignment="Stretch">
 
           <ItemsControl
             Grid.Column="0"
@@ -427,7 +431,8 @@
               </Border>
             </Panel>
           </Popup>
-        </Grid>
+          </Grid>
+        </Panel>
       </ControlTemplate>
     </Setter>
 


### PR DESCRIPTION
## Problem

On a scaled (fractional-DPI) screen, the right edge of an `EditableComboBox`'s outer border could get clipped depending on the control's width. The standard `ComboBox` is unaffected.

## Root cause

In the DevExpress `EditableComboBox` template, the border elements (`BorderElement` / `BottomBorderElement`) were children **spanning all columns of a `Grid`** that has a `*` column:

```xml
<Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto">
  <Border Name="BorderElement" Grid.Column="0" Grid.ColumnSpan="5" ... />
  ...
</Grid>
```

With `UseLayoutRounding` on (the default) and a fractional scale factor, the Grid rounds each column width independently to device pixels. A column-spanning child is arranged to the **sum** of those rounded widths, which can land ~1px short of the control's own rounded width — dropping the right border edge.

`ComboBox.axaml` never hits this because its `BorderElement` is a direct child of a `Panel`, sized once against the full control bounds.

## Fix

Wrap the content grid in a `Panel` and make the border elements direct `Panel` children (full-bounds), mirroring `ComboBox.axaml`. Geometry is identical at integer scale — this only removes the fractional-scale clipping. All existing style selectors (`Border#BorderElement`, `Border#BottomBorderElement`) and the popup's `PlacementTarget="BorderElement"` still resolve by name.

## Demo tooling

Added a `GridSplitter` to both the `EditableComboBox` and `ComboBox` demo pages so the controls can be resized at runtime, making it easy to reproduce/compare border rendering at arbitrary widths and scales.

## Testing

Manually verified in the SampleApp under the DevExpress theme on a scaled display: the right border now stays intact across widths and scale factors.