### PR TITLE
[Controls] Gate new TreeDataGrid files behind Accelerate license

### DIFF
--- a/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
+++ b/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
@@ -47,6 +47,6 @@
     </ItemGroup>
 
     <PropertyGroup Condition="'$(EnableAccelerate)' != 'true'">
-        <DefaultItemExcludes>$(DefaultItemExcludes);Behaviors/TreeDataGridPseudoTypeBehavior.cs;Behaviors/TreeDataGridAlternatingRowBehavior.cs</DefaultItemExcludes>
+        <DefaultItemExcludes>$(DefaultItemExcludes);Behaviors/TreeDataGridPseudoTypeBehavior.cs;Behaviors/TreeDataGridAlternatingRowBehavior.cs;Controls/DevoTreeDataGridExtensions.cs;Controls/TreeDataGridOverflowHeader.cs</DefaultItemExcludes>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Two newly added files in `Devolutions.AvaloniaControls` reference `TreeDataGridColumn`, a type from the licensed Avalonia Accelerate `Avalonia.Controls.TreeDataGrid` package. That package is only referenced when `EnableAccelerate == 'true'` (i.e. an `AVALONIA_LICENSE_KEY` is present), so the build failed with `CS0246` when building without a license.

This gates the two files the same way the existing TreeDataGrid `Behaviors` files are gated: excluding them from the build via `DefaultItemExcludes` when `EnableAccelerate != 'true'`.

Files added to the exclusion list:
- `Controls/DevoTreeDataGridExtensions.cs`
- `Controls/TreeDataGridOverflowHeader.cs`

Both files are entirely TreeDataGrid-specific (column/header helpers), so whole-file exclusion is the appropriate pattern.

## Testing

- `dotnet build avalonia-extensions.sln` now succeeds without a license key (previously 4 × `CS0246`).

> Note: build was verified with `EnableAccelerate=false` (no license key available locally). Building with `/p:EnableAccelerate=true` was not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)