### PR TITLE
[MultiComboBox] Add grouping support

### DIFF
--- a/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
+++ b/samples/SampleApp/DemoPages/MultiComboBoxDemo.axaml
@@ -301,6 +301,144 @@
         </MultiComboBox>
         <TextBlock Text="{Binding LotOfItemsSelectedItemsText, StringFormat='Selection: {0}'}" ToolTip.Tip="{Binding LotOfItemsSelectedItemsText}" />
       </StackPanel>
+
+      <StackPanel Width="240" HorizontalAlignment="Left" Spacing="10">
+        <TextBlock FontWeight="Bold" FontSize="16">Grouping</TextBlock>
+        <TextBlock TextWrapping="Wrap" Foreground="{DynamicResource TextControlPlaceholderForeground}">
+          Items are grouped under headers. Each header has a leading tri-state check box that
+          selects/deselects the whole group (mixed = only some selected). Grouping is data-driven
+          via GroupBinding/GroupSelector.
+        </TextBlock>
+
+        <TextBlock>Named groups + Select All</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="Grouped"
+          SelectAllText="Select All"
+          ItemsSource="{Binding GroupedItems}"
+          SelectedItems="{Binding GroupedSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderSelector="{Binding CategoryGroupOrderSelector}"
+          GroupOrderAlphabetical="True">
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+        <TextBlock Text="{Binding GroupedSelectedText, StringFormat='Selected: {0}'}" TextWrapping="Wrap" />
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>GroupOrderBinding (Group.SortOrder)</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="Ordered by SortOrder"
+          SelectAllText="Select All"
+          ItemsSource="{Binding GroupedItems}"
+          SelectedItems="{Binding GroupedOrderBindingSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderBinding="{Binding Group.SortOrder}">
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>Empty group (headerless)</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="Empty group unset"
+          SelectAllText="Select All"
+          ItemsSource="{Binding EmptyGroupItems}"
+          SelectedItems="{Binding EmptyGroupSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderSelector="{Binding EmptyGroupFirstSelector}">
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>Empty group named + HeaderForeground</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="Empty group named"
+          SelectAllText="Select All"
+          ItemsSource="{Binding EmptyGroupItems}"
+          SelectedItems="{Binding EmptyGroupNamedSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderSelector="{Binding EmptyGroupFirstSelector}"
+          EmptyGroupName="NO GROUP"
+          HeaderForeground="#266FD2">
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>Large grouped (virtualization + filter)</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="1500 grouped items"
+          SelectAllText="Select All"
+          ShowFilter="True"
+          FilterText="Find an option..."
+          ItemsSource="{Binding LargeGroupedItems}"
+          SelectedItems="{Binding LargeGroupedSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderAlphabetical="True">
+          <MultiComboBox.ItemsPanel>
+            <ItemsPanelTemplate>
+              <VirtualizingStackPanel />
+            </ItemsPanelTemplate>
+          </MultiComboBox.ItemsPanel>
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+
+        <Separator Margin="-10 10" />
+
+        <TextBlock>Custom HeaderTemplate</TextBlock>
+        <MultiComboBox
+          HorizontalAlignment="Left"
+          PlaceholderText="Custom headers"
+          SelectAllText="Select All"
+          ItemsSource="{Binding GroupedItems}"
+          SelectedItems="{Binding HeaderTemplateSelectedItems}"
+          GroupBinding="{Binding Category}"
+          GroupOrderSelector="{Binding CategoryGroupOrderSelector}"
+          GroupOrderAlphabetical="True">
+          <MultiComboBox.HeaderTemplate>
+            <DataTemplate>
+              <Border
+                Background="{DynamicResource SystemControlForegroundAccentBrush}"
+                CornerRadius="3"
+                Padding="6 2"
+                HorizontalAlignment="Left">
+                <TextBlock Text="{Binding}" Foreground="White" FontWeight="Bold" FontSize="11" />
+              </Border>
+            </DataTemplate>
+          </MultiComboBox.HeaderTemplate>
+          <MultiComboBox.ItemTemplate>
+            <DataTemplate x:DataType="vm:FoodItem">
+              <SearchHighlightTextBlock Content="{Binding Name}" />
+            </DataTemplate>
+          </MultiComboBox.ItemTemplate>
+        </MultiComboBox>
+      </StackPanel>
     </StackPanel>
   </Border>
 </UserControl>

--- a/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
+++ b/samples/SampleApp/ViewModels/MultiComboBoxViewModel.cs
@@ -1,8 +1,10 @@
 namespace SampleApp.ViewModels;
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Devolutions.AvaloniaControls.Controls;
@@ -38,7 +40,11 @@ public partial class MultiComboBoxViewModel : ObservableValidator
 
     public MultiComboBoxViewModel()
     {
+        // Pre-select part of the "Fruits" group so its header starts in the mixed (indeterminate) state.
+        this.GroupedSelectedItems = [this.GroupedItems[0], this.GroupedItems[1]];
+
         this.SelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedText));
+        this.GroupedSelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.GroupedSelectedText));
         this.SelectedEnumValues.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.SelectedEnumValuesText));
         this.LotOfItemsSelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.LotOfItemsSelectedItemsText));
         this.InlineSelectedItems.CollectionChanged += (_, _) => this.OnPropertyChanged(nameof(this.InlineSelectedItemsText));
@@ -74,4 +80,77 @@ public partial class MultiComboBoxViewModel : ObservableValidator
     public string SelectedText => this.SelectedItems.Count > 0 ? string.Join(", ", this.SelectedItems) : "None";
 
     public string SelectedEnumValuesText => this.SelectedEnumValues.Count > 0 ? string.Join(", ", this.SelectedEnumValues) : "None";
+
+    // --- Grouping demo (mirrors the EditableComboBox / GroupedComboBox demo set, for MultiComboBox) ---
+
+    // Shared group objects (name + sort order), reused across the items that belong to them.
+    private static readonly FoodGroup Meats = new("Meats", 0);
+    private static readonly FoodGroup Fruits = new("Fruits", 1);
+    private static readonly FoodGroup Vegetables = new("Vegetables", 2);
+
+    public IReadOnlyList<FoodItem> GroupedItems { get; } =
+    [
+        new("Apple", Fruits),
+        new("Banana", Fruits),
+        new("Orange", Fruits),
+        new("Strawberry", Fruits),
+        new("Carrot", Vegetables),
+        new("Broccoli", Vegetables),
+        new("Lettuce", Vegetables),
+        new("Chicken", Meats),
+        new("Beef", Meats),
+        new("Pork", Meats),
+    ];
+
+    // Start with a partial selection in one group so the group header shows the mixed (indeterminate) state.
+    public AvaloniaList<FoodItem> GroupedSelectedItems { get; }
+
+    public AvaloniaList<FoodItem> GroupedOrderBindingSelectedItems { get; } = [];
+
+    // Empty-category items render with no header at the top of the drop-down (when EmptyGroupName is unset);
+    // the remaining categories follow under their own headers.
+    public IReadOnlyList<FoodItem> EmptyGroupItems { get; } =
+    [
+        new("Water", ""),
+        new("Salt", ""),
+        new("Sugar", ""),
+        new("Coffee", "Beverages"),
+        new("Tea", "Beverages"),
+        new("Juice", "Beverages"),
+        new("Chips", "Snacks"),
+        new("Cookies", "Snacks"),
+        new("Crackers", "Snacks"),
+    ];
+
+    public AvaloniaList<FoodItem> EmptyGroupSelectedItems { get; } = [];
+
+    public AvaloniaList<FoodItem> EmptyGroupNamedSelectedItems { get; } = [];
+
+    public IReadOnlyList<FoodItem> LargeGroupedItems { get; } = GenerateLargeGroupedItems();
+
+    public AvaloniaList<FoodItem> LargeGroupedSelectedItems { get; } = [];
+
+    public AvaloniaList<FoodItem> HeaderTemplateSelectedItems { get; } = [];
+
+    public Func<string, int> CategoryGroupOrderSelector { get; } = group => group switch
+    {
+        "Meats" => 0,
+        "Fruits" => 1,
+        "Vegetables" => 2,
+        _ => 999,
+    };
+
+    public Func<string, int> EmptyGroupFirstSelector { get; } = group => string.IsNullOrEmpty(group) ? 0 : 1;
+
+    public string GroupedSelectedText =>
+        this.GroupedSelectedItems.Count > 0 ? string.Join(", ", this.GroupedSelectedItems.Select(i => i.Name)) : "None";
+
+    private static List<FoodItem> GenerateLargeGroupedItems()
+    {
+        List<FoodItem> items = new(1500);
+        for (int i = 1; i <= 600; ++i) items.Add(new FoodItem($"Alpha Item {i:D3}", "Category Alpha"));
+        for (int i = 1; i <= 600; ++i) items.Add(new FoodItem($"Beta Item {i:D3}", "Category Beta"));
+        for (int i = 1; i <= 300; ++i) items.Add(new FoodItem($"Gamma Item {i:D3}", "Category Gamma"));
+        return items;
+    }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/InnerMultiComboBoxList.axaml.cs
@@ -2,6 +2,10 @@ namespace Devolutions.AvaloniaControls.Controls;
 
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Markup.Xaml.MarkupExtensions;
+
+using Converters;
 
 public partial class MultiComboBox
 {
@@ -11,6 +15,8 @@ public partial class MultiComboBox
     /// </summary>
     internal class InnerMultiComboBoxList : SelectingItemsControl
     {
+        private static readonly object HeaderRecycleKey = typeof(MultiComboBoxGroupHeader);
+
         private readonly MultiComboBox parent;
 
         public InnerMultiComboBoxList(MultiComboBox parent)
@@ -19,18 +25,30 @@ public partial class MultiComboBox
         }
 
         protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey) =>
-            new MultiComboBoxItem();
+            recycleKey == HeaderRecycleKey
+                ? new MultiComboBoxGroupHeaderItem()
+                : new MultiComboBoxItem();
 
         protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
         {
-            recycleKey = DefaultRecycleKey;
+            recycleKey = item is MultiComboBoxGroupHeader ? HeaderRecycleKey : DefaultRecycleKey;
             return true;
         }
 
         protected override void ClearContainerForItemOverride(Control element)
         {
             base.ClearContainerForItemOverride(element);
-            if (element is MultiComboBoxItem multiComboBoxItem)
+            if (element is MultiComboBoxGroupHeaderItem headerContainer)
+            {
+                headerContainer.ClearValue(MultiComboBoxGroupHeaderItem.ForegroundProperty);
+                headerContainer.ClearValue(ContentControl.ContentTemplateProperty);
+                headerContainer.Content = null;
+                headerContainer.GroupItems = null;
+                headerContainer.BeginUpdate();
+                headerContainer.ClearValue(MultiComboBoxGroupHeaderItem.IsSelectedProperty);
+                headerContainer.EndUpdate();
+            }
+            else if (element is MultiComboBoxItem multiComboBoxItem)
             {
                 multiComboBoxItem.DataContext = null;
                 multiComboBoxItem.ClearValue(ContentControl.ContentProperty);
@@ -45,6 +63,36 @@ public partial class MultiComboBox
         protected override void PrepareContainerForItemOverride(Control container, object? item, int index)
         {
             base.PrepareContainerForItemOverride(container, item, index);
+
+            if (container is MultiComboBoxGroupHeaderItem headerContainer)
+            {
+                if (item is MultiComboBoxGroupHeader header)
+                {
+                    headerContainer[!MultiComboBoxGroupHeaderItem.ForegroundProperty] = new MultiBinding
+                    {
+                        Converter = new FirstNonNullValueMultiConverter(),
+                        Bindings =
+                        [
+                            // This method itself uses no dynamic code. It references MultiComboBox.HeaderForegroundProperty
+                            // (a StyledProperty field), which merely triggers MultiComboBox's static constructor — that ctor
+                            // only registers properties/handlers and is trim/AOT-safe. The warning is inherited from
+                            // MultiComboBox's class-level annotation (added for its lazily-invoked BindingEvaluator usage).
+#pragma warning disable IL2026
+#pragma warning disable IL3050
+                            this.parent[!MultiComboBox.HeaderForegroundProperty],
+#pragma warning restore IL3050
+#pragma warning restore IL2026
+                            new DynamicResourceExtension("SystemControlForegroundAccentBrush"),
+                        ],
+                    };
+                    headerContainer.Content = header;
+                    headerContainer.GroupItems = header.Items;
+                }
+
+                headerContainer.ContentTemplate = this.parent.HeaderTemplate;
+                headerContainer.UpdateSelection();
+                return;
+            }
 
             if (container is not MultiComboBoxItem multiComboBoxItem)
             {
@@ -66,6 +114,10 @@ public partial class MultiComboBox
             multiComboBoxItem.BeginUpdate();
             multiComboBoxItem.IsSelected = isSelected;
             multiComboBoxItem.EndUpdate();
+
+            // In grouped mode, indent items so they read as children of the group header
+            // (mirrors the checkmark-column reservation that ComboBox/GroupedComboBox items have).
+            multiComboBoxItem.SetGrouped(this.parent.IsGrouped);
         }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -1170,7 +1170,9 @@ public partial class MultiComboBox : SelectingItemsControl
     {
         if (this.selectAllItem is not null && CanFocus(this.selectAllItem))
         {
-            return this.selectAllItem.Focus();
+            // Directional (like FocusFirstItem) so the :focus-visible keyboard-focus styles activate —
+            // Focus() alone reports an unspecified navigation method and leaves the row without focus feedback.
+            return this.selectAllItem.Focus(NavigationMethod.Directional);
         }
 
         return false;

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBox.axaml.cs
@@ -21,6 +21,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Metadata;
 using Avalonia.VisualTree;
+using Helpers;
 using static Extensions.AvaloniaExtensions;
 using AvaloniaPropertyExtension = Irihi.Avalonia.Shared.Helpers.AvaloniaPropertyExtension;
 using ObservableExtension = Irihi.Avalonia.Shared.Helpers.ObservableExtension;
@@ -41,6 +42,8 @@ public enum MultiComboBoxOverflowMode
 [TemplatePart("PART_SelectedItemsList", typeof(ItemsControl), IsRequired = true)]
 [TemplatePart(PART_BackgroundBorder, typeof(Border))]
 [PseudoClasses(PC_DropDownOpen, PC_Empty)]
+[RequiresUnreferencedCode("BindingEvaluator require preserved types")]
+[RequiresDynamicCode("BindingEvaluator require preserved types")]
 public partial class MultiComboBox : SelectingItemsControl
 {
     public const string PART_BackgroundBorder = "PART_BackgroundBorder";
@@ -141,6 +144,34 @@ public partial class MultiComboBox : SelectingItemsControl
         AvaloniaProperty.RegisterDirect<MultiComboBox, bool?>(nameof(IsAllSelected),
             static o => o.IsAllSelected);
 
+    public static readonly StyledProperty<Func<object, string>?> GroupSelectorProperty =
+        AvaloniaProperty.Register<MultiComboBox, Func<object, string>?>("GroupSelector");
+
+    public static readonly StyledProperty<BindingBase?> GroupBindingProperty =
+        AvaloniaProperty.Register<MultiComboBox, BindingBase?>(nameof(GroupBinding));
+
+    public static readonly StyledProperty<bool> GroupOrderAlphabeticalProperty =
+        AvaloniaProperty.Register<MultiComboBox, bool>(nameof(GroupOrderAlphabetical));
+
+    public static readonly StyledProperty<Func<string, int>?> GroupOrderSelectorProperty =
+        AvaloniaProperty.Register<MultiComboBox, Func<string, int>?>("GroupOrderSelector");
+
+    public static readonly StyledProperty<BindingBase?> GroupOrderBindingProperty =
+        AvaloniaProperty.Register<MultiComboBox, BindingBase?>(nameof(GroupOrderBinding));
+
+    public static readonly StyledProperty<IBrush?> HeaderForegroundProperty =
+        AvaloniaProperty.Register<MultiComboBox, IBrush?>(nameof(HeaderForeground));
+
+    public static readonly StyledProperty<IDataTemplate?> HeaderTemplateProperty =
+        AvaloniaProperty.Register<MultiComboBox, IDataTemplate?>(nameof(HeaderTemplate));
+
+    /// <summary>
+    /// Display name to use for the empty/null group key. When <c>null</c>, items in the empty
+    /// group render without a header (e.g. an "uncategorized" bucket shown at the top of the drop-down).
+    /// </summary>
+    public static readonly StyledProperty<string?> EmptyGroupNameProperty =
+        AvaloniaProperty.Register<MultiComboBox, string?>(nameof(EmptyGroupName));
+
     private static readonly ITemplate<Panel> DefaultSelectedItemsPanel =
         new FuncTemplate<Panel>(static () => new VirtualizingStackPanel { Orientation = Orientation.Horizontal, Background = Brushes.Transparent });
 
@@ -168,7 +199,11 @@ public partial class MultiComboBox : SelectingItemsControl
     private ScrollViewer? selectionScrollViewer;
 
     private bool updateInternal;
-    
+
+    private bool isGrouped;
+
+    private BindingEvaluator? bindingEvaluator;
+
     private System.ComponentModel.INotifyDataErrorInfo? boundDataErrorInfo;
     
     private string? boundPropertyName;
@@ -179,6 +214,13 @@ public partial class MultiComboBox : SelectingItemsControl
         ItemsPanelProperty.OverrideDefaultValue<MultiComboBox>(DefaultPanel);
         AvaloniaPropertyExtension.AffectsPseudoClass<MultiComboBox>(IsDropDownOpenProperty, PC_DropDownOpen);
         SelectedItemsProperty.Changed.AddClassHandler<MultiComboBox, IList?>(static (box, args) => box.OnSelectedItemsChanged(args));
+
+        GroupSelectorProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
+        GroupBindingProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
+        GroupOrderAlphabeticalProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
+        GroupOrderSelectorProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
+        GroupOrderBindingProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
+        EmptyGroupNameProperty.Changed.AddClassHandler<MultiComboBox>((x, _) => x.ApplyFilter(null));
     }
 
     public MultiComboBox()
@@ -220,6 +262,9 @@ public partial class MultiComboBox : SelectingItemsControl
     }
 
     public AvaloniaList<object?> FilteredItems { get; } = [];
+
+    /// <summary>True when a group selector is configured, i.e. the drop-down is showing grouped items with headers.</summary>
+    internal bool IsGrouped => this.isGrouped;
 
     public ITemplate<Panel>? SelectedItemsPanel
     {
@@ -377,6 +422,66 @@ public partial class MultiComboBox : SelectingItemsControl
         }
     }
 
+    [Obsolete("Use GroupBinding instead for XAML-friendly, type-checked group selection.")]
+    public Func<object, string>? GroupSelector
+    {
+        get => this.GetValue(GroupSelectorProperty);
+        set => this.SetValue(GroupSelectorProperty, value);
+    }
+
+    [AssignBinding]
+    [InheritDataTypeFromItems(nameof(ItemsSource))]
+    public BindingBase? GroupBinding
+    {
+        get => this.GetValue(GroupBindingProperty);
+        set => this.SetValue(GroupBindingProperty, value);
+    }
+
+    public bool GroupOrderAlphabetical
+    {
+        get => this.GetValue(GroupOrderAlphabeticalProperty);
+        set => this.SetValue(GroupOrderAlphabeticalProperty, value);
+    }
+
+    public Func<string, int>? GroupOrderSelector
+    {
+        get => this.GetValue(GroupOrderSelectorProperty);
+        set => this.SetValue(GroupOrderSelectorProperty, value);
+    }
+
+    /// <summary>
+    /// Binding used to order the groups. It is evaluated against a single representative item of each group,
+    /// so the bound value must be consistent for every item in the same group — i.e. a function of the same
+    /// grouping defined by <see cref="GroupBinding"/>/<see cref="GroupSelector"/> (for example, bind to a
+    /// property of the shared group object). The raw value is used for comparison, so a numeric property
+    /// sorts numerically.
+    /// </summary>
+    [AssignBinding]
+    [InheritDataTypeFromItems(nameof(ItemsSource))]
+    public BindingBase? GroupOrderBinding
+    {
+        get => this.GetValue(GroupOrderBindingProperty);
+        set => this.SetValue(GroupOrderBindingProperty, value);
+    }
+
+    public IBrush? HeaderForeground
+    {
+        get => this.GetValue(HeaderForegroundProperty);
+        set => this.SetValue(HeaderForegroundProperty, value);
+    }
+
+    public IDataTemplate? HeaderTemplate
+    {
+        get => this.GetValue(HeaderTemplateProperty);
+        set => this.SetValue(HeaderTemplateProperty, value);
+    }
+
+    public string? EmptyGroupName
+    {
+        get => this.GetValue(EmptyGroupNameProperty);
+        set => this.SetValue(EmptyGroupNameProperty, value);
+    }
+
     private void OnDropDownOpenChanged((bool oldValue, bool newValue) oldAndNewValue)
     {
         if (oldAndNewValue.oldValue == oldAndNewValue.newValue) return;
@@ -472,6 +577,10 @@ public partial class MultiComboBox : SelectingItemsControl
                 {
                     i.Select();
                 }
+                else if (container is MultiComboBoxGroupHeaderItem h)
+                {
+                    h.UpdateSelection();
+                }
             }
         }
 
@@ -498,6 +607,76 @@ public partial class MultiComboBox : SelectingItemsControl
             // won't fire our `OnSelectedItemsCollectionChanged` event
             this.DoOnSelectedItemsCollectionChanged();
         }
+    }
+
+    /// <summary>
+    /// Adds every item of a group to <see cref="SelectedItems"/> (skipping already-selected ones), then
+    /// refreshes the drop-down once. Batched under <see cref="updateInternal"/> so the per-add collection
+    /// notifications don't re-enter <see cref="ApplyCurrentSelectionState"/> for each item. Used by a group
+    /// header's leading check box; operates on the group's full membership regardless of any active filter.
+    /// </summary>
+    public void SelectGroup(IReadOnlyList<object> items)
+    {
+        if (this.SelectedItems is null || items.Count == 0) return;
+
+        this.updateInternal = true;
+
+        foreach (object item in items)
+        {
+            this.GetMultiComboBoxItemContainer(item)?.BeginUpdate();
+        }
+
+        foreach (object item in items)
+        {
+            if (!this.SelectedItems.Contains(item))
+            {
+                this.SelectedItems.Add(item);
+            }
+        }
+
+        foreach (object item in items)
+        {
+            this.GetMultiComboBoxItemContainer(item)?.EndUpdate();
+        }
+
+        this.updateInternal = false;
+
+        this.SyncDisplaySelectedItems();
+        this.ApplyCurrentSelectionState();
+    }
+
+    /// <summary>
+    /// Removes every item of a group from <see cref="SelectedItems"/>, then refreshes the drop-down once.
+    /// Counterpart to <see cref="SelectGroup"/>.
+    /// </summary>
+    public void DeselectGroup(IReadOnlyList<object> items)
+    {
+        if (this.SelectedItems is null || items.Count == 0) return;
+
+        this.updateInternal = true;
+
+        foreach (object item in items)
+        {
+            this.GetMultiComboBoxItemContainer(item)?.BeginUpdate();
+        }
+
+        foreach (object item in items)
+        {
+            while (this.SelectedItems.Contains(item))
+            {
+                this.SelectedItems.Remove(item);
+            }
+        }
+
+        foreach (object item in items)
+        {
+            this.GetMultiComboBoxItemContainer(item)?.EndUpdate();
+        }
+
+        this.updateInternal = false;
+
+        this.SyncDisplaySelectedItems();
+        this.ApplyCurrentSelectionState();
     }
 
     protected override void OnInitialized()
@@ -651,7 +830,59 @@ public partial class MultiComboBox : SelectingItemsControl
 
         // Re-populate filtered items based on current filter
         this.FilteredItems.Clear();
-        this.FilteredItems.AddRange(hasFilterText ? this.ItemsView.Where(item =>  this.ItemMatchesFilter(item, filterText)) :  this.ItemsView);
+
+        Func<object, string>? groupSelector = this.ResolveGroupSelector();
+        this.isGrouped = groupSelector is not null;
+        if (groupSelector is null)
+        {
+            // Un-grouped: preserve the original behavior exactly.
+            this.FilteredItems.AddRange(hasFilterText
+                ? this.ItemsView.Where(item => this.ItemMatchesFilter(item, filterText))
+                : this.ItemsView);
+            return;
+        }
+
+        // Grouped: headers carry each group's full membership so a group's leading check box operates on
+        // the whole group; the itemFilter still hides non-matching rows and drops fully-filtered groups.
+        this.FilteredItems.AddRange(
+            ComboBoxGroupedItemsBuilder.Build(
+                this.ItemsView,
+                groupSelector,
+                this.ResolveGroupOrderSelector(groupSelector),
+                this.GroupOrderAlphabetical,
+                this.EmptyGroupName,
+                headerFactory: static (name, items) => new MultiComboBoxGroupHeader(name, items),
+                itemFilter: hasFilterText ? item => this.ItemMatchesFilter(item, filterText) : null));
+    }
+
+    private Func<object, string>? ResolveGroupSelector()
+    {
+        if (this.GetValue(GroupBindingProperty) is { } binding)
+        {
+            this.bindingEvaluator ??= BindingEvaluator.FromItemsControl(this);
+            return this.bindingEvaluator?.BuildFormattedGetter(binding);
+        }
+
+        return this.GetValue(GroupSelectorProperty);
+    }
+
+    private Func<object, object?>? ResolveGroupOrderSelector(Func<object, string>? groupSelector)
+    {
+        // GroupOrderBinding reads the sort order off each item (like GroupBinding reads the group key),
+        // keeping the raw value so numeric orders sort numerically (10 after 2, not lexically).
+        if (this.GetValue(GroupOrderBindingProperty) is { } binding)
+        {
+            this.bindingEvaluator ??= BindingEvaluator.FromItemsControl(this);
+            return this.bindingEvaluator?.BuildRawGetter(binding);
+        }
+
+        // GroupOrderSelector maps a group key to an order; adapt it to operate on an item.
+        if (this.GetValue(GroupOrderSelectorProperty) is { } orderFn && groupSelector is not null)
+        {
+            return item => orderFn(groupSelector(item));
+        }
+
+        return null;
     }
 
     private bool ItemMatchesFilter(object? item, string? filterText)
@@ -818,6 +1049,10 @@ public partial class MultiComboBox : SelectingItemsControl
                 {
                     i.UpdateSelection();
                 }
+                else if (container is MultiComboBoxGroupHeaderItem h)
+                {
+                    h.UpdateSelection();
+                }
             }
         }
 
@@ -968,6 +1203,12 @@ public partial class MultiComboBox : SelectingItemsControl
             if (dropdownItem is MultiComboBoxItem { IsFocused: true } multiComboBoxItem)
             {
                 multiComboBoxItem.IsSelected = !multiComboBoxItem.IsSelected;
+                break;
+            }
+
+            if (dropdownItem is MultiComboBoxGroupHeaderItem { IsFocused: true } headerItem)
+            {
+                headerItem.IsSelected = headerItem.IsSelected is null or false;
                 break;
             }
         }

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxGroupHeader.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxGroupHeader.cs
@@ -1,0 +1,25 @@
+namespace Devolutions.AvaloniaControls.Controls;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Non-selectable header pseudo-item interleaved into a <see cref="MultiComboBox"/> drop-down.
+/// Unlike <see cref="ComboBoxGroupHeader"/> (text only), it also carries its group's full,
+/// unfiltered membership so the header's leading check box can select/deselect the whole group
+/// and reflect a mixed (indeterminate) state — even while the drop-down shows only a filtered subset.
+/// </summary>
+internal sealed class MultiComboBoxGroupHeader
+{
+    public MultiComboBoxGroupHeader(string? text, IReadOnlyList<object> items)
+    {
+        this.Text = text;
+        this.Items = items;
+    }
+
+    public string? Text { get; }
+
+    /// <summary>The full (unfiltered) set of items belonging to this group.</summary>
+    public IReadOnlyList<object> Items { get; }
+
+    public override string? ToString() => this.Text;
+}

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml
@@ -3,12 +3,14 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <Design.PreviewWith>
-    <StackPanel Height="200">
+    <StackPanel Height="240">
       <MultiComboBoxItem Content="Option 1" />
       <MultiComboBoxItem Content="Option 2" IsEnabled="False" />
       <MultiComboBoxItem Content="Option 3" IsSelected="True" IsEnabled="False" />
       <Separator Margin="0 5" />
       <MultiComboBoxSelectAllItem Content="Option 1" />
+      <Separator Margin="0 5" />
+      <MultiComboBoxGroupHeaderItem Content="Group A" />
     </StackPanel>
   </Design.PreviewWith>
 
@@ -50,6 +52,12 @@
         </Border>
       </ControlTemplate>
     </Setter>
+
+    <!-- Grouped mode: indent items so they read as children of the group header. -->
+    <Style Selector="^:grouped /template/ CheckBox">
+      <Setter Property="Margin" Value="16 0 0 0" />
+    </Style>
+
     <Style Selector="^:disabled">
       <Setter Property="Foreground" Value="{DynamicResource ListBoxItemDisabledForeground}" />
       <Setter Property="Background" Value="{DynamicResource ListBoxItemDisabledBackground}" />
@@ -64,12 +72,75 @@
       <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
-      <Style Selector="^ /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
-      </Style>
+    <!-- Focused (keyboard) state only — a mouse click doesn't leave a persisting highlight -->
+    <Style Selector="^:focus-visible /template/ Border#RootBorder">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
+    </Style>
+  </ControlTheme>
+
+  <!--
+    Group header row: accent/semibold label with a leading tri-state check box that selects/deselects the
+    whole group (mixed state = only some selected). Uses the same Padding as MultiComboBoxItem so the row
+    highlight aligns with items. The label is a separate ContentPresenter (not the CheckBox content) so its
+    colour stays constant regardless of check state. Foreground is overridden at runtime from
+    MultiComboBox.HeaderForeground. No persisting selection highlight — the check box conveys state.
+  -->
+  <ControlTheme x:Key="{x:Type MultiComboBoxGroupHeaderItem}" TargetType="MultiComboBoxGroupHeaderItem">
+    <Setter Property="IsTabStop" Value="True" />
+    <Setter Property="Padding" Value="6 0 12 0" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="Cursor" Value="Hand" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="VerticalContentAlignment" Value="Center" />
+    <Setter Property="MinHeight" Value="32" />
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundAccentBrush}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          x:Name="RootBorder"
+          Padding="{TemplateBinding Padding}"
+          Background="{TemplateBinding Background}"
+          BorderBrush="{TemplateBinding BorderBrush}"
+          BorderThickness="{TemplateBinding BorderThickness}"
+          CornerRadius="{TemplateBinding CornerRadius}">
+          <Border.Transitions>
+            <Transitions>
+              <BrushTransition Property="Background" Duration="0:0:0.049" />
+            </Transitions>
+          </Border.Transitions>
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <CheckBox
+              IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
+              IsThreeState="True"
+              IsTabStop="False"
+              Focusable="False"
+              Padding="0"
+              VerticalAlignment="Center" />
+            <ContentPresenter
+              x:Name="PART_ContentPresenter"
+              Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              Foreground="{TemplateBinding Foreground}"
+              VerticalAlignment="Center"
+              Margin="8 0 0 0" />
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <!--  Hover / keyboard-focus tint (no persisting selection on click — the check box conveys state).  -->
+    <Style Selector="^:pointerover /template/ Border#RootBorder">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
+    </Style>
+    <Style Selector="^:focus-visible /template/ Border#RootBorder">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
     </Style>
   </ControlTheme>
 
@@ -124,12 +195,10 @@
       <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
-      <Style Selector="^ /template/ Border#RootBorder">
-        <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
-      </Style>
+    <!-- Focused (keyboard) state only — a mouse click doesn't leave a persisting highlight -->
+    <Style Selector="^:focus-visible /template/ Border#RootBorder">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundPointerOver}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushPointerOver}" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
@@ -229,6 +229,12 @@ public class MultiComboBoxSelectAllItem : ContentControl
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
+        base.OnPointerPressed(e);
+        if (e.Handled || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
         this.IsSelected = this.IsSelected is null or false;
     }
 
@@ -344,7 +350,14 @@ public class MultiComboBoxGroupHeaderItem : ContentControl
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
+        base.OnPointerPressed(e);
+        if (e.Handled || !e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
         this.IsSelected = this.IsSelected is null or false;
+        e.Handled = true;
     }
 
     protected override AutomationPeer OnCreateAutomationPeer() =>

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
@@ -236,6 +236,7 @@ public class MultiComboBoxSelectAllItem : ContentControl
         }
 
         this.IsSelected = this.IsSelected is null or false;
+        e.Handled = true;
     }
 
     internal void BeginUpdate()

--- a/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/MultiComboBox/MultiComboBoxItem.axaml.cs
@@ -1,8 +1,12 @@
 namespace Devolutions.AvaloniaControls.Controls;
 
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Mixins;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
@@ -10,11 +14,19 @@ using Extensions;
 using Irihi.Avalonia.Shared.Common;
 using Irihi.Avalonia.Shared.Helpers;
 
+[PseudoClasses(PC_Grouped)]
 public class MultiComboBoxItem : ContentControl
 {
+    /// <summary>Set on drop-down items while grouping is active, so themes can indent them under the group header.</summary>
+    public const string PC_Grouped = ":grouped";
+
     public static readonly StyledProperty<bool> IsSelectedProperty = AvaloniaProperty.Register<MultiComboBoxItem, bool>(
         nameof(IsSelected));
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Referencing MultiComboBox.FilterValueProperty merely triggers MultiComboBox's static constructor, which does not use dynamic code; the BindingEvaluator usage is confined to MultiComboBox's lazily-invoked grouping methods.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "See IL2026 justification: referencing MultiComboBox.FilterValueProperty does not itself require dynamic code.")]
     public static readonly StyledProperty<string?> FilterValueProperty =
         MultiComboBox.FilterValueProperty.AddOwner<MultiComboBoxItem>();
 
@@ -48,6 +60,11 @@ public class MultiComboBoxItem : ContentControl
     internal void Select()
     {
         this.SetValue(IsSelectedProperty, true);
+    }
+
+    internal void SetGrouped(bool grouped)
+    {
+        this.PseudoClasses.Set(PC_Grouped, grouped);
     }
 
     internal void BeginUpdate()
@@ -242,5 +259,122 @@ public class MultiComboBoxSelectAllItem : ContentControl
         }
 
         this.updateInternal = false;
+    }
+}
+
+/// <summary>
+/// Non-selectable group header row for a grouped <see cref="MultiComboBox"/>. Its leading tri-state
+/// check box selects/deselects every item of the group and shows an indeterminate (mixed) state when
+/// only some of the group's items are selected. Modeled on <see cref="MultiComboBoxSelectAllItem"/>,
+/// but scoped to a single group's items rather than the whole list.
+/// </summary>
+public class MultiComboBoxGroupHeaderItem : ContentControl
+{
+    public static readonly StyledProperty<bool?> IsSelectedProperty =
+        AvaloniaProperty.Register<MultiComboBoxGroupHeaderItem, bool?>(nameof(IsSelected), false);
+
+    private MultiComboBox? parent;
+
+    private bool updateInternal;
+
+    static MultiComboBoxGroupHeaderItem()
+    {
+        FocusableProperty.OverrideDefaultValue<MultiComboBoxGroupHeaderItem>(true);
+        IsSelectedProperty.Changed.AddClassHandler<MultiComboBoxGroupHeaderItem, bool?>((item, args) => item.OnSelectionChanged(args));
+    }
+
+    /// <summary>The full (unfiltered) items of the group this header represents.</summary>
+    internal IReadOnlyList<object>? GroupItems { get; set; }
+
+    public bool? IsSelected
+    {
+        get => this.GetValue(IsSelectedProperty);
+        set => this.SetValueIfChanged(IsSelectedProperty, value);
+    }
+
+    internal void BeginUpdate()
+    {
+        this.updateInternal = true;
+    }
+
+    internal void EndUpdate()
+    {
+        this.updateInternal = false;
+    }
+
+    internal void UpdateSelection()
+    {
+        this.updateInternal = true;
+
+        IReadOnlyList<object>? items = this.GroupItems;
+        IList? selected = this.parent?.SelectedItems;
+
+        if (items is null || items.Count == 0 || selected is null || selected.Count == 0)
+        {
+            this.IsSelected = false;
+        }
+        else
+        {
+            int selectedCount = 0;
+            foreach (object item in items)
+            {
+                if (selected.Contains(item))
+                {
+                    selectedCount++;
+                }
+            }
+
+            this.IsSelected = selectedCount == 0 ? false : selectedCount == items.Count ? true : null;
+        }
+
+        this.updateInternal = false;
+    }
+
+    protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToLogicalTree(e);
+        this.parent = this.FindLogicalAncestorOfType<MultiComboBox>();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        this.UpdateSelection();
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        this.IsSelected = this.IsSelected is null or false;
+    }
+
+    protected override AutomationPeer OnCreateAutomationPeer() =>
+        new ListItemAutomationPeer(this);
+
+    private void OnSelectionChanged(AvaloniaPropertyChangedEventArgs<bool?> args)
+    {
+        if (this.updateInternal) return;
+        if (args.OldValue.Value == args.NewValue.Value) return;
+
+        // The indeterminate state is never a user-selectable target: coming from it always means "select all".
+        if (args.OldValue.Value is null && args.NewValue.Value != true)
+        {
+            this.IsSelected = true;
+            return;
+        }
+
+        if (this.GroupItems is not { } items)
+        {
+            return;
+        }
+
+        if (args.OldValue.Value != true)
+        {
+            this.parent?.SelectGroup(items);
+            this.IsSelected = true;
+        }
+        else
+        {
+            this.parent?.DeselectGroup(items);
+        }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Helpers/ComboBoxGroupedItemsBuilder.cs
+++ b/src/Devolutions.AvaloniaControls/Helpers/ComboBoxGroupedItemsBuilder.cs
@@ -29,13 +29,25 @@ internal static class ComboBoxGroupedItemsBuilder
     /// <param name="orderAlphabetical">Order groups alphabetically (after <paramref name="orderSelector"/>, if any).</param>
     /// <param name="emptyGroupName">Display name for the empty ("") group key. When <c>null</c>/empty,
     /// items in the empty group render without a header (e.g. the current item shown at the top).</param>
+    /// <param name="headerFactory">Optional factory for the header pseudo-item, given the group's display name
+    /// and its full ordered membership. When <c>null</c>, a plain <see cref="ComboBoxGroupHeader"/> (text only)
+    /// is produced. Callers that need the header to carry its group's items (e.g. a group-level select-all
+    /// checkbox) supply a factory here.</param>
+    /// <param name="itemFilter">Optional per-item display filter. When supplied, <paramref name="sourceItems"/>
+    /// is treated as the full, unfiltered set: each group's header still carries the full membership, but only
+    /// items passing the filter are emitted into the display list, and a group with no visible items is dropped
+    /// entirely (its header included). When <c>null</c>, every item is emitted (the original behavior).</param>
     public static List<object> Build(
         IEnumerable<object?> sourceItems,
         Func<object, string> groupSelector,
         Func<object, object?>? orderSelector,
         bool orderAlphabetical,
-        string? emptyGroupName)
+        string? emptyGroupName,
+        Func<string, IReadOnlyList<object>, object>? headerFactory = null,
+        Func<object, bool>? itemFilter = null)
     {
+        headerFactory ??= static (name, _) => new ComboBoxGroupHeader(name);
+
         // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
         IEnumerable<IGrouping<string, (object item, string groupName, int originalIndex)>> grouped = sourceItems
             .SkipNulls()
@@ -55,16 +67,25 @@ internal static class ComboBoxGroupedItemsBuilder
         bool hasEmptyName = string.IsNullOrEmpty(emptyGroupName);
         foreach (IGrouping<string, (object item, string groupName, int originalIndex)> group in grouped)
         {
+            List<object> fullItems = group.OrderBy(static x => x.originalIndex).Select(static x => x.item).ToList();
+            List<object> visibleItems = itemFilter is null
+                ? fullItems
+                : fullItems.Where(itemFilter).ToList();
+
+            // When filtering, a group with no visible items drops out entirely (its header included).
+            if (itemFilter is not null && visibleItems.Count == 0)
+            {
+                continue;
+            }
+
             bool isEmptyHeaderless = group.Key.Length == 0 && hasEmptyName;
             if (!isEmptyHeaderless)
             {
-                displayItems.Add(new ComboBoxGroupHeader(group.Key.Length == 0 ? emptyGroupName : group.Key));
+                string displayName = group.Key.Length == 0 ? emptyGroupName! : group.Key;
+                displayItems.Add(headerFactory(displayName, fullItems));
             }
 
-            foreach ((object item, _, _) in group.OrderBy(static x => x.originalIndex))
-            {
-                displayItems.Add(item);
-            }
+            displayItems.AddRange(visibleItems);
         }
 
         return displayItems;

--- a/src/Devolutions.AvaloniaControls/README.md
+++ b/src/Devolutions.AvaloniaControls/README.md
@@ -40,6 +40,8 @@ dotnet add package Devolutions.AvaloniaControls
 
 - `EditableComboBox`
   (Supports optional grouping via `GroupBinding`/`GroupSelector`, with customizable group order and an optional headerless empty group)
+- `MultiComboBox`
+  (Multi-selection combo box with per-item check boxes; supports optional grouping via `GroupBinding`/`GroupSelector`, where each group header has a leading tri-state check box that selects/deselects the whole group)
 - `SearchHighlightTextBlock`
 - `TabPane`
   (Extends `TabControl` for different styling only)

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MultiComboBoxItem.axaml
@@ -61,6 +61,11 @@
       </ControlTemplate>
     </Setter>
 
+    <!-- Grouped mode: indent items so they read as children of the group header. -->
+    <Style Selector="^:grouped /template/ CheckBox">
+      <Setter Property="Margin" Value="16 0 0 0" />
+    </Style>
+
     <!--  Selected state  -->
     <Style Selector="^:selected">
       <Style Selector="^ /template/ Border#LayoutRoot">
@@ -84,8 +89,8 @@
       </Style>
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
+    <!-- Focused (keyboard) state only — a mouse click doesn't leave a persisting highlight -->
+    <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#LayoutRoot">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
         <Style Selector="^ ContentPresenter#PART_ContentPresenter">
@@ -170,8 +175,8 @@
       </Style>
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
+    <!-- Focused (keyboard) state only — a mouse click doesn't leave a persisting highlight -->
+    <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#LayoutRoot">
         <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
         <Style Selector="^ ContentPresenter#PART_ContentPresenter">
@@ -188,6 +193,78 @@
       <Setter Property="Background" Value="{DynamicResource ComboBoxItemBackgroundDisabled}" />
       <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxItemBorderBrushDisabled}" />
       <Setter Property="Foreground" Value="{DynamicResource ComboBoxItemForegroundDisabled}" />
+    </Style>
+  </ControlTheme>
+
+  <!--
+    Group header row: accent/semibold label with a leading tri-state check box that selects/deselects the
+    whole group. A transparent spacer matches the item's selection-highlight column so the row aligns. The
+    label is a separate ContentPresenter (not the CheckBox content) so its colour stays constant regardless
+    of check state. Foreground is overridden at runtime from MultiComboBox.HeaderForeground. No persisting
+    selection highlight — the check box conveys state.
+  -->
+  <ControlTheme x:Key="{x:Type MultiComboBoxGroupHeaderItem}" TargetType="MultiComboBoxGroupHeaderItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundAccentBrush}" />
+    <Setter Property="Background" Value="{DynamicResource BackgroundColor}" />
+    <Setter Property="MinHeight" Value="26" />
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Name="LayoutRoot"
+          Background="Transparent"
+          MinHeight="{DynamicResource ComboBoxItemMinHeight}"
+          CornerRadius="{TemplateBinding CornerRadius}"
+          Padding="0 0 8 0">
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+            <Border
+              Name="SelectionHighlight"
+              Width="{DynamicResource ComboBoxSelectionHighlightWidth}"
+              Height="{StaticResource ComboBoxItemSelectionHighlightHeight}"
+              Margin="{DynamicResource ComboBoxSelectionHighlightMargin}"
+              VerticalAlignment="Stretch"
+              Background="Transparent"
+              CornerRadius="{DynamicResource ComboBoxSelectionHighlightRadius}" />
+
+            <CheckBox
+              IsThreeState="True"
+              IsTabStop="False"
+              Focusable="False"
+              Padding="0"
+              IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
+              VerticalAlignment="Center" />
+            <ContentPresenter
+              x:Name="PART_ContentPresenter"
+              Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              Foreground="{TemplateBinding Foreground}"
+              VerticalAlignment="Center"
+              Margin="6 0 0 0" />
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <!--
+      Show the accent selection bar + row tint on hover and keyboard focus, matching items. A mouse click
+      does not leave a persisting highlight (focus-visible only) — the check box conveys the selection state.
+    -->
+    <Style Selector="^:pointerover /template/ Border#LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
+    </Style>
+    <Style Selector="^:pointerover /template/ Border#SelectionHighlight">
+      <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
+    </Style>
+    <Style Selector="^:focus-visible /template/ Border#LayoutRoot">
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
+    </Style>
+    <Style Selector="^:focus-visible /template/ Border#SelectionHighlight">
+      <Setter Property="Background" Value="{DynamicResource ControlBorderSelectedBrush}" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
@@ -64,12 +64,12 @@
       </Style>
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
-      <Style Selector="^:selected /template/ Path#CheckMark">
-        <Setter Property="Fill" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
+    <!-- Keyboard focus: tint the row like hover so arrow-key navigation is visible (no persisting selection on click). -->
+    <Style Selector="^:focus-visible">
+      <Style Selector="^ /template/ Border#RootPanel">
+        <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
       </Style>
-      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+      <Style Selector="^ /template/ CheckBox">
         <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
       </Style>
     </Style>
@@ -127,15 +127,12 @@
       </Style>
     </Style>
 
-    <!-- Focused state -->
-    <Style Selector="^:focus, ^[IsFocused=True]">
+    <!-- Keyboard focus: tint the row like hover so arrow-key navigation is visible (no persisting selection on click). -->
+    <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#RootPanel">
-        <Setter Property="Background" Value="{DynamicResource ControlBackgroundAccentRaisedBrush}" />
+        <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
       </Style>
-      <Style Selector="^:selected /template/ Path#CheckMark">
-        <Setter Property="Fill" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
-      </Style>
-      <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+      <Style Selector="^ /template/ CheckBox">
         <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
       </Style>
     </Style>
@@ -190,11 +187,15 @@
       </ControlTemplate>
     </Setter>
 
-    <!-- PointerOver: tint the row and brighten the label so it stays readable on the highlight. -->
-    <Style Selector="^:pointerover /template/ Border#RootPanel">
+    <!--
+      Hover and keyboard focus: tint the row and brighten the label so it stays readable on the highlight.
+      Keyboard focus (:focus-visible) mirrors hover so arrow-key navigation is visible; a mouse click leaves
+      no persisting selection — the check box conveys the group's state.
+    -->
+    <Style Selector="^:pointerover /template/ Border#RootPanel, ^:focus-visible /template/ Border#RootPanel">
       <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
     </Style>
-    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter, ^:focus-visible /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
     </Style>
   </ControlTheme>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
@@ -43,6 +43,11 @@
       </ControlTemplate>
     </Setter>
 
+    <!-- Grouped mode: indent items so they read as children of the group header. -->
+    <Style Selector="^:grouped /template/ CheckBox">
+      <Setter Property="Margin" Value="20 0 6 0" />
+    </Style>
+
     <Style Selector="^:selected /template/ Path#CheckMark">
       <Setter Property="Fill" Value="{DynamicResource ForegroundHighBrush}" />
     </Style>
@@ -137,6 +142,60 @@
 
     <Style Selector="^:disabled /template/ ContentPresenter#PART_ContentPresenter">
       <Setter Property="Foreground" Value="{DynamicResource ForegroundLowBrush}" />
+    </Style>
+  </ControlTheme>
+
+  <!--
+    Group header row: accent/semibold label with a leading tri-state check box that selects/deselects the
+    whole group. Uses ComboBoxItemMargin (same as items) so the row highlight aligns. The label is a
+    separate ContentPresenter (not the CheckBox content) so its colour stays constant regardless of check
+    state. Foreground is overridden at runtime from MultiComboBox.HeaderForeground. No persisting selection
+    highlight; on hover the label brightens to stay readable on the highlight.
+  -->
+  <ControlTheme x:Key="{x:Type MultiComboBoxGroupHeaderItem}" TargetType="MultiComboBoxGroupHeaderItem">
+    <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="HorizontalContentAlignment" Value="Left" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundAccentBrush}" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Name="RootPanel"
+          CornerRadius="{TemplateBinding CornerRadius}"
+          Padding="{TemplateBinding Padding}"
+          Background="Transparent">
+
+          <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="4 0 6 0">
+            <CheckBox
+              IsChecked="{TemplateBinding IsSelected, Mode=TwoWay}"
+              IsThreeState="True"
+              IsTabStop="False"
+              Focusable="False"
+              Padding="0"
+              VerticalAlignment="Center" />
+            <ContentPresenter
+              x:Name="PART_ContentPresenter"
+              Content="{TemplateBinding Content}"
+              ContentTemplate="{TemplateBinding ContentTemplate}"
+              Foreground="{TemplateBinding Foreground}"
+              VerticalAlignment="Center"
+              Margin="6 0 0 0" />
+          </StackPanel>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+
+    <!-- PointerOver: tint the row and brighten the label so it stays readable on the highlight. -->
+    <Style Selector="^:pointerover /template/ Border#RootPanel">
+      <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
+    </Style>
+    <Style Selector="^:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Foreground" Value="{DynamicResource ControlForegroundAccentHighBrush}" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary

Adds optional item grouping to `MultiComboBox`, mirroring the proven `GroupedComboBox`/`EditableComboBox` design (#591). When a group selector is configured, drop-down items are grouped under headers, with a customizable group order and an optional headerless empty group. Grouping is inert unless a selector is set, so existing `MultiComboBox` usage is unaffected.

The distinguishing requirement: each group header carries a **leading tri-state check box** that selects/deselects the whole group and shows a **mixed** state when only some of the group's items are selected. The header operates on the group's **full membership**, regardless of any active filter.

## What changed

**Control library**
- New grouping properties mirroring the sibling controls: `GroupBinding`/`GroupSelector`, `GroupOrderAlphabetical`, `GroupOrderSelector`/`GroupOrderBinding`, `HeaderForeground`, `HeaderTemplate`, `EmptyGroupName`.
- `ApplyFilter` routes through `ComboBoxGroupedItemsBuilder` when grouping is active; headers are interleaved into the private `FilteredItems` (the public `ItemsSource` is never mutated).
- New `MultiComboBoxGroupHeader` pseudo-item (carries the group's full membership) and `MultiComboBoxGroupHeaderItem` container (tri-state check box), plus parent `SelectGroup`/`DeselectGroup`.
- Group-child items get a `:grouped` pseudo-class so themes indent them under the header (matching the checkmark-column reservation that ComboBox/GroupedComboBox items have).
- `ComboBoxGroupedItemsBuilder.Build` gains optional `headerFactory` + `itemFilter` params (behavior-preserving for the existing callers).

**Themes**
- `MultiComboBoxGroupHeaderItem` ControlTheme added to MacOS and DevExpress (base covers Linux via fallback).
- Group headers show no persisting selection highlight (the check box conveys state); the header label sits in its own `ContentPresenter` so its colour is stable regardless of check state.
- Items switched to `:focus-visible` so a mouse click no longer leaves a stuck focus highlight; the DevExpress header shows the accent selection bar on hover/keyboard focus like items; the macOS header label brightens on hover for contrast.

**Sample**
- `MultiComboBoxDemo` gains a Grouping section (named groups, group ordering, empty group with/without `EmptyGroupName`, virtualized + filter, custom `HeaderTemplate`) plus grouped view-model data.

## Notes / intentional differences
- Grouping is data-driven (`GroupBinding`/`GroupSelector`); it targets a strongly-typed bound `ItemsSource` of data objects (same as `EditableComboBox`).
- A group header's check box operates on the group's **full** membership even when a filter hides some rows (its tri-state is computed against the full group).

## Testing
- Full solution builds clean (0 errors, no new warnings).
- Demo page + view model instantiate/render in all themes.
- Manually verified in the SampleApp; styling and focus feedback across macOS, Linux (Yaru), and Windows (DevExpress) was incorporated (header/item highlight alignment, header accent colour, no persisting selection on click, per-group tri-state, keyboard nav/toggle).

> ⚠️ The `MultiComboBoxDemo` visual-regression baselines need regenerating — the page content changed, so it affects every theme it's tested in. Baselines are per-OS: the macOS set can be regenerated locally (`UPDATE_BASELINES=true ./devtest --filter MultiCombo`); the Windows and Linux sets regenerate on their respective CI runners.
