### PR TITLE
Allow publishing from release branches

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,6 +3,11 @@ name: build package
 on:
   workflow_dispatch:
     inputs:
+      build-branch:
+        description: "Branch to build from (must be 'master' or 'release/*')"
+        type: string
+        default: 'master'
+        required: true
       build-mac:
         description: 'AvaloniaTheme.MacOS'
         type: boolean
@@ -48,6 +53,7 @@ jobs:
       package-list: ${{ steps.info.outputs.package-list }}
       skip-publish: ${{ steps.info.outputs.skip-publish }}
       dry-run: ${{ steps.info.outputs.dry-run }}
+      build-branch: ${{ steps.info.outputs.build-branch }}
 
     steps:
       - name: Package information
@@ -55,6 +61,13 @@ jobs:
         shell: pwsh
         run: |
           $IsScheduledJob = ('${{ github.event_name }}' -eq 'schedule')
+
+          # Branch to build from. Scheduled jobs have no inputs, so default to 'master'.
+          $BuildBranch = '${{ inputs.build-branch }}'
+          if ([string]::IsNullOrEmpty($BuildBranch)) { $BuildBranch = 'master' }
+          if ($BuildBranch -ne 'master' -And $BuildBranch -NotMatch '^release/.+') {
+            throw "invalid build branch: $BuildBranch, must be 'master' or 'release/*'"
+          }
 
           $PublishMode = '${{ inputs.publish-mode }}'
           if ([string]::IsNullOrEmpty($PublishMode)) { $PublishMode = 'Skip Publishing' }
@@ -120,8 +133,9 @@ jobs:
           echo "package-list=$PackageList" >> $Env:GITHUB_OUTPUT
           echo "skip-publish=$($SkipPublish.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
           echo "dry-run=$($DryRun.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
+          echo "build-branch=$BuildBranch" >> $Env:GITHUB_OUTPUT
 
-          echo "::notice::Branch: ${{ github.ref_name }}"
+          echo "::notice::Branch: $BuildBranch"
           echo "::notice::Building Packages: $PackageList"
           echo "::notice::Version: $PackageVersion"
           echo "::notice::SkipPublish: $SkipPublish"
@@ -136,6 +150,8 @@ jobs:
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.build-branch }}
 
       - name: Configure runner
         shell: pwsh

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -32,8 +32,8 @@ on:
         type: choice
         options:
           - 'Skip Publishing'
-          - 'Dry Run (Master only)'
-          - 'Publish (Master only)'
+          - 'Dry Run'
+          - 'Publish'
         default: 'Skip Publishing'
   schedule:
     - cron: '32 5 * * 1' # 05:32 AM UTC every Monday
@@ -54,27 +54,23 @@ jobs:
         id: info
         shell: pwsh
         run: |
-          $IsMasterBranch = ('${{ github.ref_name }}' -eq 'master')
           $IsScheduledJob = ('${{ github.event_name }}' -eq 'schedule')
 
           $PublishMode = '${{ inputs.publish-mode }}'
           if ([string]::IsNullOrEmpty($PublishMode)) { $PublishMode = 'Skip Publishing' }
 
           $SkipPublish = ($PublishMode -eq 'Skip Publishing')
-          $DryRun = ($PublishMode -eq 'Dry Run (Master only)')
+          $DryRun = ($PublishMode -eq 'Dry Run')
 
-          $IsPrerelease = -Not [string]::IsNullOrEmpty('${{ inputs.prerelease-suffix }}')
-
-          $PackageEnv = if ((-Not $SkipPublish) -And (-Not $IsScheduledJob) -And ($IsMasterBranch -Or $IsPrerelease)) {
+          # Manual dispatch can publish from any branch selected in the Actions UI ref picker.
+          # Scheduled jobs always skip publishing.
+          $PackageEnv = if ((-Not $SkipPublish) -And (-Not $IsScheduledJob)) {
             "publish-prod"
           } else {
             "publish-test"
           }
 
           if ($IsScheduledJob) {
-            $SkipPublish = $true # force skipping publish for scheduled jobs
-            $DryRun = $false # just to avoid confusing 'Notice' messages
-          } elseif (-Not $IsMasterBranch -And -Not $IsPrerelease) {
             $SkipPublish = $true # force skipping publish (jobs running in 'publish-test' cannot test the publishing step)
             $DryRun = $false
           }
@@ -125,6 +121,7 @@ jobs:
           echo "skip-publish=$($SkipPublish.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
           echo "dry-run=$($DryRun.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
 
+          echo "::notice::Branch: ${{ github.ref_name }}"
           echo "::notice::Building Packages: $PackageList"
           echo "::notice::Version: $PackageVersion"
           echo "::notice::SkipPublish: $SkipPublish"

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -84,8 +84,8 @@ jobs:
           }
 
           if ($IsScheduledJob) {
-            $SkipPublish = $true # force skipping publish (jobs running in 'publish-test' cannot test the publishing step)
-            $DryRun = $false
+            $SkipPublish = $true # scheduled jobs always skip publishing
+            $DryRun = $false # just to avoid confusing 'Notice' messages
           }
 
           $PackageVersion = '${{ inputs.version }}'

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -85,7 +85,7 @@ jobs:
 
           if ($IsScheduledJob) {
             $SkipPublish = $true # scheduled jobs always skip publishing
-            $DryRun = $false # just to avoid confusing 'Notice' messages
+            $DryRun = $false
           }
 
           $PackageVersion = '${{ inputs.version }}'


### PR DESCRIPTION
## Summary

Enables publishing a release from `release/*` branches (and `master`), instead of being restricted to `master` only.

## Changes to `.github/workflows/build-package.yml`

- **Add a `build-branch` input** (free-text, default `master`) so the branch to build from is chosen explicitly rather than relying solely on the Actions UI ref picker. It's validated in preflight and must be `master` or `release/*` (`^release/.+`), otherwise the run fails fast with a clear error.
- **Remove the hardcoded master-only publish gate.** Previously, a non-master, non-prerelease dispatch was force-skipped from publishing. Now a manual dispatch can publish from the selected branch; scheduled cron runs still always skip publishing.
- **Check out the chosen branch** explicitly (`actions/checkout` with `ref: ${{ needs.preflight.outputs.build-branch }}`), so the packaged code matches `build-branch`.
- Drop `(Master only)` from the publish-mode option labels (and update the matching comparison) since the restriction no longer applies.
- Report the selected branch in the run notices.

## Notes / caveats

- The prerelease-suffix functionality is unchanged.

## Screenshots

<img width="335" height="637" alt="PusblishPopup" src="https://github.com/user-attachments/assets/2cb21a9c-543e-4edc-a4af-9231149fab43" />
