### PR TITLE
[MacOS] Fix ButtonToggleSwitch variant rendering and harmonize cursor across variants

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ToggleSwitch.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ToggleSwitch.axaml
@@ -249,44 +249,96 @@
           Name="Background"
           Padding="{TemplateBinding Padding}"
           Background="{TemplateBinding Background}"
-          CornerRadius="{TemplateBinding CornerRadius}"
-          Cursor="Hand">
-          <Panel>
-            <Panel Name="PART_SwitchKnob" />
-            <Panel Name="PART_MovingKnobs" />
+          CornerRadius="{TemplateBinding CornerRadius}">
+          <DockPanel HorizontalAlignment="Stretch">
+            <Border
+              Name="SwitchBackgroundBorder"
+              DockPanel.Dock="Right"
+              TemplatedControl.IsTemplateFocusTarget="True"
+              Width="{DynamicResource ToggleSwitchDefaultWidth}"
+              Height="{DynamicResource ToggleSwitchDefaultHeight}"
+              BorderBrush="{DynamicResource ToggleSwitchDefaultBorderBrush}"
+              BorderThickness="1"
+              CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}">
+              <Border.Transitions>
+                <Transitions>
+                  <BrushTransition Property="Background" Duration="0:0:0.2" />
+                </Transitions>
+              </Border.Transitions>
+              <Canvas
+                Name="PART_SwitchKnob"
+                Width="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                Height="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                HorizontalAlignment="Left">
+                <Grid
+                  Name="PART_MovingKnobs"
+                  Width="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                  Height="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                  Margin="{DynamicResource ToggleSwitchIndicatorDefaultMargin}">
+                  <Border
+                    Name="SwitchKnobIndicator"
+                    Background="{DynamicResource ToggleSwitchKnobBackground}"
+                    BoxShadow="{DynamicResource ToggleSwitchIndicatorBoxShadow}"
+                    CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}" />
+                  <Arc
+                    Name="SwitchKnobLoadingIndicator"
+                    IsVisible="False"
+                    StrokeThickness="2"
+                    StartAngle="0"
+                    SweepAngle="140"
+                    StrokeJoin="Round"
+                    StrokeLineCap="Round">
+                    <Arc.Stroke>
+                      <ConicGradientBrush>
+                        <GradientStops>
+                          <GradientStop Offset="0.1" Color="Transparent" />
+                          <GradientStop Offset="0.7" Color="White" />
+                        </GradientStops>
+                      </ConicGradientBrush>
+                    </Arc.Stroke>
+                    <Arc.Styles>
+                      <Style Selector="Arc[IsVisible=True]">
+                        <Style.Animations>
+                          <Animation IterationCount="Infinite" Duration="0:0:0.6">
+                            <KeyFrame Cue="0%">
+                              <Setter Property="RotateTransform.Angle" Value="0.0" />
+                            </KeyFrame>
+                            <KeyFrame Cue="100%">
+                              <Setter Property="RotateTransform.Angle" Value="360.0" />
+                            </KeyFrame>
+                          </Animation>
+                        </Style.Animations>
+                      </Style>
+                    </Arc.Styles>
+                  </Arc>
+                </Grid>
+              </Canvas>
+            </Border>
+
+            <ContentPresenter
+              Name="PART_ContentPresenter"
+              Margin="{DynamicResource ToggleSwitchHeaderMargin}"
+              VerticalAlignment="Center"
+              HorizontalAlignment="Left"
+              Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              IsVisible="{TemplateBinding Content, Converter={x:Static ObjectConverters.IsNotNull}}"
+              RecognizesAccessKey="True" />
+
             <ContentPresenter
               Name="PART_OnContentPresenter"
-              Margin="{DynamicResource ToggleSwitchOnContentMargin}"
+              Margin="0"
               Content="{TemplateBinding OnContent}"
               ContentTemplate="{TemplateBinding OnContentTemplate}" />
             <ContentPresenter
               Name="PART_OffContentPresenter"
-              Margin="{DynamicResource ToggleSwitchOnContentMargin}"
+              Margin="0"
               Content="{TemplateBinding OffContent}"
               ContentTemplate="{TemplateBinding OffContentTemplate}" />
-          </Panel>
+          </DockPanel>
         </Border>
       </ControlTemplate>
     </Setter>
-    <Style Selector="^:pointerover">
-      <Setter Property="Background" Value="{DynamicResource ButtonDefaultPointeroverBackground}" />
-    </Style>
-    <Style Selector="^:pressed">
-      <Setter Property="Background" Value="{DynamicResource ControlBackgroundActiveHighBrush}" />
-    </Style>
-
-    <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible /template/ Border#Background">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="3" />
-        </Template>
-      </Setter>
-    </Style>
   </ControlTheme>
 
   <ControlTheme
@@ -301,7 +353,6 @@
         <Border
           Name="SwitchBackgroundBorder"
           Background="{TemplateBinding Background}"
-          Cursor="Hand"
           Width="{DynamicResource ToggleSwitchDefaultWidth}"
           Height="{DynamicResource ToggleSwitchDefaultHeight}"
           BorderBrush="{DynamicResource ToggleSwitchDefaultBorderBrush}"


### PR DESCRIPTION
## Summary

- Fix the `ButtonToggleSwitch` variant of `ToggleSwitch` in the macOS theme — it was rendering nothing on screen (only a small focus ring when tabbed to).
- Drop the `Cursor=\"Hand\"` setters from `ButtonToggleSwitch` and `SimpleToggleSwitch` so all three variants behave consistently and match Fluent (which uses the default arrow).

## Root cause

PR #285 ([MacOS] Consolidate ToggleSwitch resources and add dark mode) restructured the base `ToggleSwitch` template to use a single `PART_ContentPresenter` bound to `Content`, and added unconditional `IsVisible=\"False\"` styles on `PART_OnContentPresenter` / `PART_OffContentPresenter` in the base ControlTheme.

`ButtonToggleSwitch` (BasedOn the base theme) was left rendering its content through the now-hidden `PART_OnContentPresenter` / `PART_OffContentPresenter` and never bound `Content` at all, so nothing was visible. The empty `PART_SwitchKnob` / `PART_MovingKnobs` placeholders meant the switch chrome wasn't drawn either — only an 8px transparent click-area remained.

The same PR also dropped `Cursor=\"Hand\"` from the base template (which previously had it on its root `Grid`), but left it on the `ButtonToggleSwitch` and `SimpleToggleSwitch` templates — pure leftover inconsistency.

## Changes

- `ButtonToggleSwitch` template now renders the full switch (sliding knob + state-driven `SwitchBackgroundBorder` + loading `Arc`) wrapped in the outer button-shaped `Border#Background`. Element names match the base ControlTheme so inherited `:checked`/`:unchecked`/`.Loading`/`.Small`/`.Large`/`:focus-visible` styles apply automatically — no per-state styles needed in the variant.
- Removed `Cursor=\"Hand\"` from both `ButtonToggleSwitch` and `SimpleToggleSwitch` outer Borders. All three variants now use the default cursor, matching Fluent.

## Test plan

- [x] Open SampleApp on macOS and navigate to the ToggleSwitch demo page.
- [x] **Base ToggleSwitch:** confirm appearance is unchanged (sliding knob, color transitions on checked/unchecked, focus ring on tab).
- [x] **ButtonToggleSwitch:** confirm the switch is now visible (sliding knob + label text on the left), behaves on click, focus ring shows on tab, no spurious button border on click.
- [x] **SimpleToggleSwitch:** confirm appearance unchanged.
- [x] Hover over all three variants — none should show the Hand cursor.
- [x] Verify Light + Dark accents render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)