### PR TITLE
[EditableComboBox] Fix tab navigation

### DIFF
--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -673,7 +673,7 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
 
         foreach (Visual visual in root.GetVisualDescendants())
         {
-            if (visual is not InputElement { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true } stop)
+            if (visual is not InputElement { Focusable: true, IsTabStop: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true } stop)
             {
                 continue;
             }

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/EditableComboBox.axaml.cs
@@ -545,7 +545,10 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
     {
         if (e.Handled) return;
 
-        if (e.Source is InnerTextBox) this.innerTextBox.Focus();
+        // When the composite control itself receives focus (e.g. tabbed or clicked into, rather than a
+        // specific inner element like a side button), route focus to the text box so the caret lands
+        // there — the text box is the control's entry point.
+        if (ReferenceEquals(e.Source, this)) this.innerTextBox.Focus();
     }
 
     protected override void OnInitialized()
@@ -633,25 +636,87 @@ public partial class EditableComboBox : SelectingItemsControl, IInputElement
                 else if (e.Key == Key.Tab)
                 {
                     NavigationDirection? direction = e.Key.ToNavigationDirection(e.KeyModifiers);
-                    if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next))
+                    if (direction is NavigationDirection dir && (dir == NavigationDirection.Previous || dir == NavigationDirection.Next)
+                        && this.TryMoveFocusOutsideOnTab(dir, e.KeyModifiers))
                     {
-                        Visual? containerChild = this;
-                        while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
-                               (containerChild = container as Visual) != null)
-                        {
-                            IInputElement? nextControl = GetNextControl(container, dir, this, false);
-                            if (nextControl is not null)
-                            {
-                                e.Handled = true;
-                                nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                                return;
-                            }
-                        }
+                        e.Handled = true;
+                        return;
                     }
                 }
             }
 
             this.Focus();
+        }
+    }
+
+    /// <summary>
+    /// Moves keyboard focus to the next (or previous) focusable control that lies outside this
+    /// EditableComboBox, using Avalonia's tree-wide tab traversal. Unlike walking a parent Grid's direct
+    /// children, this works regardless of how the control is nested (e.g. wrapped in a StackPanel). The
+    /// control's own inner content is navigated separately (in InnerComboBox) before this is reached.
+    /// </summary>
+    private bool TryMoveFocusOutsideOnTab(NavigationDirection direction, KeyModifiers keyModifiers)
+    {
+        if (TopLevel.GetTopLevel(this) is not Visual root)
+        {
+            return false;
+        }
+
+        // Single pass over the window's visual tree in document order (the default tab order). Walking the
+        // whole tree (rather than a parent Grid's direct children) means this works no matter how the control
+        // is nested, e.g. wrapped in a StackPanel. This control's own subtree (chrome + inner content) is
+        // contiguous in that order, so we can find the focusable stop just outside it without materializing
+        // the full list. Inner content was already navigated in InnerComboBox.
+        bool forward = direction != NavigationDirection.Previous;
+        InputElement? beforeSelf = null; // last stop before our subtree — the target when tabbing backward
+        bool pastSelf = false;
+
+        foreach (Visual visual in root.GetVisualDescendants())
+        {
+            if (visual is not InputElement { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true } stop)
+            {
+                continue;
+            }
+
+            if (IsSelfOrDescendant(stop))
+            {
+                if (!forward)
+                {
+                    break; // going back: the last stop before our subtree (beforeSelf) is the answer
+                }
+
+                pastSelf = true;
+                continue;
+            }
+
+            if (forward && pastSelf)
+            {
+                stop.Focus(NavigationMethod.Tab, keyModifiers); // first stop after our subtree
+                return true;
+            }
+
+            beforeSelf = stop;
+        }
+
+        if (!forward && beforeSelf is not null)
+        {
+            beforeSelf.Focus(NavigationMethod.Tab, keyModifiers);
+            return true;
+        }
+
+        return false;
+
+        bool IsSelfOrDescendant(Visual v)
+        {
+            for (Visual? p = v; p is not null; p = p.GetVisualParent())
+            {
+                if (ReferenceEquals(p, this))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 

--- a/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/EditableComboBox/InnerComboBox.cs
@@ -206,39 +206,12 @@ public partial class EditableComboBox
                     return;
                 }
 
-                Visual? containerChild = this.parent;
-                while (containerChild.FindAncestorOfType<INavigableContainer>() is { } container &&
-                       (containerChild = container as Visual) != null)
+                // Inner content is exhausted; move focus to the next control outside the EditableComboBox.
+                // Delegated to a tree-wide traversal so it works no matter how the control is nested.
+                if (this.parent.TryMoveFocusOutsideOnTab(dir, e.KeyModifiers))
                 {
-                    nextControl = GetNextControl(container, dir, this.parent, false);
-                    if (nextControl is not null)
-                    {
-                        e.Handled = true;
-                        nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                        return;
-                    }
-                }
-
-                containerChild = this.parent;
-                while (containerChild.FindAncestorOfType<Grid>() is { } grid)
-                {
-                    int index = -1;
-                    if (containerChild is Control control) index = grid.Children.IndexOf(control);
-
-                    int increment = dir == NavigationDirection.Previous ? -1 : 1;
-                    index += increment;
-                    for (; 0 <= index && index < grid.Children.Count; index += increment)
-                    {
-                        nextControl = grid.Children[index];
-                        if (nextControl is { Focusable: true, IsEffectivelyVisible: true, IsEffectivelyEnabled: true })
-                        {
-                            e.Handled = true;
-                            nextControl.Focus(NavigationMethod.Tab, e.KeyModifiers);
-                            return;
-                        }
-                    }
-
-                    containerChild = grid;
+                    e.Handled = true;
+                    return;
                 }
             }
 


### PR DESCRIPTION
## Summary

Tab / Shift+Tab through an `EditableComboBox` misbehaved when the control was **nested** (e.g. wrapped in a `StackPanel`). The bespoke tab-out logic assumed the control was a direct `Grid` child, so it jumped to the wrong control and could not tab backward at all. This was reproducible in the Grouping section of the EditableComboBox demo, where the combos are wrapped in `StackPanel`s.

## Changes

- **Tab-out traversal.** Replaced the grid-child-based logic with `TryMoveFocusOutsideOnTab`, a single document-order (visual-tree) walk that steps to the focusable control just outside this control's own subtree, in either direction, regardless of nesting. Both the closed-dropdown path (`InnerComboBox`) and the open-dropdown Tab path (`EditableComboBox`) route through it.
- **Focus entry.** `OnGotFocus` now redirects to the inner text box when the composite control *itself* receives focus (rather than a specific inner element such as a side button). Previously it only redirected when the source was already the text box, so focus got stuck on the outer control — a phantom stop with no caret — and combos with side buttons landed on the first button instead of the text box.

## Known limitation

The tab-out walk uses **document order and does not honor explicit `TabIndex`**. This is **not a regression** — the previous implementation (a `Grid.Children` walk) didn't honor `TabIndex` either. Avalonia's own `TabIndex`-aware traversal (`KeyboardNavigationHandler.GetNext`) is `internal` and unusable from here, which is why the walk is reimplemented by hand. A stable `TabIndex` sort could be layered on later if a real use case needs it.

## Testing

- Control library + SampleApp build clean (0 errors).
- Manually validated in the SampleApp Grouping section (macOS theme): Tab lands on each combo's text box (caret visible) with no phantom stop; the inner-slots combo hits the text box first, then its side buttons; Shift+Tab reverses cleanly.