### PR TITLE
[SampleApp] Preserve launch metadata and window placement across theme switches

### DIFF
--- a/samples/SampleApp/App.axaml.cs
+++ b/samples/SampleApp/App.axaml.cs
@@ -21,6 +21,8 @@ using ViewModels;
 
 public class App : Application
 {
+    private readonly record struct WindowPlacement(PixelPoint Position, double Width, double Height, WindowState State);
+
     // Theme name constants to avoid unnecessary allocations when resolving MacOS automatic theme
     internal const string MacClassicThemeName = "MacClassic";
     internal const string LiquidGlassThemeName = "LiquidGlass";
@@ -323,6 +325,7 @@ public class App : Application
                 // IMPORTANT: Capture state and hide old window BEFORE changing styles
                 // to prevent expensive re-rendering of a window we're about to discard
                 Window? oldWindow = desktopLifetime.MainWindow;
+                WindowPlacement? windowPlacement = CaptureWindowPlacement(oldWindow);
                 int selectedTabIndex = oldWindow is MainWindow oldMainWindow
                     ? oldMainWindow.FindControl<TabControl>("MainTabControl")?.SelectedIndex ?? 0
                     : 0;
@@ -344,7 +347,7 @@ public class App : Application
                 app.themeStylesContainer.Clear();
                 app.themeStylesContainer.AddRange(styles);
 
-                RecreateMainWindow(desktopLifetime, oldWindow, selectedTabIndex);
+                RecreateMainWindow(desktopLifetime, oldWindow, selectedTabIndex, windowPlacement);
             }
             else
             {
@@ -372,11 +375,50 @@ public class App : Application
         DevolutionsMacOsTheme.ClearWallpaperTintResources(app);
     }
 
-    private static void RecreateMainWindow(IClassicDesktopStyleApplicationLifetime lifetime, Window? oldWindow, int selectedTabIndex)
+    private static WindowPlacement? CaptureWindowPlacement(Window? window)
+    {
+        if (window == null)
+        {
+            return null;
+        }
+
+        Rect bounds = window.Bounds;
+        return new WindowPlacement(window.Position, bounds.Width, bounds.Height, window.WindowState);
+    }
+
+    private static void ApplyWindowPlacement(MainWindow window, WindowPlacement? placement)
+    {
+        if (placement is null)
+        {
+            return;
+        }
+
+        WindowPlacement p = placement.Value;
+
+        // Manual startup location prevents centering on the primary display when recreating the window.
+        window.WindowStartupLocation = WindowStartupLocation.Manual;
+        window.Position = p.Position;
+
+        if (p.Width > 0 && p.Height > 0)
+        {
+            window.Width = p.Width;
+            window.Height = p.Height;
+        }
+
+        // Don't carry a minimized state across recreation.
+        window.WindowState = p.State == WindowState.Minimized ? WindowState.Normal : p.State;
+    }
+
+    private static void RecreateMainWindow(
+        IClassicDesktopStyleApplicationLifetime lifetime,
+        Window? oldWindow,
+        int selectedTabIndex,
+        WindowPlacement? windowPlacement)
     {
         object? dataContext = oldWindow?.DataContext;
 
         MainWindow newWindow = new() { DataContext = dataContext };
+        ApplyWindowPlacement(newWindow, windowPlacement);
 
         // Suppress theme change events during window initialization to prevent
         // SelectionChanged from firing multiple times as bindings initialize

--- a/samples/SampleApp/MainWindow.axaml.cs
+++ b/samples/SampleApp/MainWindow.axaml.cs
@@ -15,6 +15,8 @@ using ViewModels;
 
 public partial class MainWindow : Window
 {
+  private static readonly string LaunchTime = DateTime.Now.ToString("MMM d, HH:mm");
+  private static readonly Lazy<Task<string?>> LaunchBranch = new(GetGitBranchAsync);
   private readonly IBrush tieDyeBrush;
   private MainWindowViewModel? currentViewModel;
   private bool suppressThemeChangeEvents;
@@ -277,12 +279,11 @@ public partial class MainWindow : Window
 
   private static async Task<string> BuildWindowTitleAsync(string? baseTitle)
   {
-    string launchTime = DateTime.Now.ToString("MMM d, HH:mm");
     string prefix = string.IsNullOrWhiteSpace(baseTitle) ? "SampleApp" : baseTitle;
-    string? branch = await GetGitBranchAsync();
+    string? branch = await LaunchBranch.Value;
     return string.IsNullOrEmpty(branch)
-      ? $"{prefix} — {launchTime}"
-      : $"{prefix} — {branch} — {launchTime}";
+      ? $"{prefix} — {LaunchTime}"
+      : $"{prefix} — {branch} — {LaunchTime}";
   }
 
   private static async Task<string?> GetGitBranchAsync()


### PR DESCRIPTION
## Summary
- keep SampleApp title metadata stable across theme-triggered window recreation by caching launch time and launch branch once per process
- preserve window placement when recreating `MainWindow` on theme changes (position, size, and window state)
- avoid reopening on the primary display by forcing manual startup location when applying saved placement

## Why
Switching themes intentionally recreates the window. Before this change, that caused:
- title branch/time to refresh to current values instead of original launch values
- the recreated window to jump back to the laptop/primary monitor

This PR keeps both pieces of context stable across theme switches.

## Validation
- `dotnet test` passed (124/124)

## Notes
- minimized state is not carried across recreation; it restores as `Normal` to avoid reopening minimized.