### PR TITLE
[LiquidGlass] Fix various regressions due to conversion of Static resources to Dynamic

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -149,7 +149,8 @@
 
       <SolidColorBrush x:Key="AccentBackgroundWash" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource LightModeAccentBackgroundWashConverter}}"
                        Opacity="0.43" />
-      <SolidColorBrush x:Key="AccentHighlight" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource LightModeAccentHighlightConverter}}"
+      <SolidColorBrush x:Key="AccentHighlight" x:DataType="SolidColorBrush"
+                       Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource LightModeAccentHighlightConverter}}"
                        Opacity="0.64" />
 
       <!-- Generic resources shared across controls (use sparingly!) -->
@@ -207,7 +208,7 @@
       <StaticResource x:Key="CheckBoxBoxShadow" ResourceKey="NoShadow" />
 
       <StaticResource x:Key="PopupBorderBrush" ResourceKey="ForegroundT20" />
-      <StaticResource x:Key='ComboBoxItemPointerOverBackgroundBrush' ResourceKey='AccentHighlight' />
+      <StaticResource x:Key="ComboBoxItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -229,7 +230,8 @@
 
       <SolidColorBrush x:Key="AccentBackgroundWash" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource DarkModeAccentBackgroundWashConverter}}"
                        Opacity="0.43" />
-      <SolidColorBrush x:Key="AccentHighlight" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource DarkModeAccentHighlightConverter}}"
+      <SolidColorBrush x:Key="AccentHighlight"
+                       Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource DarkModeAccentHighlightConverter}}"
                        Opacity="0.69" />
 
       <!-- Generic resources shared across controls (use sparingly!) -->
@@ -286,7 +288,7 @@
       <StaticResource x:Key="CheckBoxBoxShadow" ResourceKey="NoShadow" />
 
       <StaticResource x:Key="PopupBorderBrush" ResourceKey="ForegroundT26" />
-      <StaticResource x:Key='ComboBoxItemPointerOverBackgroundBrush' ResourceKey='AccentHighlight' />
+      <StaticResource x:Key="ComboBoxItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -374,8 +376,8 @@
   <!-- MenuItem -->
   <Thickness x:Key="MenuItemPadding">9 4 7 4</Thickness>
   <x:Double x:Key="MenuItemMinHeight">24</x:Double>
-  <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="ComboBoxItemPointerOverBackgroundBrush" />
-  <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="ComboBoxItemPointerOverBackgroundBrush" />
+  <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
+  <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
 
 
   <!-- TextBox -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -147,7 +147,8 @@
 
       <SolidColorBrush x:Key="TranslucentSurface" Color="#f8f9f9" Opacity="0.93" />
 
-      <SolidColorBrush x:Key="AccentBackgroundWash" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource LightModeAccentBackgroundWashConverter}}"
+      <SolidColorBrush x:Key="AccentBackgroundWash" x:DataType="SolidColorBrush"
+                       Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource LightModeAccentBackgroundWashConverter}}"
                        Opacity="0.43" />
       <SolidColorBrush x:Key="AccentHighlight" x:DataType="SolidColorBrush"
                        Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource LightModeAccentHighlightConverter}}"
@@ -228,7 +229,8 @@
 
       <SolidColorBrush x:Key="TranslucentSurface" Color="#171717" Opacity="0.89" />
 
-      <SolidColorBrush x:Key="AccentBackgroundWash" Color="{Binding Source={DynamicResource SystemAccentColor}, Converter={StaticResource DarkModeAccentBackgroundWashConverter}}"
+      <SolidColorBrush x:Key="AccentBackgroundWash"
+                       Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource DarkModeAccentBackgroundWashConverter}}"
                        Opacity="0.43" />
       <SolidColorBrush x:Key="AccentHighlight"
                        Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource DarkModeAccentHighlightConverter}}"


### PR DESCRIPTION
#546 changed several resource definitions to dynamic lookup, breaking some brushes for LiquidGlass UI elements that rely on a converter to calculate their colour (Menu/ComboBox hover states and disabled checked CheckBox/RadioButton backgrounds). 

This fixes those regressions by using stable bindings to SystemAccent.Color.
