### PR TITLE
[MacOS] Add horizontal tab scrolling to the TabControl

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -605,6 +605,7 @@
 
   <!-- TabControl & TabItem Resources -->
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0.5 0.5 0.5 0.6</Thickness>
   <x:Double x:Key="TabItemDividerHeight">12</x:Double>
   <Thickness x:Key="TabItemDividerMargin">-2 0 0 0</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -606,6 +606,7 @@
   <!-- TabControl & TabItem Resources -->
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
   <Thickness x:Key="TabControlTopItemsPresenterMargin">0</Thickness>
+  <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-2 0 4 0 #40000000</BoxShadows>
   <Thickness x:Key="TabControlTabStripBorderThickness">0.5 0.5 0.5 0.6</Thickness>
   <x:Double x:Key="TabItemDividerHeight">12</x:Double>
   <Thickness x:Key="TabItemDividerMargin">-2 0 0 0</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -313,6 +313,7 @@
   <!-- TabControl & TabItem -->
   <Thickness x:Key="TabControlBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0</Thickness>
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">2 0 0 0</Thickness>
   <StaticResource x:Key="TabItemDividerBorderBrush" ResourceKey="SurfaceT10" />
   <Thickness x:Key="TabItemPadding">16 4</Thickness>
   <x:Double x:Key="TabItemDividerHeight">14</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -314,6 +314,7 @@
   <Thickness x:Key="TabControlBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTopItemsPresenterMargin">2 0 0 0</Thickness>
+  <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-1 0 4 0 #40000000</BoxShadows>
   <StaticResource x:Key="TabItemDividerBorderBrush" ResourceKey="SurfaceT10" />
   <Thickness x:Key="TabItemPadding">16 4</Thickness>
   <x:Double x:Key="TabItemDividerHeight">14</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Behaviors/TabStripScrollBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Behaviors/TabStripScrollBehavior.cs
@@ -1,0 +1,289 @@
+namespace Devolutions.AvaloniaTheme.MacOS.Behaviors;
+
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Runtime.CompilerServices;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+internal static class TabStripScrollBehavior
+{
+    public static readonly AttachedProperty<bool> EnableProperty =
+        AvaloniaProperty.RegisterAttached<TabControl, bool>("Enable", typeof(TabStripScrollBehavior));
+
+    private static readonly ConditionalWeakTable<TabControl, TabStripScrollState> States = new();
+
+    static TabStripScrollBehavior()
+    {
+        EnableProperty.Changed.Subscribe(args =>
+        {
+            if (args.Sender is not TabControl tabControl)
+            {
+                return;
+            }
+
+            bool enable = args.NewValue.GetValueOrDefault<bool>();
+            if (enable)
+            {
+                Enable(tabControl);
+            }
+            else
+            {
+                Disable(tabControl);
+            }
+        });
+    }
+
+    public static void SetEnable(TabControl element, bool value) => element.SetValue(EnableProperty, value);
+
+    public static bool GetEnable(TabControl element) => element.GetValue(EnableProperty);
+
+    private static void Enable(TabControl tabControl)
+    {
+        if (States.TryGetValue(tabControl, out _))
+        {
+            return;
+        }
+
+        States.Add(tabControl, new TabStripScrollState(tabControl));
+    }
+
+    private static void Disable(TabControl tabControl)
+    {
+        if (!States.TryGetValue(tabControl, out var state))
+        {
+            return;
+        }
+
+        state.Dispose();
+        States.Remove(tabControl);
+    }
+
+    private sealed class TabStripScrollState : IDisposable
+    {
+        private readonly TabControl tabControl;
+        private CompositeDisposable compositeDisposable = [];
+        private CompositeDisposable templateSubscriptions = [];
+        private ScrollViewer? tabHeaderScrollViewer;
+        private RepeatButton? scrollLeftButton;
+        private RepeatButton? scrollRightButton;
+        private bool disposed;
+
+        public TabStripScrollState(TabControl tabControl)
+        {
+            this.tabControl = tabControl;
+
+            this.tabControl.TemplateApplied += this.OnTemplateApplied;
+            this.tabControl.Loaded += this.OnTabControlLoaded;
+            this.tabControl.Unloaded += this.OnTabControlUnloaded;
+
+            this.compositeDisposable.Add(this.tabControl
+                .GetObservable(SelectingItemsControl.SelectedIndexProperty)
+                .Subscribe(_ => this.ScrollSelectedTabIntoView()));
+
+            this.compositeDisposable.Add(this.tabControl
+                .GetObservable(TabControl.TabStripPlacementProperty)
+                .Subscribe(_ => this.UpdateScrollButtonState()));
+
+            if (this.tabControl.Items is INotifyCollectionChanged notifyCollectionChanged)
+            {
+                notifyCollectionChanged.CollectionChanged += this.OnItemsChanged;
+                this.compositeDisposable.Add(Disposable.Create(() => notifyCollectionChanged.CollectionChanged -= this.OnItemsChanged));
+            }
+
+            this.TryAttachTemplateParts();
+        }
+
+        private void OnTabControlLoaded(object? sender, RoutedEventArgs e)
+        {
+            this.TryAttachTemplateParts();
+            this.UpdateScrollButtonState();
+            this.ScrollSelectedTabIntoView();
+        }
+
+        private void OnTabControlUnloaded(object? sender, RoutedEventArgs e)
+        {
+            this.templateSubscriptions.Dispose();
+            this.templateSubscriptions = [];
+            this.tabHeaderScrollViewer = null;
+            this.scrollLeftButton = null;
+            this.scrollRightButton = null;
+        }
+
+        private void OnTemplateApplied(object? sender, TemplateAppliedEventArgs e)
+        {
+            this.TryAttachTemplateParts(e.NameScope);
+        }
+
+        private void TryAttachTemplateParts(INameScope? nameScope = null)
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.templateSubscriptions.Dispose();
+            this.templateSubscriptions = [];
+
+            this.tabHeaderScrollViewer = nameScope?.Find<ScrollViewer>("PART_TabHeaderScrollViewer")
+                                       ?? this.tabControl.FindDescendantOfType<ScrollViewer>("PART_TabHeaderScrollViewer");
+            this.scrollLeftButton = nameScope?.Find<RepeatButton>("PART_TabScrollLeftButton")
+                                    ?? this.tabControl.FindDescendantOfType<RepeatButton>("PART_TabScrollLeftButton");
+            this.scrollRightButton = nameScope?.Find<RepeatButton>("PART_TabScrollRightButton")
+                                     ?? this.tabControl.FindDescendantOfType<RepeatButton>("PART_TabScrollRightButton");
+
+            if (this.tabHeaderScrollViewer is null || this.scrollLeftButton is null || this.scrollRightButton is null)
+            {
+                return;
+            }
+
+            var leftButton = this.scrollLeftButton;
+            var rightButton = this.scrollRightButton;
+
+            leftButton.Click += this.OnScrollLeftClick;
+            rightButton.Click += this.OnScrollRightClick;
+
+            this.templateSubscriptions.Add(Disposable.Create(() => leftButton.Click -= this.OnScrollLeftClick));
+            this.templateSubscriptions.Add(Disposable.Create(() => rightButton.Click -= this.OnScrollRightClick));
+            this.templateSubscriptions.Add(this.tabHeaderScrollViewer.GetObservable(ScrollViewer.OffsetProperty).Subscribe(_ => this.UpdateScrollButtonState()));
+            this.templateSubscriptions.Add(this.tabHeaderScrollViewer.GetObservable(ScrollViewer.ViewportProperty).Subscribe(_ => this.UpdateScrollButtonState()));
+            this.templateSubscriptions.Add(this.tabHeaderScrollViewer.GetObservable(ScrollViewer.ExtentProperty).Subscribe(_ => this.UpdateScrollButtonState()));
+            this.templateSubscriptions.Add(this.tabHeaderScrollViewer.GetObservable(Visual.BoundsProperty).Subscribe(_ => this.UpdateScrollButtonState()));
+
+            this.UpdateScrollButtonState();
+            this.ScrollSelectedTabIntoView();
+        }
+
+        private void OnItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            this.UpdateScrollButtonState();
+            this.ScrollSelectedTabIntoView();
+        }
+
+        private void OnScrollLeftClick(object? sender, RoutedEventArgs e)
+        {
+            if (this.tabHeaderScrollViewer is null)
+            {
+                return;
+            }
+
+            this.ScrollBy(-this.GetScrollStep());
+        }
+
+        private void OnScrollRightClick(object? sender, RoutedEventArgs e)
+        {
+            if (this.tabHeaderScrollViewer is null)
+            {
+                return;
+            }
+
+            this.ScrollBy(this.GetScrollStep());
+        }
+
+        private void ScrollBy(double delta)
+        {
+            if (this.tabHeaderScrollViewer is null)
+            {
+                return;
+            }
+
+            double maxOffsetX = Math.Max(0, this.tabHeaderScrollViewer.Extent.Width - this.tabHeaderScrollViewer.Viewport.Width);
+            double newOffsetX = Math.Clamp(this.tabHeaderScrollViewer.Offset.X + delta, 0, maxOffsetX);
+            this.tabHeaderScrollViewer.Offset = new Vector(newOffsetX, this.tabHeaderScrollViewer.Offset.Y);
+        }
+
+        private double GetScrollStep()
+        {
+            if (this.tabHeaderScrollViewer is null)
+            {
+                return 80;
+            }
+
+            return Math.Max(80, this.tabHeaderScrollViewer.Viewport.Width * 0.5);
+        }
+
+        private void ScrollSelectedTabIntoView()
+        {
+            if (this.disposed || this.tabControl.TabStripPlacement != Dock.Top)
+            {
+                return;
+            }
+
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (this.disposed || this.tabControl.SelectedIndex < 0)
+                {
+                    return;
+                }
+
+                if (this.tabControl.ContainerFromIndex(this.tabControl.SelectedIndex) is Control selectedContainer)
+                {
+                    selectedContainer.BringIntoView();
+                    this.UpdateScrollButtonState();
+                }
+            }, DispatcherPriority.Background);
+        }
+
+        private void UpdateScrollButtonState()
+        {
+            if (this.scrollLeftButton is null || this.scrollRightButton is null || this.tabHeaderScrollViewer is null)
+            {
+                return;
+            }
+
+            if (this.tabControl.TabStripPlacement != Dock.Top)
+            {
+                this.scrollLeftButton.IsVisible = false;
+                this.scrollRightButton.IsVisible = false;
+                this.scrollLeftButton.IsEnabled = false;
+                this.scrollRightButton.IsEnabled = false;
+                return;
+            }
+
+            double maxOffsetX = Math.Max(0, this.tabHeaderScrollViewer.Extent.Width - this.tabHeaderScrollViewer.Viewport.Width);
+            bool hasOverflow = maxOffsetX > 0.5;
+
+            this.scrollLeftButton.IsVisible = hasOverflow;
+            this.scrollRightButton.IsVisible = hasOverflow;
+
+            if (!hasOverflow)
+            {
+                this.scrollLeftButton.IsEnabled = false;
+                this.scrollRightButton.IsEnabled = false;
+                return;
+            }
+
+            double offsetX = this.tabHeaderScrollViewer.Offset.X;
+            this.scrollLeftButton.IsEnabled = offsetX > 0.5;
+            this.scrollRightButton.IsEnabled = offsetX < maxOffsetX - 0.5;
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.tabControl.TemplateApplied -= this.OnTemplateApplied;
+            this.tabControl.Loaded -= this.OnTabControlLoaded;
+            this.tabControl.Unloaded -= this.OnTabControlUnloaded;
+            this.templateSubscriptions.Dispose();
+            this.compositeDisposable.Dispose();
+        }
+    }
+
+    private static T? FindDescendantOfType<T>(this Visual visual, string name)
+        where T : StyledElement
+    {
+        return visual.GetVisualDescendants()
+            .OfType<T>()
+            .FirstOrDefault(element => element.Name == name && element.TemplatedParent == visual);
+    }
+}

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -107,7 +107,10 @@
                             Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
                             Stretch="Uniform">
                         <Path.RenderTransform>
-                          <RotateTransform Angle="-90" />
+                          <TransformGroup>
+                            <RotateTransform Angle="90" />
+                            <ScaleTransform ScaleX="-1" />
+                          </TransformGroup>
                         </Path.RenderTransform>
                       </Path>
                     </RepeatButton>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -152,7 +152,7 @@
         </ControlTemplate>
       </Setter>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter">
-        <Setter Property="Margin" Value="0" />
+        <Setter Property="Margin" Value="{DynamicResource TabControlTopItemsPresenterMargin}" />
       </Style>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
         <Setter Property="Margin" Value="0 0 0 0" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -95,7 +95,8 @@
                             BorderBrush="{DynamicResource ButtonBorderBrush}"
                             BorderThickness="{DynamicResource ButtonBorderThickness}"
                             CornerRadius="{DynamicResource ButtonCornerRadius}"
-                            BoxShadow="{DynamicResource TabControlScrollButtonBoxShadow}">
+                            BoxShadow="{DynamicResource TabControlScrollButtonBoxShadow}"
+                            IsVisible="{Binding IsVisible, ElementName=PART_TabScrollLeftButton}">
                       <Grid ColumnDefinitions="Auto,Auto,Auto">
                         <RepeatButton Name="PART_TabScrollLeftButton"
                                       Grid.Column="0"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design"
+                    xmlns:behaviors="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Behaviors">
 
   <Design.PreviewWith>
     <design:ThemePreviewer Padding="20">
@@ -36,11 +37,17 @@
     <Setter Property="Background" Value="{DynamicResource TabControlTabstripBackgroundBrush}" />
 
     <Style Selector="^[TabStripPlacement=Top]">
+      <Setter Property="behaviors:TabStripScrollBehavior.Enable" Value="True" />
       <Setter Property="BorderBrush" Value="{DynamicResource LayoutBorderMidBrush}" />
       <Setter Property="BorderThickness" Value="{DynamicResource TabControlBorderThickness}" />
       <Setter Property="CornerRadius" Value="{DynamicResource LayoutCornerRadius}" />
       <Setter Property="ClipToBounds" Value="False" />
       <Setter Property="Padding" Value="10 -10 10 10" />
+      <Setter Property="ItemsPanel">
+        <ItemsPanelTemplate>
+          <StackPanel Orientation="Horizontal" />
+        </ItemsPanelTemplate>
+      </Setter>
       <Setter Property="Template">
         <ControlTemplate>
           <Border Background="Transparent"
@@ -65,14 +72,69 @@
 
                 <Border Name="TabstripPanel"
                         ClipToBounds="False"
+                        MaxWidth="{Binding Bounds.Width, ElementName=PART_SelectedContentHost}"
                         BorderBrush="{DynamicResource LayoutBorderMidBrush}"
                         BorderThickness="{DynamicResource TabControlTabStripBorderThickness}"
                         CornerRadius="{DynamicResource ControlCornerRadius}"
                         Padding="2 0 0 0">
-
-                  <ItemsPresenter Name="PART_ItemsPresenter"
+                  <Grid ColumnDefinitions="*,Auto,Auto"
+                        ClipToBounds="False">
+                    <ScrollViewer Name="PART_TabHeaderScrollViewer"
+                                  Grid.Column="0"
                                   ClipToBounds="False"
-                                  ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                  HorizontalScrollBarVisibility="Hidden"
+                                  VerticalScrollBarVisibility="Hidden">
+                      <ItemsPresenter Name="PART_ItemsPresenter"
+                                      ClipToBounds="False"
+                                      ItemsPanel="{TemplateBinding ItemsPanel}" />
+                    </ScrollViewer>
+                    <RepeatButton Name="PART_TabScrollLeftButton"
+                                  Grid.Column="1"
+                                  Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
+                                  AutomationProperties.Name="Scroll tabs left"
+                                  IsTabStop="False"
+                                  Focusable="False"
+                                  Foreground="{DynamicResource ForegroundHighBrush}"
+                                  Background="Transparent"
+                                  BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+                                  BorderThickness="1 0 0 0"
+                                  Padding="8 0"
+                                  IsVisible="False"
+                                  IsEnabled="False">
+                      <Path Width="8"
+                            Height="4"
+                            Data="{StaticResource ChevronPath}"
+                            Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
+                            Stretch="Uniform">
+                        <Path.RenderTransform>
+                          <RotateTransform Angle="-90" />
+                        </Path.RenderTransform>
+                      </Path>
+                    </RepeatButton>
+                    <RepeatButton Name="PART_TabScrollRightButton"
+                                  Grid.Column="2"
+                                  Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
+                                  AutomationProperties.Name="Scroll tabs right"
+                                  IsTabStop="False"
+                                  Focusable="False"
+                                  Foreground="{DynamicResource ForegroundHighBrush}"
+                                  Background="Transparent"
+                                  BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+                                  BorderThickness="1 0 0 0"
+                                  Padding="8 0"
+                                  IsVisible="False"
+                                  IsEnabled="False">
+                      <Path Width="8"
+                            Height="4"
+                            Data="{StaticResource ChevronPath}"
+                            Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
+                            Stretch="Uniform">
+                        <Path.RenderTransform>
+                          <RotateTransform Angle="90" />
+                        </Path.RenderTransform>
+                      </Path>
+                    </RepeatButton>
+                  </Grid>
                 </Border>
               </Panel>
 
@@ -99,6 +161,9 @@
         <Setter Property="Padding" Value="20" />
         <Setter Property="Background" Value="{DynamicResource LayoutBackgroundLowBrush}" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
+      </Style>
+      <Style Selector="^/template/ RepeatButton#PART_TabScrollLeftButton:disabled, ^/template/ RepeatButton#PART_TabScrollRightButton:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
       </Style>
     </Style>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -88,55 +88,84 @@
                                       ClipToBounds="False"
                                       ItemsPanel="{TemplateBinding ItemsPanel}" />
                     </ScrollViewer>
-                    <RepeatButton Name="PART_TabScrollLeftButton"
-                                  Grid.Column="1"
-                                  Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
-                                  AutomationProperties.Name="Scroll tabs left"
-                                  IsTabStop="False"
-                                  Focusable="False"
-                                  Foreground="{DynamicResource ForegroundHighBrush}"
-                                  Background="Transparent"
-                                  BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-                                  BorderThickness="1 0 0 0"
-                                  Padding="8 0"
-                                  IsVisible="False"
-                                  IsEnabled="False">
-                      <Path Width="8"
-                            Height="4"
-                            Data="{StaticResource ChevronPath}"
-                            Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
-                            Stretch="Uniform">
-                        <Path.RenderTransform>
-                          <TransformGroup>
-                            <RotateTransform Angle="90" />
-                            <ScaleTransform ScaleX="-1" />
-                          </TransformGroup>
-                        </Path.RenderTransform>
-                      </Path>
-                    </RepeatButton>
-                    <RepeatButton Name="PART_TabScrollRightButton"
-                                  Grid.Column="2"
-                                  Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
-                                  AutomationProperties.Name="Scroll tabs right"
-                                  IsTabStop="False"
-                                  Focusable="False"
-                                  Foreground="{DynamicResource ForegroundHighBrush}"
-                                  Background="Transparent"
-                                  BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-                                  BorderThickness="1 0 0 0"
-                                  Padding="8 0"
-                                  IsVisible="False"
-                                  IsEnabled="False">
-                      <Path Width="8"
-                            Height="4"
-                            Data="{StaticResource ChevronPath}"
-                            Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
-                            Stretch="Uniform">
-                        <Path.RenderTransform>
-                          <RotateTransform Angle="90" />
-                        </Path.RenderTransform>
-                      </Path>
-                    </RepeatButton>
+                    <Border Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            MinHeight="{DynamicResource ButtonMinHeight}"
+                            Background="{DynamicResource ButtonBackgroundBrush}"
+                            BorderBrush="{DynamicResource ButtonBorderBrush}"
+                            BorderThickness="{DynamicResource ButtonBorderThickness}"
+                            CornerRadius="{DynamicResource ButtonCornerRadius}"
+                            BoxShadow="{DynamicResource ButtonBorderBoxShadow}">
+                      <Grid ColumnDefinitions="Auto,Auto,Auto">
+                        <RepeatButton Name="PART_TabScrollLeftButton"
+                                      Grid.Column="0"
+                                      Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
+                                      AutomationProperties.Name="Scroll tabs left"
+                                      IsTabStop="False"
+                                      Focusable="False"
+                                      Foreground="{DynamicResource ForegroundHighBrush}"
+                                      Background="Transparent"
+                                      BorderBrush="Transparent"
+                                      BorderThickness="0"
+                                      MinWidth="22"
+                                      Padding="0"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center"
+                                      IsVisible="False"
+                                      IsEnabled="False">
+                          <PathIcon Width="9"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
+                                    Data="{StaticResource ChevronPath}"
+                                    RenderTransformOrigin="50%,50%">
+                            <PathIcon.RenderTransform>
+                              <TransformGroup>
+                                <RotateTransform Angle="90" />
+                                <ScaleTransform ScaleX="-1" />
+                              </TransformGroup>
+                            </PathIcon.RenderTransform>
+                          </PathIcon>
+                        </RepeatButton>
+
+                        <Rectangle Grid.Column="1"
+                                   HorizontalAlignment="Left"
+                                   Height="15"
+                                   VerticalAlignment="Center"
+                                   Width="{DynamicResource SplitButtonSeparatorWidth}"
+                                   Fill="{DynamicResource ForegroundHighBrush}"
+                                   IsHitTestVisible="False"
+                                   Opacity="0.5" />
+
+                        <RepeatButton Name="PART_TabScrollRightButton"
+                                      Grid.Column="2"
+                                      Theme="{StaticResource FluentButtonSpinnerRepeatButton}"
+                                      AutomationProperties.Name="Scroll tabs right"
+                                      IsTabStop="False"
+                                      Focusable="False"
+                                      Foreground="{DynamicResource ForegroundHighBrush}"
+                                      Background="Transparent"
+                                      BorderBrush="Transparent"
+                                      BorderThickness="0"
+                                      MinWidth="22"
+                                      Padding="0"
+                                      HorizontalContentAlignment="Center"
+                                      VerticalContentAlignment="Center"
+                                      IsVisible="False"
+                                      IsEnabled="False">
+                          <PathIcon Width="9"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RepeatButton}}"
+                                    Data="{StaticResource ChevronPath}"
+                                    RenderTransformOrigin="50%,50%">
+                            <PathIcon.RenderTransform>
+                              <RotateTransform Angle="90" />
+                            </PathIcon.RenderTransform>
+                          </PathIcon>
+                        </RepeatButton>
+                      </Grid>
+                    </Border>
                   </Grid>
                 </Border>
               </Panel>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -95,7 +95,7 @@
                             BorderBrush="{DynamicResource ButtonBorderBrush}"
                             BorderThickness="{DynamicResource ButtonBorderThickness}"
                             CornerRadius="{DynamicResource ButtonCornerRadius}"
-                            BoxShadow="{DynamicResource ButtonBorderBoxShadow}">
+                            BoxShadow="{DynamicResource TabControlScrollButtonBoxShadow}">
                       <Grid ColumnDefinitions="Auto,Auto,Auto">
                         <RepeatButton Name="PART_TabScrollLeftButton"
                                       Grid.Column="0"


### PR DESCRIPTION
Following #553 this implements a similar control on the MacOS TabControl (which previously wrapped excess tabs to appear in rows - functional, but not a very good look)