### PR TITLE
Remove empty WinUI theme from build workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -16,10 +16,6 @@ on:
         description: 'AvaloniaTheme.DevExpress'
         type: boolean
         default: false
-      build-winui:
-        description: 'AvaloniaTheme.WinUI'
-        type: boolean
-        default: false
       build-linux:
         description: 'AvaloniaTheme.Linux'
         type: boolean
@@ -116,9 +112,6 @@ jobs:
           if ('${{ inputs.build-devexpress }}' -eq 'true') {
               $Packages += "AvaloniaTheme.DevExpress"
           }
-          if ('${{ inputs.build-winui }}' -eq 'true') {
-              $Packages += "AvaloniaTheme.WinUI"
-          }
           if ('${{ inputs.build-linux }}' -eq 'true') {
               $Packages += "AvaloniaTheme.Linux"
           }
@@ -129,7 +122,6 @@ jobs:
               $Packages = @(
                   "AvaloniaTheme.MacOS",
                   "AvaloniaTheme.DevExpress",
-                  "AvaloniaTheme.WinUI",
                   "AvaloniaTheme.Linux",
                   "AvaloniaControls"
               )


### PR DESCRIPTION
We are halting our efforts to develop a WinUI theme as there may be one coming from Avalonia themselves. 

I'll keep the scaffolding we created for now, but remove it from the build script so it doesn't get inadvertently published at some point ...