### PR TITLE
Expose DevExpress menu styles for use independent of theme

### DIFF
--- a/docs/menu-pack-fluent-dependency-decision.md
+++ b/docs/menu-pack-fluent-dependency-decision.md
@@ -1,0 +1,110 @@
+# Open decision: should the Menu Pack be fully independent of Fluent?
+
+*Companion to "The DevExpress Menu Pack — Purpose and Structure".*
+*Current status: **deferred**. README prerequisite sharpened in the meantime.*
+
+---
+
+## 1. The dependency
+
+The menu pack is self-contained except for **one** foreign resource reference:
+Fluent's `FluentMenuScrollViewer` control theme, referenced from `MenuItem.axaml` (the scroll
+container for menus long enough to overflow).
+
+`Separator` is no longer part of this dependency discussion. The pack previously merged
+`Separator.axaml` (implicit `{x:Type Separator}` theme), but that leaked styling out to non-menu
+separators in the host app. The pack now does **not** merge `Separator.axaml`; instead it relies on
+the host separator template and seals menu separators through scoped setters in
+`Separator.styles.axaml`.
+
+This was confirmed by audit, not assumption: it is the **only** `StaticResource` in the entire pack
+that is neither `DevExMenu*`-owned nor defined locally. Everything else is already pinned.
+
+## 2. Why it matters — the failure mode
+
+If `FluentTheme` is not present, the pack does not degrade gracefully. It throws
+**`InvalidCastException` during template construction**. Three properties make this unusually
+hard to diagnose:
+
+- It fires on **any** menu, including a single-item menu that can never scroll. So nothing about
+  the symptom points at a *scroll viewer*.
+- The exception message does not mention scrolling, Fluent, or resources.
+- **Scoping `FluentTheme` to a subtree does not fix it.** Verified: `TryFindResource` from a
+  descendant *does* return the `ControlTheme`, and the template build *still* throws. The
+  requirement is strictly application-wide Fluent.
+
+  (Best interpretation: the `StaticResource` inside our merged dictionary resolves in the
+  dictionary's own scope, which cannot see a subtree-scoped theme. Stated as reading of the
+  behaviour, not a verified mechanism.)
+
+The practical risk is therefore not "menus look slightly off" but "an unfamiliar consumer hits an
+undiagnosable exception and concludes the pack is broken."
+
+## 3. Argument for removing it
+
+Makes the pack genuinely self-contained — matching the stated goal of an *externally consumable*
+pack — and works over Avalonia's Simple theme, or a standalone custom theme. Since the themes are
+open source, we do not control what consumers base their branded sections on.
+
+**A leak argument was initially advanced here and should be discounted.** The concern was that a
+host theme restyling the scroll viewer would bleed into our menus. On checking: **0 of our 4 themes**
+override `ScrollBarButtonArrowForeground`, `...PointerOver`, or `...IconFontSize`, despite heavily
+customising ~20 other `ScrollBar*` keys. Modern Fluent scrollbars do not draw arrow buttons at all.
+This is a dead corner and not a reason to act.
+
+## 4. Argument for keeping it
+
+**The packs are not distributed in isolation.** They ship as part of the Fluent-based platform
+themes, as a companion to the global-styles opt-out for branded sections. In the primary consuming
+app those sections are *Fluent islands* — Fluent is already loaded application-wide by construction.
+
+So for the actual known consumer, removing the dependency is worth **exactly zero**. The benefit is
+entirely hypothetical, accruing only to an external open-source consumer who bases their branded
+sections on something other than Fluent.
+
+App-wide Fluent is a reasonable, cheap, documentable prerequisite for a pack that is conceptually a
+Fluent add-on in the first place.
+
+## 5. What removal would involve
+
+Vendor the control theme into our own theme as `DevExMenuScrollViewer`.
+
+**Cost — verified, not estimated:**
+
+| Aspect | Finding |
+|---|---|
+| Size | ~92 lines, one new file |
+| Converter | `MenuScrollingVisibilityConverter` is **public in `Avalonia.Controls`**, not the Fluent assembly — no blocker, no reimplementation |
+| Template stability | md5-identical across Avalonia 11.0.0, 11.2.0, 11.3.2. 12.0.2 adds a single setter (`IsScrollChainingEnabled="False"`) |
+| Wiring | 3 reference sites in `MenuItem.axaml` |
+| Proven? | Yes — a spike was built and confirmed: *"pack over SimpleTheme (no Fluent anywhere): OK"* |
+
+Because the upstream template has been effectively frozen across four releases, ongoing maintenance
+is close to zero.
+
+**The spike is saved and ready to re-apply** (`MenuScrollViewer.axaml` + `wiring.diff`).
+
+**Cost that does not scale for free:** MacOS references `FluentMenuScrollViewer` at 4 sites and Linux
+at 3. Vendoring per-theme means N near-identical copies. The natural shared home would be
+`Devolutions.AvaloniaControls`, but the pack currently has **zero** dependency on that assembly, and
+introducing one to save ~92 duplicated lines is probably the worse trade. Recommendation would be to
+accept the duplication.
+
+## 6. Decision taken for now
+
+**Keep the dependency; sharpen the documentation.**
+
+The README prerequisite has been upgraded from "requires Fluent" to an explicit statement that
+`FluentTheme` must be loaded **application-wide in `Application.Styles`, not scoped to a subtree**,
+including a description of the `InvalidCastException` symptom so anyone who hits it can identify the
+cause immediately. This is free and removes most of the practical risk regardless of what is decided
+later.
+
+## 7. Question for reviewers
+
+Does anyone anticipate a consumer basing branded sections on something **other than** Fluent —
+Simple, or a fully standalone theme?
+
+- **No** → keep as is. The dependency costs nothing and the docs now cover the failure mode.
+- **Yes / uncertain, and we want the packs to stand alone** → vendoring is cheap, proven, and low
+  maintenance; the spike can be re-applied quickly.

--- a/docs/menu-pack-overview.md
+++ b/docs/menu-pack-overview.md
@@ -1,3 +1,6 @@
+Menu-pack-overview - my shortened version
+
+
 # The DevExpress Menu Pack — Purpose and Structure
 
 *Status: implemented for DevExpress only. Other platform themes deferred until this one is confirmed.*
@@ -6,9 +9,9 @@
 
 ## 1. The problem it solves
 
-Our platform themes (DevExpress, MacClassic, Linux, WinUI, LiquidGlass) are designed to make an app
+Our platform themes (DevExpress, MacClassic, Linux, LiquidGlass) are designed to make an app
 look native to the platform it runs on. But a consuming app often has **branded sections** that
-deliberately opt out of the platform look — internally these are called *"Fluent islands"*: plain
+deliberately opt out of the platform look — e.g. RDM *"Fluent islands"*: plain
 `FluentTheme` plus local style rules, rather than the platform-specific theme.
 
 That opt-out creates an inconsistency. A branded section still has menus — context menus, menu bars,
@@ -17,9 +20,9 @@ chrome, not branding; users read them as part of the application shell, so they 
 consistent even where the surrounding content does not.
 
 **The menu pack is the fix:** an individually addressable style pack that applies one theme's menu
-styling to a section, without dragging in that theme's full control set.
+styling to a section, without bringing in that theme's full control set.
 
-So the pack is best understood not as a standalone product, but as a **companion to the
+So the pack is not meant as a standalone product, but as a **companion to the
 global-styles opt-out** — the piece that lets a section drop the platform theme for its content
 while keeping the platform theme for its menus.
 
@@ -32,7 +35,7 @@ Consumed with a single line:
 
 ```xaml
 <Application.Styles>
-  <FluentTheme />   <!-- prerequisite; must be application-wide -->
+  <FluentTheme />   <!-- Fluent or Fluent-based theme prerequisite; must be application-wide -->
   <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
 </Application.Styles>
 ```
@@ -41,18 +44,13 @@ Consumed with a single line:
 
 The pack gets layered over a **host theme we do not control**. That creates a two-way hazard:
 
-- **Leak in** — the host redefines a generic key our menus depend on, and our menus change shape.
-  This was observed for real: loading the pack over the MacOS theme made menu outlines disappear.
-- **Leak out** — our resources override host keys and restyle the host's non-menu controls. Also
-  observed: a `ComboBox` placed inside a pack-styled context menu rendered with the wrong chevron.
+- **Leak in** — the host redefines a generic key that our menus depend on, and our menus change shape.
+- **Leak out** — our resources override host keys and restyle the host's non-menu controls. 
 
-The root cause was the same in both directions: menu templates were resolving through **generic,
+The root cause is the same in both directions: menu templates are resolving through **generic,
 widely-owned keys** (`MenuFlyoutPresenterBorderThemeThickness`, `FlyoutThemeMaxWidth`,
 `MenuFlyoutSeparatorThemeHeight`, …). Those keys mean "whoever won the resource lookup", which is
-exactly the wrong semantics when two themes are in the same visual tree.
-
-An earlier iteration also duplicated the token definitions — one copy for the full theme, one for
-the pack. That dual source of truth caused two separate bugs before it was removed.
+exactly the wrong semantics when two themes are in the same visual tree. We solve this by using a unique prefix.
 
 ## 4. The architecture
 
@@ -61,7 +59,8 @@ Three rules, in order of importance:
 ### Rule 1 — One source of truth
 
 All menu tokens live in **`Accents/MenuResources.axaml`**, included by *both* the full theme
-(via `ThemeRoot.axaml`) and the pack (via `MenuPack.styles.axaml`).
+(via `ThemeRoot.axaml`) and the pack (via `MenuPack.styles.axaml`), so there will be no drift between 
+the pack and the full theme
 
 ```
                   Accents/MenuResources.axaml        <-- 36 DevExMenu* tokens
@@ -69,10 +68,6 @@ All menu tokens live in **`Accents/MenuResources.axaml`**, included by *both* th
         ThemeRoot.axaml              MenuPack.styles.axaml
         (full theme)                 (external consumers)
 ```
-
-Drift between the pack and the full theme is now **structurally impossible**, rather than something
-a reviewer has to remember to check. This directly addresses the maintenance concern that motivated
-the redesign.
 
 ### Rule 2 — Every key the pack owns is prefixed `DevExMenu`
 
@@ -88,33 +83,8 @@ loads several themes in one process. The prefix names the *vendor*, not the *con
 ### Rule 3 — Values are pinned literals, never aliases
 
 A token defined as `{StaticResource FlyoutThemeMaxWidth}` re-opens the leak Rule 2 just closed. So
-every value is a literal. Getting this right required probing the real Fluent values at runtime
-rather than reading them off — three of the initial guesses were wrong (padding `0` not `1`,
-max width `456` not `816`, horizontal min width `32` not `128`).
+every value is a literal. 
 
-### Rule 4 — The pack styles menu content only, never the host's own controls
-
-Leakage runs both ways, and the outward direction is easy to miss. A `ControlTheme` keyed
-`x:Key="{x:Type Foo}"` is an *implicit* theme: merging it makes it the default for **every** `Foo` in
-the consuming app, with no selector involved.
-
-The pack originally merged `Separator.axaml` for exactly this reason and it caused a real
-leak-out — a plain `<Separator/>` outside any menu rendered opaque black and full-bleed
-(`0,14,400,1`) instead of the host's subtle inset line (`12,18,376,1`), because the theme's
-unprefixed `SeparatorBrush` / `SeparatorMargin` values ship only with the full theme.
-
-The fix is not to duplicate the template but to **rely on the host's and pin what it binds**.
-Fluent's `Separator` template turns out to be copied verbatim by our DevExpress, MacOS and Linux
-themes — all four are character-for-character identical, differing only in which resource keys the
-setters reference. So the pack drops the implicit theme entirely and instead pins every
-template-bound property (`Background`, `Margin`, `Height`, `HorizontalAlignment`,
-`VerticalAlignment`, `BorderThickness`, `CornerRadius`, `Focusable`) inside the existing
-menu-scoped selector in `Separator.styles.axaml`.
-
-Measured result — menu separators are byte-identical over Fluent, MacOS, Linux, and a deliberately
-hostile host that sets magenta at 9px with a 5px lime border and 12px corner radius; meanwhile plain
-separators over each host are byte-identical to that host *without* the pack. This also removes a
-duplicated Fluent template, satisfying the project's "no template duplication" requirement.
 
 ### What is *deliberately* inherited from the host
 
@@ -126,18 +96,6 @@ Only one dependency is intentionally inherited:
 
 This list is the explicit contract. Anything *not* on it and not `DevExMenu*`-prefixed is a bug.
 
-**Typography was originally on this list, and was moved off it.** Inheriting `DefaultFontFamily` /
-`ControlFontSize` from the host directly contradicted §1: DevExpress sets size 12 and its own family,
-MacOS 13, Linux Open Sans, and plain Fluent defines neither — so a branded section rendered its menus
-in the *branded* font, visibly different from the platform-themed menus they were meant to match.
-`DevExMenuFontFamily` / `DevExMenuFontSize` / `DevExMenuFontWeight` are now pinned like everything
-else.
-
-Pinning them also revealed a second gap: the `{x:Type MenuItem}` theme pinned `FontSize` but not
-`FontFamily`, and the popup Border pinned all three — so *menu-bar* items still inherited the host
-font while popup items did not. With both closed, a top-level menu item now measures **37×23 over
-Fluent, MacClassic and Linux alike** (it was 38×20 / 37×23 / 38×20 before). Menu geometry is
-host-invariant, which is what makes the cheap test strategy in §5 possible.
 
 ## 5. How it is guarded
 
@@ -158,36 +116,11 @@ The `MenuTokens` array in that file is the machine-readable contract; new tokens
 Tests 1–3 were each **verified to have teeth** by temporarily reintroducing the bug they guard and
 confirming a loud failure with a readable diff, rather than trusting that green meant covered.
 
-### Visual coverage — planned approach
-
-The demo pages are not yet in the visual regression matrix. The obvious approach — a baseline per
-page per host — would cost 3 pages × 4 hosts per pack, and triple again once the MacOS and Linux
-packs land.
-
-Because menu geometry is now host-invariant (§4), that matrix is avoidable. Two **differential**
-assertions cover the real invariants and need *no stored baselines at all*:
-
-- **leak-out:** render a row of ordinary controls with and without the pack over the same host;
-  assert the two captures are pixel-identical. Scales to N packs × N hosts for free. The
-  `Separator` case of this is **already implemented** (test 3 above) as a property-level assertion;
-  extending it to a pixel comparison over a control row is the natural next step.
-- **leak-in:** render each menu page over two different hosts; assert identical. This is only
-  meaningful because typography is pinned.
-
-`ImageComparer.CompareImages` already operates on file paths, so both are cheap to build.
-
-Note that these two invariants pull in opposite directions — menus must look the *same* across hosts,
-host controls must keep looking *different*. They therefore belong on separate demo pages; mixing
-menu content and a host-control row on one page makes neither assertion expressible.
-
 ## 6. Proving it in the SampleApp
 
 Four dedicated demo pages under a `MenuPack` heading (`MenuPackAbout`, `MenuPackMenuDemo`,
 `MenuPackContextMenuDemo`, `MenuPackMenuFlyoutDemo`). These load the pack **by avares URI**, not via
 the theme object — so the sample exercises the same path an external consumer would.
-
-Separate pages, rather than additions to the existing demo pages, because several of those are
-already full and extra content risked pushing controls off-screen and disturbing visual baselines.
 
 ## 7. Current status
 
@@ -197,25 +130,8 @@ already full and extra content risked pushing controls off-screen and disturbing
 
 **Known gaps:**
 
-- The MenuPack demo pages have no `status` entry in the page catalog, so they are **not** covered by
-  visual regression testing. Adding coverage means 4 pages × N themes of new baselines.
-- Packs for MacOS / Linux / WinUI are not built yet.
+- Packs for MacOS & Linux are not built yet.
 - The `FluentMenuScrollViewer` dependency — see the companion decision document.
 
-## 8. Files
-
-**Added**
-- `src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml`
-- `src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`
-- `tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs`
-- `samples/SampleApp/DemoPages/MenuPack*.axaml` (+ `.axaml.cs`) — 4 pages
-
-**Modified**
-- `Accents/ThemeResources.axaml`, `ThemeRoot.axaml`
-- `Controls/MenuItem.axaml`, `Menu.axaml`, `MenuSvg.styles.axaml`, `Separator.styles.axaml`
-- `README.md`
-
-**Removed**
-- `Accents/MenuPackThemeResources.axaml` (the duplicate token set)
 
 **URI:** `avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`

--- a/docs/menu-pack-overview.md
+++ b/docs/menu-pack-overview.md
@@ -1,0 +1,221 @@
+# The DevExpress Menu Pack — Purpose and Structure
+
+*Status: implemented for DevExpress only. Other platform themes deferred until this one is confirmed.*
+
+---
+
+## 1. The problem it solves
+
+Our platform themes (DevExpress, MacClassic, Linux, WinUI, LiquidGlass) are designed to make an app
+look native to the platform it runs on. But a consuming app often has **branded sections** that
+deliberately opt out of the platform look — internally these are called *"Fluent islands"*: plain
+`FluentTheme` plus local style rules, rather than the platform-specific theme.
+
+That opt-out creates an inconsistency. A branded section still has menus — context menus, menu bars,
+flyouts — and those menus suddenly look different from every other menu in the app. Menus are
+chrome, not branding; users read them as part of the application shell, so they should stay
+consistent even where the surrounding content does not.
+
+**The menu pack is the fix:** an individually addressable style pack that applies one theme's menu
+styling to a section, without dragging in that theme's full control set.
+
+So the pack is best understood not as a standalone product, but as a **companion to the
+global-styles opt-out** — the piece that lets a section drop the platform theme for its content
+while keeping the platform theme for its menus.
+
+## 2. What it covers
+
+`ContextMenu`, `MenuFlyoutPresenter`, `Menu`, `MenuItem`, `Separator`, plus the menu-specific helper
+styles (`Menu.styles.axaml`, `Separator.styles.axaml`, and the `MenuItem` SVG icon CSS).
+
+Consumed with a single line:
+
+```xaml
+<Application.Styles>
+  <FluentTheme />   <!-- prerequisite; must be application-wide -->
+  <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+</Application.Styles>
+```
+
+## 3. The central design problem
+
+The pack gets layered over a **host theme we do not control**. That creates a two-way hazard:
+
+- **Leak in** — the host redefines a generic key our menus depend on, and our menus change shape.
+  This was observed for real: loading the pack over the MacOS theme made menu outlines disappear.
+- **Leak out** — our resources override host keys and restyle the host's non-menu controls. Also
+  observed: a `ComboBox` placed inside a pack-styled context menu rendered with the wrong chevron.
+
+The root cause was the same in both directions: menu templates were resolving through **generic,
+widely-owned keys** (`MenuFlyoutPresenterBorderThemeThickness`, `FlyoutThemeMaxWidth`,
+`MenuFlyoutSeparatorThemeHeight`, …). Those keys mean "whoever won the resource lookup", which is
+exactly the wrong semantics when two themes are in the same visual tree.
+
+An earlier iteration also duplicated the token definitions — one copy for the full theme, one for
+the pack. That dual source of truth caused two separate bugs before it was removed.
+
+## 4. The architecture
+
+Three rules, in order of importance:
+
+### Rule 1 — One source of truth
+
+All menu tokens live in **`Accents/MenuResources.axaml`**, included by *both* the full theme
+(via `ThemeRoot.axaml`) and the pack (via `MenuPack.styles.axaml`).
+
+```
+                  Accents/MenuResources.axaml        <-- 36 DevExMenu* tokens
+                     /                    \
+        ThemeRoot.axaml              MenuPack.styles.axaml
+        (full theme)                 (external consumers)
+```
+
+Drift between the pack and the full theme is now **structurally impossible**, rather than something
+a reviewer has to remember to check. This directly addresses the maintenance concern that motivated
+the redesign.
+
+### Rule 2 — Every key the pack owns is prefixed `DevExMenu`
+
+A prefixed key cannot collide with, or be silently overridden by, the host's keys. This includes
+keys that happen to be unique today (`SvgMenuItem*Css`, `MenuItemChevronPathData`,
+`KeyGestureConverter`) — uniqueness by coincidence is not a contract, and a future host theme could
+introduce any of them.
+
+Prefix choice: `DevExMenu` rather than `MenuPack`. When the other platform themes get packs, a
+shared `MenuPack*` prefix would collide between them — most visibly in our own SampleApp, which
+loads several themes in one process. The prefix names the *vendor*, not the *contract*.
+
+### Rule 3 — Values are pinned literals, never aliases
+
+A token defined as `{StaticResource FlyoutThemeMaxWidth}` re-opens the leak Rule 2 just closed. So
+every value is a literal. Getting this right required probing the real Fluent values at runtime
+rather than reading them off — three of the initial guesses were wrong (padding `0` not `1`,
+max width `456` not `816`, horizontal min width `32` not `128`).
+
+### Rule 4 — The pack styles menu content only, never the host's own controls
+
+Leakage runs both ways, and the outward direction is easy to miss. A `ControlTheme` keyed
+`x:Key="{x:Type Foo}"` is an *implicit* theme: merging it makes it the default for **every** `Foo` in
+the consuming app, with no selector involved.
+
+The pack originally merged `Separator.axaml` for exactly this reason and it caused a real
+leak-out — a plain `<Separator/>` outside any menu rendered opaque black and full-bleed
+(`0,14,400,1`) instead of the host's subtle inset line (`12,18,376,1`), because the theme's
+unprefixed `SeparatorBrush` / `SeparatorMargin` values ship only with the full theme.
+
+The fix is not to duplicate the template but to **rely on the host's and pin what it binds**.
+Fluent's `Separator` template turns out to be copied verbatim by our DevExpress, MacOS and Linux
+themes — all four are character-for-character identical, differing only in which resource keys the
+setters reference. So the pack drops the implicit theme entirely and instead pins every
+template-bound property (`Background`, `Margin`, `Height`, `HorizontalAlignment`,
+`VerticalAlignment`, `BorderThickness`, `CornerRadius`, `Focusable`) inside the existing
+menu-scoped selector in `Separator.styles.axaml`.
+
+Measured result — menu separators are byte-identical over Fluent, MacOS, Linux, and a deliberately
+hostile host that sets magenta at 9px with a 5px lime border and 12px corner radius; meanwhile plain
+separators over each host are byte-identical to that host *without* the pack. This also removes a
+duplicated Fluent template, satisfying the project's "no template duplication" requirement.
+
+### What is *deliberately* inherited from the host
+
+Only one dependency is intentionally inherited:
+
+| Key | Rationale |
+|-----|-----------|
+| `FluentMenuScrollViewer` | Technical dependency only: reused rather than vendored (for now). See the companion decision document. |
+
+This list is the explicit contract. Anything *not* on it and not `DevExMenu*`-prefixed is a bug.
+
+**Typography was originally on this list, and was moved off it.** Inheriting `DefaultFontFamily` /
+`ControlFontSize` from the host directly contradicted §1: DevExpress sets size 12 and its own family,
+MacOS 13, Linux Open Sans, and plain Fluent defines neither — so a branded section rendered its menus
+in the *branded* font, visibly different from the platform-themed menus they were meant to match.
+`DevExMenuFontFamily` / `DevExMenuFontSize` / `DevExMenuFontWeight` are now pinned like everything
+else.
+
+Pinning them also revealed a second gap: the `{x:Type MenuItem}` theme pinned `FontSize` but not
+`FontFamily`, and the popup Border pinned all three — so *menu-bar* items still inherited the host
+font while popup items did not. With both closed, a top-level menu item now measures **37×23 over
+Fluent, MacClassic and Linux alike** (it was 38×20 / 37×23 / 38×20 before). Menu geometry is
+host-invariant, which is what makes the cheap test strategy in §5 possible.
+
+## 5. How it is guarded
+
+`MenuPackContractTests` (visual test project), 21 cases across four tests:
+
+1. **Token parity** — every `DevExMenu*` token resolves *identically* under the full theme and under
+   "pack over a foreign host", in both Light and Dark. This is what enforces Rule 1.
+2. **Hostile-host leak guard** — a host theme that deliberately redefines the generic keys our menus
+   used to depend on cannot move any menu token. This enforces Rules 2 and 3.
+3. **Leak-out guard** — adding the pack over a host must not change a `Separator` that is outside any
+   menu. This enforces Rule 4, and is *differential*: it compares host-only against host-plus-pack
+   and so needs no stored baseline.
+4. **Page-construction smoke** — the MenuPack demo pages build over DevExpress, MacClassic,
+   LiquidGlass, and Linux hosts.
+
+The `MenuTokens` array in that file is the machine-readable contract; new tokens must be added to it.
+
+Tests 1–3 were each **verified to have teeth** by temporarily reintroducing the bug they guard and
+confirming a loud failure with a readable diff, rather than trusting that green meant covered.
+
+### Visual coverage — planned approach
+
+The demo pages are not yet in the visual regression matrix. The obvious approach — a baseline per
+page per host — would cost 3 pages × 4 hosts per pack, and triple again once the MacOS and Linux
+packs land.
+
+Because menu geometry is now host-invariant (§4), that matrix is avoidable. Two **differential**
+assertions cover the real invariants and need *no stored baselines at all*:
+
+- **leak-out:** render a row of ordinary controls with and without the pack over the same host;
+  assert the two captures are pixel-identical. Scales to N packs × N hosts for free. The
+  `Separator` case of this is **already implemented** (test 3 above) as a property-level assertion;
+  extending it to a pixel comparison over a control row is the natural next step.
+- **leak-in:** render each menu page over two different hosts; assert identical. This is only
+  meaningful because typography is pinned.
+
+`ImageComparer.CompareImages` already operates on file paths, so both are cheap to build.
+
+Note that these two invariants pull in opposite directions — menus must look the *same* across hosts,
+host controls must keep looking *different*. They therefore belong on separate demo pages; mixing
+menu content and a host-control row on one page makes neither assertion expressible.
+
+## 6. Proving it in the SampleApp
+
+Four dedicated demo pages under a `MenuPack` heading (`MenuPackAbout`, `MenuPackMenuDemo`,
+`MenuPackContextMenuDemo`, `MenuPackMenuFlyoutDemo`). These load the pack **by avares URI**, not via
+the theme object — so the sample exercises the same path an external consumer would.
+
+Separate pages, rather than additions to the existing demo pages, because several of those are
+already full and extra content risked pushing controls off-screen and disturbing visual baselines.
+
+## 7. Current status
+
+- Build clean; `dotnet test` **164/164**; all 145 visual baselines unchanged.
+- Two real bugs fixed along the way: a `KeyNotFoundException` crash when the pack was used over a
+  bare Fluent host (i.e. the documented consumer scenario), and a separator-height leak-in.
+
+**Known gaps:**
+
+- The MenuPack demo pages have no `status` entry in the page catalog, so they are **not** covered by
+  visual regression testing. Adding coverage means 4 pages × N themes of new baselines.
+- Packs for MacOS / Linux / WinUI are not built yet.
+- The `FluentMenuScrollViewer` dependency — see the companion decision document.
+
+## 8. Files
+
+**Added**
+- `src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml`
+- `src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`
+- `tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs`
+- `samples/SampleApp/DemoPages/MenuPack*.axaml` (+ `.axaml.cs`) — 4 pages
+
+**Modified**
+- `Accents/ThemeResources.axaml`, `ThemeRoot.axaml`
+- `Controls/MenuItem.axaml`, `Menu.axaml`, `MenuSvg.styles.axaml`, `Separator.styles.axaml`
+- `README.md`
+
+**Removed**
+- `Accents/MenuPackThemeResources.axaml` (the duplicate token set)
+
+**URI:** `avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`

--- a/samples/SampleApp/DemoPages/MenuPackAbout.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackAbout.axaml
@@ -1,0 +1,40 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
+             x:Class="SampleApp.DemoPages.MenuPackAbout">
+
+  <StackPanel Margin="10" Spacing="14" MaxWidth="900" HorizontalAlignment="Left">
+    <TextBlock Classes="h1">About DevExpress Menu Pack</TextBlock>
+
+    <TextBlock FontSize="15" TextWrapping="Wrap">
+      The DevExpress Menu Pack is an externally consumable style pack for menu-related controls. It lets apps import menu styling without importing the full theme object.
+    </TextBlock>
+
+    <TextBlock FontSize="15" TextWrapping="Wrap">
+      The pages in this section load the MenuPack on top of the currently selected theme. It can be used as a drop-in replacement for the default menu styles where a consistent look across all platforms is required.
+    </TextBlock>
+
+    <TextBlock Classes="section-title">Menu pack URI</TextBlock>
+    <TextBlock FontFamily="{DynamicResource CodeFontFamily}"
+               Text="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml"
+               TextWrapping="Wrap" />
+
+    <TextBlock Classes="section-title">Minimal usage</TextBlock>
+    <TextBlock Classes="code"
+               HorizontalAlignment="Left"
+               LineHeight="18"
+               Margin="5 -5 0 0"
+               Padding="5 8 6 8">
+      <TextBlock.Inlines>
+        <Run Text="&lt;Application ...&gt;&#x0a;" />
+        <Run Text="  &lt;Application.Styles&gt;&#x0a;" />
+        <Run Text="    &lt;FluentTheme /&gt;&#x0a;" />
+        <Run Text="    &lt;StyleInclude Source=&quot;avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml&quot; /&gt;&#x0a;" />
+        <Run Text="  &lt;/Application.Styles&gt;&#x0a;" />
+        <Run Text="&lt;/Application&gt;" />
+      </TextBlock.Inlines>
+    </TextBlock>
+  </StackPanel>
+</UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackAbout.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackAbout.axaml
@@ -5,6 +5,10 @@
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackAbout">
 
+  <UserControl.Styles>
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+  </UserControl.Styles>
+
   <StackPanel Margin="10" Spacing="14" MaxWidth="900" HorizontalAlignment="Left">
     <TextBlock Classes="h1">About DevExpress Menu Pack</TextBlock>
 
@@ -13,7 +17,7 @@
     </TextBlock>
 
     <TextBlock FontSize="15" TextWrapping="Wrap">
-      The pages in this section load the MenuPack on top of the currently selected theme. It can be used as a drop-in replacement for the default menu styles where a consistent look across all platforms is required.
+      The pages in this section load the MenuPack on top of the currently selected theme (must be or contain Fluent). It can be used as a drop-in replacement for the default menu styles where a consistent look across all platforms is required.
     </TextBlock>
 
     <TextBlock Classes="section-title">Menu pack URI</TextBlock>
@@ -36,5 +40,82 @@
         <Run Text="&lt;/Application&gt;" />
       </TextBlock.Inlines>
     </TextBlock>
+
+    <TextBlock Classes="h1">Isolation Demo</TextBlock>
+
+    <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+      <StackPanel Spacing="10">
+        <TextBlock Classes="section-title">Non-menu controls stay host-themed</TextBlock>
+        <TextBlock TextWrapping="Wrap">
+          These controls are outside any menu scope and remain styled by the selected host theme.
+        </TextBlock>
+
+        <Separator />
+
+        <WrapPanel ItemWidth="180" Orientation="Horizontal">
+          <Button Margin="0 0 10 10" Content="Button" />
+
+          <ComboBox Margin="0 0 10 10" SelectedIndex="2" Width="170">
+            <ComboBoxItem>Option 1</ComboBoxItem>
+            <ComboBoxItem IsEnabled="False">Option 2</ComboBoxItem>
+            <ComboBoxItem>ComobBox</ComboBoxItem>
+            <ComboBoxItem>Option 4</ComboBoxItem>
+          </ComboBox>
+
+          <TextBox Margin="0 0 10 10" Width="170" Watermark="TextBox" />
+
+          <CheckBox Margin="0 0 10 10" Content="CheckBox" IsChecked="True" />
+        </WrapPanel>
+      </StackPanel>
+    </Border>
+
+    <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+      <StackPanel Spacing="10">
+        <TextBlock Classes="section-title">Menus get the DevExpress theme from the MenuPack</TextBlock>
+
+        <StackPanel Orientation="Horizontal" Spacing="30">
+
+          <StackPanel Spacing="10" VerticalAlignment="Top">
+            <Button Content="Right-click for ContextMenu">
+              <Button.ContextMenu>
+                <ContextMenu>
+                  <MenuItem Header="Refresh" />
+                  <MenuItem Header="Rename" />
+                  <Separator />
+                  <MenuItem Header="Delete" />
+                </ContextMenu>
+              </Button.ContextMenu>
+            </Button>
+
+            <Button Content="Click for MenuFlyout">
+              <Button.Flyout>
+                <MenuFlyout>
+                  <MenuItem Header="Settings" />
+                  <MenuItem Header="Profile" />
+                  <Separator />
+                  <MenuItem Header="Sign out" />
+                </MenuFlyout>
+              </Button.Flyout>
+            </Button>
+          </StackPanel>
+
+            <MenuFlyoutPresenter>
+              <MenuItem Header="Open session" />
+              <MenuItem Header="Open with parameters" IsSubMenuOpen="True">
+                <MenuItem Header="Embedded/tabbed" />
+                <MenuItem Header="Embedded SFTP connection" />
+                <MenuItem Header="Embedded SCP connection" IsEnabled="False" />
+              </MenuItem>
+              <MenuItem Header="Copy name" />
+              <Separator />
+              <MenuItem Header="Toggle Options" IsSubMenuOpen="True">
+                <MenuItem Header="Option 1" ToggleType="CheckBox" />
+                <MenuItem Header="Option 2" ToggleType="CheckBox" IsChecked="True" />
+              </MenuItem>
+            </MenuFlyoutPresenter>
+
+        </StackPanel>
+      </StackPanel>
+    </Border>
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackAbout.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuPackAbout.axaml.cs
@@ -1,0 +1,11 @@
+namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
+
+public partial class MenuPackAbout : UserControl
+{
+  public MenuPackAbout()
+  {
+    this.InitializeComponent();
+  }
+}

--- a/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackContextMenuDemo">
 
@@ -9,63 +10,5 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <StackPanel Margin="20" Spacing="16">
-    <TextBlock Classes="section-title">Menu Pack proof: ContextMenu</TextBlock>
-
-    <Border Padding="12"
-            HorizontalAlignment="Left"
-            Background="{DynamicResource LayoutBackgroundLowBrush}"
-            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-            BorderThickness="{DynamicResource BorderThickness}"
-            CornerRadius="{DynamicResource LayoutCornerRadius}">
-      <ContextMenu>
-        <MenuItem Header="Connect">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/Computer.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-        <MenuItem Header="Copy Username" InputGesture="Ctrl+U">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/CopyUserName.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-        <MenuItem Header="Copy Password" InputGesture="Ctrl+Shift+U" IsEnabled="False">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/CopyPassword.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-        <Separator />
-        <MenuItem Header="Options">
-          <MenuItem Header="Auto Type" ToggleType="CheckBox" IsChecked="True" />
-          <MenuItem Header="Prompt for MFA" ToggleType="CheckBox" />
-        </MenuItem>
-      </ContextMenu>
-    </Border>
-
-    <Border Padding="16"
-            Background="{DynamicResource LayoutBackgroundLowBrush}"
-            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-            BorderThickness="{DynamicResource BorderThickness}"
-            CornerRadius="{DynamicResource LayoutCornerRadius}">
-      <StackPanel>
-        <TextBlock TextWrapping="Wrap">
-          Right-click this panel for a regular attached ContextMenu:
-        </TextBlock>
-        <Border Margin="0,12,0,0"
-                Height="180"
-                Background="Transparent"
-                BorderBrush="{DynamicResource SeparatorBrush}"
-                BorderThickness="1">
-          <Border.ContextMenu>
-            <ContextMenu>
-              <MenuItem Header="Action 1" />
-              <MenuItem Header="Action 2" />
-              <Separator />
-              <MenuItem Header="Disabled Action" IsEnabled="False" />
-            </ContextMenu>
-          </Border.ContextMenu>
-        </Border>
-      </StackPanel>
-    </Border>
-  </StackPanel>
+  <demo:ContextMenuDemo />
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
@@ -1,0 +1,71 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
+             x:Class="SampleApp.DemoPages.MenuPackContextMenuDemo">
+
+  <UserControl.Styles>
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+  </UserControl.Styles>
+
+  <StackPanel Margin="20" Spacing="16">
+    <TextBlock Classes="section-title">Menu Pack proof: ContextMenu</TextBlock>
+
+    <Border Padding="12"
+            HorizontalAlignment="Left"
+            Background="{DynamicResource LayoutBackgroundLowBrush}"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="{DynamicResource BorderThickness}"
+            CornerRadius="{DynamicResource LayoutCornerRadius}">
+      <ContextMenu>
+        <MenuItem Header="Connect">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/Computer.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Copy Username" InputGesture="Ctrl+U">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/CopyUserName.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Copy Password" InputGesture="Ctrl+Shift+U" IsEnabled="False">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/CopyPassword.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <Separator />
+        <MenuItem Header="Options">
+          <MenuItem Header="Auto Type" ToggleType="CheckBox" IsChecked="True" />
+          <MenuItem Header="Prompt for MFA" ToggleType="CheckBox" />
+        </MenuItem>
+      </ContextMenu>
+    </Border>
+
+    <Border Padding="16"
+            Background="{DynamicResource LayoutBackgroundLowBrush}"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="{DynamicResource BorderThickness}"
+            CornerRadius="{DynamicResource LayoutCornerRadius}">
+      <StackPanel>
+        <TextBlock TextWrapping="Wrap">
+          Right-click this panel for a regular attached ContextMenu:
+        </TextBlock>
+        <Border Margin="0,12,0,0"
+                Height="180"
+                Background="Transparent"
+                BorderBrush="{DynamicResource SeparatorBrush}"
+                BorderThickness="1">
+          <Border.ContextMenu>
+            <ContextMenu>
+              <MenuItem Header="Action 1" />
+              <MenuItem Header="Action 2" />
+              <Separator />
+              <MenuItem Header="Disabled Action" IsEnabled="False" />
+            </ContextMenu>
+          </Border.ContextMenu>
+        </Border>
+      </StackPanel>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml.cs
@@ -1,0 +1,11 @@
+namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
+
+public partial class MenuPackContextMenuDemo : UserControl
+{
+  public MenuPackContextMenuDemo()
+  {
+    this.InitializeComponent();
+  }
+}

--- a/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackMenuDemo">
 
@@ -9,49 +10,5 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <StackPanel Margin="20" Spacing="16">
-    <TextBlock Classes="section-title">Menu Pack proof: Menu</TextBlock>
-    <TextBlock TextWrapping="Wrap">
-      This page imports the DevExpress MenuPack via avares URI. Use the Fluent theme for intended rendering.
-    </TextBlock>
-
-    <Border BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-            BorderThickness="{DynamicResource BorderThickness}"
-            CornerRadius="{DynamicResource LayoutCornerRadius}">
-      <DockPanel>
-        <Menu DockPanel.Dock="Top">
-          <MenuItem Header="File">
-            <MenuItem Header="Open" InputGesture="Ctrl+O" />
-            <MenuItem Header="Open Recent">
-              <MenuItem Header="Session 1" />
-              <MenuItem Header="Session 2" />
-              <Separator />
-              <MenuItem Header="Clear Recent" />
-            </MenuItem>
-            <Separator />
-            <MenuItem Header="Exit" />
-          </MenuItem>
-          <MenuItem Header="Edit">
-            <MenuItem Header="Copy">
-              <MenuItem.Icon>
-                <Svg Path="/Assets/CopyName.svg" />
-              </MenuItem.Icon>
-            </MenuItem>
-            <MenuItem Header="Paste" IsEnabled="False" />
-          </MenuItem>
-          <Separator />
-          <MenuItem Header="View">
-            <MenuItem Header="Toolbar" ToggleType="CheckBox" IsChecked="True" />
-            <MenuItem Header="Status Bar" ToggleType="CheckBox" />
-          </MenuItem>
-        </Menu>
-
-        <Border Padding="16" Background="{DynamicResource LayoutBackgroundLowBrush}">
-          <TextBlock TextWrapping="Wrap">
-            Top-level menu and submenus above are styled only through the imported MenuPack.
-          </TextBlock>
-        </Border>
-      </DockPanel>
-    </Border>
-  </StackPanel>
+  <demo:MenuDemo />
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
@@ -1,0 +1,57 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
+             x:Class="SampleApp.DemoPages.MenuPackMenuDemo">
+
+  <UserControl.Styles>
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+  </UserControl.Styles>
+
+  <StackPanel Margin="20" Spacing="16">
+    <TextBlock Classes="section-title">Menu Pack proof: Menu</TextBlock>
+    <TextBlock TextWrapping="Wrap">
+      This page imports the DevExpress MenuPack via avares URI. Use the Fluent theme for intended rendering.
+    </TextBlock>
+
+    <Border BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="{DynamicResource BorderThickness}"
+            CornerRadius="{DynamicResource LayoutCornerRadius}">
+      <DockPanel>
+        <Menu DockPanel.Dock="Top">
+          <MenuItem Header="File">
+            <MenuItem Header="Open" InputGesture="Ctrl+O" />
+            <MenuItem Header="Open Recent">
+              <MenuItem Header="Session 1" />
+              <MenuItem Header="Session 2" />
+              <Separator />
+              <MenuItem Header="Clear Recent" />
+            </MenuItem>
+            <Separator />
+            <MenuItem Header="Exit" />
+          </MenuItem>
+          <MenuItem Header="Edit">
+            <MenuItem Header="Copy">
+              <MenuItem.Icon>
+                <Svg Path="/Assets/CopyName.svg" />
+              </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="Paste" IsEnabled="False" />
+          </MenuItem>
+          <Separator />
+          <MenuItem Header="View">
+            <MenuItem Header="Toolbar" ToggleType="CheckBox" IsChecked="True" />
+            <MenuItem Header="Status Bar" ToggleType="CheckBox" />
+          </MenuItem>
+        </Menu>
+
+        <Border Padding="16" Background="{DynamicResource LayoutBackgroundLowBrush}">
+          <TextBlock TextWrapping="Wrap">
+            Top-level menu and submenus above are styled only through the imported MenuPack.
+          </TextBlock>
+        </Border>
+      </DockPanel>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml.cs
@@ -1,0 +1,11 @@
+namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
+
+public partial class MenuPackMenuDemo : UserControl
+{
+  public MenuPackMenuDemo()
+  {
+    this.InitializeComponent();
+  }
+}

--- a/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
@@ -1,0 +1,45 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
+             x:Class="SampleApp.DemoPages.MenuPackMenuFlyoutDemo">
+
+  <UserControl.Styles>
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+  </UserControl.Styles>
+
+  <StackPanel Margin="20" Spacing="16">
+    <TextBlock Classes="section-title">Menu Pack proof: MenuFlyoutPresenter</TextBlock>
+
+    <Border HorizontalAlignment="Left"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="{DynamicResource BorderThickness}"
+            CornerRadius="{DynamicResource LayoutCornerRadius}">
+      <MenuFlyoutPresenter>
+        <MenuItem Header="Open session" InputGesture="Ctrl+O">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/Computer.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Open with parameters">
+          <MenuItem Header="Embedded" />
+          <MenuItem Header="External" />
+          <Separator />
+          <MenuItem Header="Select credentials..." />
+        </MenuItem>
+        <Separator />
+        <MenuItem Header="Copy username">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/CopyUserName.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Copy password" IsEnabled="False">
+          <MenuItem.Icon>
+            <Svg Path="/Assets/CopyPassword.svg" />
+          </MenuItem.Icon>
+        </MenuItem>
+      </MenuFlyoutPresenter>
+    </Border>
+  </StackPanel>
+</UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackMenuFlyoutDemo">
 
@@ -9,37 +10,5 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <StackPanel Margin="20" Spacing="16">
-    <TextBlock Classes="section-title">Menu Pack proof: MenuFlyoutPresenter</TextBlock>
-
-    <Border HorizontalAlignment="Left"
-            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-            BorderThickness="{DynamicResource BorderThickness}"
-            CornerRadius="{DynamicResource LayoutCornerRadius}">
-      <MenuFlyoutPresenter>
-        <MenuItem Header="Open session" InputGesture="Ctrl+O">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/Computer.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-        <MenuItem Header="Open with parameters">
-          <MenuItem Header="Embedded" />
-          <MenuItem Header="External" />
-          <Separator />
-          <MenuItem Header="Select credentials..." />
-        </MenuItem>
-        <Separator />
-        <MenuItem Header="Copy username">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/CopyUserName.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-        <MenuItem Header="Copy password" IsEnabled="False">
-          <MenuItem.Icon>
-            <Svg Path="/Assets/CopyPassword.svg" />
-          </MenuItem.Icon>
-        </MenuItem>
-      </MenuFlyoutPresenter>
-    </Border>
-  </StackPanel>
+  <demo:MenuFlyoutDemo />
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml.cs
+++ b/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml.cs
@@ -1,0 +1,11 @@
+namespace SampleApp.DemoPages;
+
+using Avalonia.Controls;
+
+public partial class MenuPackMenuFlyoutDemo : UserControl
+{
+  public MenuPackMenuFlyoutDemo()
+  {
+    this.InitializeComponent();
+  }
+}

--- a/samples/SampleApp/PageCatalog/page-catalog.jsonc
+++ b/samples/SampleApp/PageCatalog/page-catalog.jsonc
@@ -441,9 +441,6 @@
         "demo": "MenuPackMenuDemo.axaml",
         "status": {
           "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        },
-        "excludeFromTests": {
-          "Fluent": true
         }
       },
       {
@@ -453,9 +450,6 @@
         "demo": "MenuPackContextMenuDemo.axaml",
         "status": {
           "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        },
-        "excludeFromTests": {
-          "Fluent": true
         }
       },
       {
@@ -465,9 +459,6 @@
         "demo": "MenuPackMenuFlyoutDemo.axaml",
         "status": {
           "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        },
-        "excludeFromTests": {
-          "Fluent": true
         }
       }
     ],

--- a/samples/SampleApp/PageCatalog/page-catalog.jsonc
+++ b/samples/SampleApp/PageCatalog/page-catalog.jsonc
@@ -27,7 +27,7 @@
     "Overview",
     "Control Demos",
     "Control Alignment",
-    "Menu Pack",
+    "DevExpress Menu Pack",
     "Experiments"
   ],
   "pages": {
@@ -433,33 +433,28 @@
         }
       }
     ],
-    "Menu Pack": [
+    "DevExpress Menu Pack": [
       {
-        "uniqueTitle": "MenuPack: Menu",
-        "source": "Avalonia",
-        "category": "Navigation",
-        "demo": "MenuPackMenuDemo.axaml",
-        "status": {
-          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        }
+        "uniqueTitle": "About",
+        "demo": "MenuPackAbout.axaml"
       },
       {
-        "uniqueTitle": "MenuPack: ContextMenu",
+        "uniqueTitle": "📦 Menu",
         "source": "Avalonia",
         "category": "Navigation",
-        "demo": "MenuPackContextMenuDemo.axaml",
-        "status": {
-          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        }
+        "demo": "MenuPackMenuDemo.axaml"
       },
       {
-        "uniqueTitle": "MenuPack: MenuFlyoutPresenter",
+        "uniqueTitle": "📦 ContextMenu",
         "source": "Avalonia",
         "category": "Navigation",
-        "demo": "MenuPackMenuFlyoutDemo.axaml",
-        "status": {
-          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
-        }
+        "demo": "MenuPackContextMenuDemo.axaml"
+      },
+      {
+        "uniqueTitle": "📦 MenuFlyoutPresenter",
+        "source": "Avalonia",
+        "category": "Navigation",
+        "demo": "MenuPackMenuFlyoutDemo.axaml"
       }
     ],
     "Experiments": [

--- a/samples/SampleApp/PageCatalog/page-catalog.jsonc
+++ b/samples/SampleApp/PageCatalog/page-catalog.jsonc
@@ -27,6 +27,7 @@
     "Overview",
     "Control Demos",
     "Control Alignment",
+    "Menu Pack",
     "Experiments"
   ],
   "pages": {
@@ -429,6 +430,44 @@
         "demo": "ControlAlignment.axaml",
         "status": {
           "Simple": "✅", "Fluent": "✅", "MacClassic": "✅", "LiquidGlass": "❌", "DevExpress": "✅", "Linux": "⚠️", "WinUI": "❌"
+        }
+      }
+    ],
+    "Menu Pack": [
+      {
+        "uniqueTitle": "MenuPack: Menu",
+        "source": "Avalonia",
+        "category": "Navigation",
+        "demo": "MenuPackMenuDemo.axaml",
+        "status": {
+          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
+        },
+        "excludeFromTests": {
+          "Fluent": true
+        }
+      },
+      {
+        "uniqueTitle": "MenuPack: ContextMenu",
+        "source": "Avalonia",
+        "category": "Navigation",
+        "demo": "MenuPackContextMenuDemo.axaml",
+        "status": {
+          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
+        },
+        "excludeFromTests": {
+          "Fluent": true
+        }
+      },
+      {
+        "uniqueTitle": "MenuPack: MenuFlyoutPresenter",
+        "source": "Avalonia",
+        "category": "Navigation",
+        "demo": "MenuPackMenuFlyoutDemo.axaml",
+        "status": {
+          "Simple": "❌", "Fluent": "✅", "MacClassic": "❌", "LiquidGlass": "❌", "DevExpress": "❌", "Linux": "❌", "WinUI": "❌"
+        },
+        "excludeFromTests": {
+          "Fluent": true
         }
       }
     ],

--- a/samples/SampleApp/PageCatalog/page-catalog.jsonc
+++ b/samples/SampleApp/PageCatalog/page-catalog.jsonc
@@ -434,6 +434,8 @@
       }
     ],
     "DevExpress Menu Pack": [
+      // No visual regression tests required for these pages.
+      // They are tested in MenuPackContractTests.cs
       {
         "uniqueTitle": "About",
         "demo": "MenuPackAbout.axaml"
@@ -451,7 +453,7 @@
         "demo": "MenuPackContextMenuDemo.axaml"
       },
       {
-        "uniqueTitle": "📦 MenuFlyoutPresenter",
+        "uniqueTitle": "📦 MenuFlyout",
         "source": "Avalonia",
         "category": "Navigation",
         "demo": "MenuPackMenuFlyoutDemo.axaml"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
@@ -1,0 +1,111 @@
+<!--
+  DevExpress menu token contract — the single source of truth for menu visuals.
+
+  Included by BOTH:
+    - ThemeRoot.axaml            (full DevolutionsDevExpressTheme)
+    - Controls/MenuPack.styles.axaml (externally consumable menu pack)
+
+  so the two can never drift apart.
+
+  Rules for this file:
+    1. Every key is prefixed "DevExMenu" so it can never collide with, or be
+       silently overridden by, a host theme when the pack is layered on top.
+    2. Values are pinned literals. Do NOT use StaticResource/DynamicResource to
+       point at theme-wide or Fluent-owned keys: when the pack is consumed over a
+       foreign host theme those keys resolve to the host's values and the menus
+       drift. Everything the menus depend on visually lives here.
+    3. Keys deliberately NOT owned here are intentionally inherited from the host.
+       At this point that list is only FluentMenuScrollViewer (a ControlTheme).
+       See README for the full prerequisite contract.
+
+  Typography is PINNED here, not inherited. The pack exists so that menus in a
+  branded/opted-out section still match the platform-themed menus elsewhere in the
+  same app. Inheriting DefaultFontFamily / ControlFontSize from the host defeated
+  that: a branded section rendered its menus in the branded font and size, which is
+  precisely the inconsistency the pack is meant to remove. Pinning also makes menu
+  geometry host-invariant, which is what lets the visual tests compare captures
+  across hosts directly instead of storing a baseline per host.
+-->
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <ResourceDictionary.ThemeDictionaries>
+    <ResourceDictionary x:Key="Light">
+      <SolidColorBrush x:Key="DevExMenuBackgroundBrush" Color="#f0f0f0" />
+      <SolidColorBrush x:Key="DevExMenuPopupBorderBrush" Color="#c3c3c3" />
+      <SolidColorBrush x:Key="DevExMenuItemBackground" Color="Transparent" />
+      <SolidColorBrush x:Key="DevExMenuItemForeground" Color="#000000" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForeground" Color="#99000000" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundPointerOver" Color="#000000" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundPointerOver" Color="#99000000" />
+      <SolidColorBrush x:Key="DevExMenuItemBackgroundPressed" Color="#33000000" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundPressed" Color="#000000" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundPressed" Color="#99000000" />
+      <SolidColorBrush x:Key="DevExMenuItemBackgroundDisabled" Color="Transparent" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundDisabled" Color="#66000000" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundDisabled" Color="#66000000" />
+      <SolidColorBrush x:Key="DevExMenuItemPointerOverBackground" Color="#eaeaea" />
+      <SolidColorBrush x:Key="DevExMenuSeparatorBrush" Color="#dadada" />
+      <SolidColorBrush x:Key="DevExMenuItemChevronBrush" Color="#000000" />
+      <x:String x:Key="DevExMenuSvgItemDefaultCss">.st0{fill:#010101;}</x:String>
+      <x:String x:Key="DevExMenuSvgItemDisabledCss">.st0,.st1,.st2,.st3{fill:#bdbdbd;}</x:String>
+    </ResourceDictionary>
+
+    <ResourceDictionary x:Key="Dark">
+      <SolidColorBrush x:Key="DevExMenuBackgroundBrush" Color="#202020" />
+      <SolidColorBrush x:Key="DevExMenuPopupBorderBrush" Color="#414141" />
+      <SolidColorBrush x:Key="DevExMenuItemBackground" Color="Transparent" />
+      <SolidColorBrush x:Key="DevExMenuItemForeground" Color="#ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForeground" Color="#99ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundPointerOver" Color="#ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundPointerOver" Color="#99ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemBackgroundPressed" Color="#33ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundPressed" Color="#ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundPressed" Color="#99ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemBackgroundDisabled" Color="Transparent" />
+      <SolidColorBrush x:Key="DevExMenuItemForegroundDisabled" Color="#66ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemKeyboardAcceleratorTextForegroundDisabled" Color="#66ffffff" />
+      <SolidColorBrush x:Key="DevExMenuItemPointerOverBackground" Color="#3c3c3c" />
+      <SolidColorBrush x:Key="DevExMenuSeparatorBrush" Color="#404040" />
+      <SolidColorBrush x:Key="DevExMenuItemChevronBrush" Color="#f5f5f5" />
+      <x:String x:Key="DevExMenuSvgItemDefaultCss">.st0{fill:#f5f5f5;}</x:String>
+      <x:String x:Key="DevExMenuSvgItemDisabledCss">.st0,.st1,.st2,.st3{fill:#656565;}</x:String>
+    </ResourceDictionary>
+  </ResourceDictionary.ThemeDictionaries>
+
+  <!-- Typography (pinned — see header) -->
+  <FontFamily x:Key="DevExMenuFontFamily">Segoe UI, Tahoma, sans-serif</FontFamily>
+  <x:Double x:Key="DevExMenuFontSize">12</x:Double>
+  <FontWeight x:Key="DevExMenuFontWeight">Normal</FontWeight>
+
+  <!-- Menu bar -->
+  <x:Double x:Key="DevExMenuBarHeight">32</x:Double>
+
+  <!-- Popup surfaces -->
+  <Thickness x:Key="DevExMenuPopupBorderThickness">1</Thickness>
+  <Thickness x:Key="DevExMenuPopupPadding">1</Thickness>
+  <Thickness x:Key="DevExMenuFlyoutPresenterPadding">0</Thickness>
+  <Thickness x:Key="DevExMenuTopLevelPopupPadding">0</Thickness>
+  <Thickness x:Key="DevExMenuPopupMargin">0 0 0 10</Thickness>
+  <CornerRadius x:Key="DevExMenuPopupCornerRadius">4</CornerRadius>
+  <CornerRadius x:Key="DevExMenuTopLevelPopupCornerRadius">4</CornerRadius>
+  <BoxShadows x:Key="DevExMenuPopupShadow">0 3 7 0 #30000000</BoxShadows>
+  <x:Double x:Key="DevExMenuPopupMaxWidth">456</x:Double>
+  <x:Double x:Key="DevExMenuPopupMinHeight">32</x:Double>
+  <x:Double x:Key="DevExMenuHorizontalFlyoutMinWidth">32</x:Double>
+  <x:Double x:Key="DevExMenuSubMenuPopupHorizontalOffset">5</x:Double>
+
+  <!-- Separators -->
+  <Thickness x:Key="DevExMenuSeparatorMargin">7 1 0 1</Thickness>
+  <x:Double x:Key="DevExMenuSeparatorHeight">1</x:Double>
+  <x:Double x:Key="DevExMenuSeparatorIconColumnWidth">30</x:Double>
+  <Thickness x:Key="DevExMenuBarSeparatorMargin">0 4</Thickness>
+  <x:Double x:Key="DevExMenuBarSeparatorWidth">1</x:Double>
+
+  <!-- Menu items -->
+  <x:Double x:Key="DevExMenuNestedItemMinHeight">26</x:Double>
+  <Thickness x:Key="DevExMenuNestedItemPadding">10,2</Thickness>
+  <Thickness x:Key="DevExMenuIconPresenterMargin">4 0 10 0</Thickness>
+  <Thickness x:Key="DevExMenuInputGestureTextMargin">15,0,0,0</Thickness>
+
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -99,8 +99,6 @@
     
       <SolidColorBrush x:Key="DefaultFocusBorderBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.6" />
 
-      <x:String x:Key="SvgMenuItemDefaultCss">.st0{fill:#010101;}</x:String>
-      <x:String x:Key="SvgMenuItemDisabledCss">.st0,.st1,.st2,.st3{fill:#bdbdbd;}</x:String>
     </ResourceDictionary>
 
     <!-- MARK: Dark Mode -->
@@ -197,8 +195,6 @@
     
       <SolidColorBrush x:Key="DefaultFocusBorderBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.5" />
 
-      <x:String x:Key="SvgMenuItemDefaultCss">.st0{fill:#f5f5f5;}</x:String>
-      <x:String x:Key="SvgMenuItemDisabledCss">.st0,.st1,.st2,.st3{fill:#656565;}</x:String>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
@@ -334,11 +330,11 @@
   <StaticResource x:Key="DefaultFontFamily" ResourceKey="DevExpressThemeFontFamily" />
   <SolidColorBrush x:Key="MenuItemBackgroundPointerOver" Color="{DynamicResource MenuItemBackgroundPointerOverColor}" />
 
+  <!-- Menu tokens live in Accents/MenuResources.axaml (shared with the menu pack). -->
+
   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
   <SolidColorBrush x:Key="MenuSeparatorBrush" Color="{DynamicResource MenuSeparatorColor}" />
   <Thickness x:Key="SeparatorMargin">0 2</Thickness>
-  <Thickness x:Key="SeparatorContextMenuMargin">7 1 0 1</Thickness>
-  <x:Double x:Key="SeparatorContextMenuIconColumnWidth">30</x:Double>
 
   <x:Double x:Key="OpacityVisible">1</x:Double>
   <x:Double x:Key="OpacityHidden">0</x:Double>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/MenuSeparatorAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/MenuSeparatorAlignmentBehavior.cs
@@ -51,8 +51,8 @@ internal static class MenuSeparatorAlignmentBehavior
 
     private static void UpdateMargin(Separator separator)
     {
-        Thickness baseMargin = GetResource(separator, "SeparatorContextMenuMargin", defaultMargin);
-        double iconColumnWidth = GetResource(separator, "SeparatorContextMenuIconColumnWidth", DefaultIconColumnWidth);
+        Thickness baseMargin = GetResource(separator, "DevExMenuSeparatorMargin", defaultMargin);
+        double iconColumnWidth = GetResource(separator, "DevExMenuSeparatorIconColumnWidth", DefaultIconColumnWidth);
         int iconColumnCount = GetIconColumnCount(separator);
 
         separator.Margin = new Thickness(

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ContextMenu.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/ContextMenu.axaml
@@ -39,27 +39,27 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type ContextMenu}" TargetType="ContextMenu">
-    <Setter Property="Background" Value="{DynamicResource MenuBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxDropDownBorderBrush}" />
-    <Setter Property="BorderThickness" Value="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}" />
-    <Setter Property="Padding" Value="{DynamicResource ContextMenuBorderPadding}" />
-    <Setter Property="MaxWidth" Value="{DynamicResource FlyoutThemeMaxWidth}" />
-    <Setter Property="MinHeight" Value="{DynamicResource MenuFlyoutThemeMinHeight}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource DevExMenuPopupBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource DevExMenuPopupBorderThickness}" />
+    <Setter Property="Padding" Value="{DynamicResource DevExMenuPopupPadding}" />
+    <Setter Property="MaxWidth" Value="{DynamicResource DevExMenuPopupMaxWidth}" />
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuPopupMinHeight}" />
     <Setter Property="Focusable" Value="True" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="WindowManagerAddShadowHint" Value="False" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ContextMenuCornerRadius}" />
-    <Setter Property="FontFamily" Value="{DynamicResource DefaultFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource DefaultFontWeight}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource DevExMenuPopupCornerRadius}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
 
     <Setter Property="Template">
       <ControlTemplate>
         <Border Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
-                Margin="{DynamicResource ComboBoxPopupBorderMargin}"
-                BoxShadow="{DynamicResource ComboBoxDropDownShadow}"
+                Margin="{DynamicResource DevExMenuPopupMargin}"
+                BoxShadow="{DynamicResource DevExMenuPopupShadow}"
                 Padding="{TemplateBinding Padding}"
                 MaxWidth="{TemplateBinding MaxWidth}"
                 MinHeight="{TemplateBinding MinHeight}"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.axaml
@@ -16,11 +16,9 @@
     </Border>
   </Design.PreviewWith>
   
-  <x:Double x:Key="MenuBarHeight">32</x:Double>
-
   <ControlTheme x:Key="MenuTopLevelMenuItem" TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
-    <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForeground}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
     <Setter Property="Padding" Value="6 1" />
     
     <Setter Property="Template">
@@ -40,12 +38,12 @@
             <StackPanel Grid.Column="0" Orientation="Horizontal">
               <ContentControl Name="PART_ToggleIconPresenter"
                               IsVisible="False"
-                              Theme="{StaticResource FluentMenuItemIconTheme}"
+                              Theme="{StaticResource DevExMenuItemIconTheme}"
                               Margin="0 0 6 0" />
   
               <ContentControl Name="PART_IconPresenter"
                               IsVisible="False"
-                              Theme="{StaticResource FluentMenuItemIconTheme}"
+                              Theme="{StaticResource DevExMenuItemIconTheme}"
                               Content="{TemplateBinding Icon}"
                               Margin="0 0 6 0" />
             </StackPanel>
@@ -63,17 +61,17 @@
                    IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}"
                    Placement="BottomEdgeAlignedLeft"
                    OverlayInputPassThroughElement="{Binding $parent[Menu]}">
-              <Border Background="{DynamicResource MenuFlyoutPresenterBackground}"
-                      BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                      BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
-                      TextElement.FontFamily="{DynamicResource DefaultFontFamily}"
-                      TextElement.FontSize="{DynamicResource ControlFontSize}"
-                      TextElement.FontWeight="{DynamicResource DefaultFontWeight}"
-                      Padding="{DynamicResource MenuFlyoutPresenterThemePadding}"
-                      MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                      MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+              <Border Background="{DynamicResource DevExMenuBackgroundBrush}"
+                      BorderBrush="{DynamicResource DevExMenuPopupBorderBrush}"
+                      BorderThickness="{DynamicResource DevExMenuPopupBorderThickness}"
+                      TextElement.FontFamily="{DynamicResource DevExMenuFontFamily}"
+                      TextElement.FontSize="{DynamicResource DevExMenuFontSize}"
+                      TextElement.FontWeight="{DynamicResource DevExMenuFontWeight}"
+                      Padding="{DynamicResource DevExMenuTopLevelPopupPadding}"
+                      MaxWidth="{DynamicResource DevExMenuPopupMaxWidth}"
+                      MinHeight="{DynamicResource DevExMenuPopupMinHeight}"
                       HorizontalAlignment="Stretch"
-                      CornerRadius="{DynamicResource OverlayCornerRadius}">
+                      CornerRadius="{DynamicResource DevExMenuTopLevelPopupCornerRadius}">
                 <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}" Margin="1">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   ItemsPanel="{TemplateBinding ItemsPanel}"
@@ -89,7 +87,7 @@
 
   <ControlTheme x:Key="{x:Type Menu}" TargetType="Menu">
     <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Height" Value="{DynamicResource MenuBarHeight}" />
+    <Setter Property="Height" Value="{DynamicResource DevExMenuBarHeight}" />
     <Setter Property="ItemContainerTheme" Value="{StaticResource MenuTopLevelMenuItem}" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
@@ -14,14 +14,14 @@
   </Design.PreviewWith>
 
   <Style Selector="Menu > Separator, Menu > MenuItem:separator > Separator">
-    <Setter Property="Margin" Value="0 4" />
-    <Setter Property="Width" Value="1" />
+    <Setter Property="Margin" Value="{DynamicResource DevExMenuBarSeparatorMargin}" />
+    <Setter Property="Width" Value="{DynamicResource DevExMenuBarSeparatorWidth}" />
     <Setter Property="Height" Value="NaN" />
     <Setter Property="behaviors:MenuSeparatorAlignmentBehavior.Enable" Value="False" />
   </Style>
 
   <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
-    <Setter Property="MinHeight" Value="26" />
-    <Setter Property="Padding" Value="10,2" />
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource DevExMenuNestedItemPadding}" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuFlyoutPresenter.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuFlyoutPresenter.axaml
@@ -4,26 +4,26 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   
   <ControlTheme x:Key="{x:Type MenuFlyoutPresenter}" TargetType="MenuFlyoutPresenter">
-    <Setter Property="Background" Value="{DynamicResource MenuBackground}" />
-    <Setter Property="BorderBrush" Value="{DynamicResource ComboBoxDropDownBorderBrush}" />
-    <Setter Property="BorderThickness" Value="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}" />
-    <Setter Property="Padding" Value="{DynamicResource ComboBoxDropdownBorderPadding}" />
-    <Setter Property="MaxWidth" Value="{DynamicResource FlyoutThemeMaxWidth}" />
-    <Setter Property="MinHeight" Value="{DynamicResource MenuFlyoutThemeMinHeight}" />
-    <Setter Property="FontFamily" Value="{DynamicResource DefaultFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource DefaultFontWeight}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuBackgroundBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource DevExMenuPopupBorderBrush}" />
+    <Setter Property="BorderThickness" Value="{DynamicResource DevExMenuPopupBorderThickness}" />
+    <Setter Property="Padding" Value="{DynamicResource DevExMenuFlyoutPresenterPadding}" />
+    <Setter Property="MaxWidth" Value="{DynamicResource DevExMenuPopupMaxWidth}" />
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuPopupMinHeight}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
     <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto" />
     <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ContextMenuCornerRadius}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource DevExMenuPopupCornerRadius}" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border Name="LayoutRoot"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
-                Margin="{DynamicResource ComboBoxPopupBorderMargin}"
-                BoxShadow="{DynamicResource ComboBoxDropDownShadow}"
+                Margin="{DynamicResource DevExMenuPopupMargin}"
+                BoxShadow="{DynamicResource DevExMenuPopupShadow}"
                 Padding="{TemplateBinding Padding}"
                 CornerRadius="{TemplateBinding CornerRadius}">
           <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -39,7 +39,7 @@
     </Setter>
   </ControlTheme>
   <ControlTheme x:Key="HorizontalMenuFlyoutPresenter" TargetType="MenuFlyoutPresenter"  BasedOn="{StaticResource {x:Type MenuFlyoutPresenter}}">
-    <Setter Property="MinWidth" Value="{DynamicResource HorizontalMenuFlyoutThemeMinWidth}" />
+    <Setter Property="MinWidth" Value="{DynamicResource DevExMenuHorizontalFlyoutMinWidth}" />
     <Setter Property="ItemsPanel">
       <ItemsPanelTemplate>
         <StackPanel Orientation="Horizontal"/>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
@@ -51,20 +51,19 @@
     </Border>
   </Design.PreviewWith>
 
-  <conv:PlatformKeyGestureConverter x:Key="KeyGestureConverter" />
-  <x:Double x:Key="SubMenuPopupHorizontalOffset">5</x:Double>
-  <Thickness x:Key="MenuIconPresenterMargin">4 0 10 0</Thickness>
-  <Thickness x:Key="MenuInputGestureTextMargin">15,0,0,0</Thickness>
-  <StreamGeometry x:Key="MenuItemChevronPathData">M 1,0 10,10 l -9,10 -1,-1 L 8,10 -0,1 Z</StreamGeometry>
-  <StreamGeometry x:Key="MenuItemCheckMarkPathData">M 0.5,4.5 L 3.5,7.5 L 10.5,0.5</StreamGeometry>
+  <conv:PlatformKeyGestureConverter x:Key="DevExMenuKeyGestureConverter" />
+  <StreamGeometry x:Key="DevExMenuItemChevronPathData">M1881.76,1.56l-876.76,876.76L126.68,0C82.97,0,0,158.32,0,158.32l1005,1005L2010,158.32,1881.76,1.56Z</StreamGeometry>
+  <StreamGeometry x:Key="DevExMenuItemCheckMarkPathData">M 0.5,4.5 L 3.5,7.5 L 10.5,0.5</StreamGeometry>
 
   <ControlTheme x:Key="{x:Type MenuItem}" TargetType="MenuItem">
-    <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForeground}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
     <Setter Property="Padding" Value="4 1" />
     <Setter Property="Margin" Value="3" />
     <Setter Property="CornerRadius" Value="4" />
-    <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
     <!-- Block inheritance of LineHeight from parent controls -->
     <Setter Property="TextBlock.LineHeight" Value="NaN" />
     
@@ -93,15 +92,15 @@
               <ContentControl Grid.Column="0"
                               x:Name="PART_ToggleIconPresenter"
                               IsVisible="False"
-                              Theme="{StaticResource FluentMenuItemIconTheme}"
-                              Margin="{DynamicResource MenuIconPresenterMargin}" />
+                              Theme="{StaticResource DevExMenuItemIconTheme}"
+                              Margin="{DynamicResource DevExMenuIconPresenterMargin}" />
 
               <ContentControl Grid.Column="1"
                               x:Name="PART_IconPresenter"
                               IsVisible="False"
-                              Theme="{StaticResource FluentMenuItemIconTheme}"
+                              Theme="{StaticResource DevExMenuItemIconTheme}"
                               Content="{TemplateBinding Icon}"
-                              Margin="{DynamicResource MenuIconPresenterMargin}" />
+                              Margin="{DynamicResource DevExMenuIconPresenterMargin}" />
 
               <ContentPresenter Name="PART_HeaderPresenter"
                                 Content="{TemplateBinding Header}"
@@ -112,11 +111,11 @@
                                 Grid.Column="2" />
               <TextBlock x:Name="PART_InputGestureText"
                          Grid.Column="3"
-                         Margin="{DynamicResource MenuInputGestureTextMargin}"
-                         Text="{TemplateBinding InputGesture, Converter={StaticResource KeyGestureConverter}}"
+                         Margin="{DynamicResource DevExMenuInputGestureTextMargin}"
+                         Text="{TemplateBinding InputGesture, Converter={StaticResource DevExMenuKeyGestureConverter}}"
                          HorizontalAlignment="Right"
                          VerticalAlignment="Center"
-                         Foreground="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForeground}" />
+                         Foreground="{DynamicResource DevExMenuItemKeyboardAcceleratorTextForeground}" />
               <PathIcon Name="PART_ChevronPath"
                         Grid.Column="4"
                         Margin="8 0 0 0"
@@ -125,8 +124,8 @@
                         Width="9"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        Foreground="{DynamicResource ForegroundHighBrush}"
-                        Data="{StaticResource ChevronPath}">
+                        Foreground="{DynamicResource DevExMenuItemChevronBrush}"
+                        Data="{StaticResource DevExMenuItemChevronPathData}">
                 <PathIcon.RenderTransform>
                   <RotateTransform Angle="-90" />
                 </PathIcon.RenderTransform>
@@ -136,22 +135,22 @@
           <Popup Name="PART_Popup"
                  WindowManagerAddShadowHint="False"
                  Placement="RightEdgeAlignedTop"
-                 HorizontalOffset="{DynamicResource SubMenuPopupHorizontalOffset}"
+                 HorizontalOffset="{DynamicResource DevExMenuSubMenuPopupHorizontalOffset}"
                  VerticalOffset="-7"
                  IsLightDismissEnabled="False"
                  IsOpen="{TemplateBinding IsSubMenuOpen, Mode=TwoWay}">
-            <Border Background="{DynamicResource MenuBackground}"
-                    BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
-                    BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThemeThickness}"
-                    BoxShadow="{DynamicResource ComboBoxDropDownShadow}"
-                    TextElement.FontFamily="{DynamicResource DefaultFontFamily}"
-                    TextElement.FontSize="{DynamicResource ControlFontSize}"
-                    TextElement.FontWeight="{DynamicResource DefaultFontWeight}"
-                    Padding="{DynamicResource ContextMenuBorderPadding}"
-                    MaxWidth="{DynamicResource FlyoutThemeMaxWidth}"
-                    MinHeight="{DynamicResource MenuFlyoutThemeMinHeight}"
+            <Border Background="{DynamicResource DevExMenuBackgroundBrush}"
+                    BorderBrush="{DynamicResource DevExMenuPopupBorderBrush}"
+                    BorderThickness="{DynamicResource DevExMenuPopupBorderThickness}"
+                    BoxShadow="{DynamicResource DevExMenuPopupShadow}"
+                    TextElement.FontFamily="{DynamicResource DevExMenuFontFamily}"
+                    TextElement.FontSize="{DynamicResource DevExMenuFontSize}"
+                    TextElement.FontWeight="{DynamicResource DevExMenuFontWeight}"
+                    Padding="{DynamicResource DevExMenuPopupPadding}"
+                    MaxWidth="{DynamicResource DevExMenuPopupMaxWidth}"
+                    MinHeight="{DynamicResource DevExMenuPopupMinHeight}"
                     HorizontalAlignment="Stretch"
-                    CornerRadius="{DynamicResource ContextMenuCornerRadius}">
+                    CornerRadius="{DynamicResource DevExMenuPopupCornerRadius}">
               <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
                 <ItemsPresenter Name="PART_ItemsPresenter"
                                 ItemsPanel="{TemplateBinding ItemsPanel}"
@@ -172,42 +171,42 @@
     </Style>
     <Style Selector="^:selected">
       <Style Selector="^ /template/ Border#PART_LayoutRoot">
-        <Setter Property="Background" Value="{DynamicResource MenuItemBackgroundPointerOver}" />
+        <Setter Property="Background" Value="{DynamicResource DevExMenuItemPointerOverBackground}" />
       </Style>
       <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPointerOver}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForegroundPointerOver}" />
       </Style>
       <Style Selector="^ /template/ TextBlock#PART_InputGestureText">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPointerOver}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemKeyboardAcceleratorTextForegroundPointerOver}" />
       </Style>
     </Style>
 
     <!--  Listen for PART_LayoutRoot:pointerover, so it will not be triggered when subitem is pressed  -->
     <Style Selector="^:pressed /template/ Border#PART_LayoutRoot:pointerover">
-      <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackgroundPressed}" />
+      <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackgroundPressed}" />
       <Style Selector="^ ContentPresenter#PART_HeaderPresenter">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundPressed}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForegroundPressed}" />
       </Style>
       <Style Selector="^ TextBlock#PART_InputGestureText">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundPressed}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemKeyboardAcceleratorTextForegroundPressed}" />
       </Style>
     </Style>
 
     <Style Selector="^:disabled">
       <Style Selector="^ /template/ Border#PART_LayoutRoot">
-        <Setter Property="Background" Value="{DynamicResource MenuFlyoutItemBackgroundDisabled}" />
+        <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackgroundDisabled}" />
       </Style>
       <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForegroundDisabled}" />
       </Style>
       <Style Selector="^ /template/ TextBlock#PART_InputGestureText">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemKeyboardAcceleratorTextForegroundDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemKeyboardAcceleratorTextForegroundDisabled}" />
       </Style>
       <Style Selector="^ /template/ PathIcon#PART_ChevronPath">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForegroundDisabled}" />
       </Style>
       <Style Selector="^ /template/ ContentControl#PART_IconPresenter">
-        <Setter Property="Foreground" Value="{DynamicResource MenuFlyoutItemForegroundDisabled}" />
+        <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForegroundDisabled}" />
       </Style>
     </Style>
 
@@ -242,7 +241,7 @@
                 Stretch="None"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
-                Data="{StaticResource MenuItemCheckMarkPathData}" />
+                Data="{StaticResource DevExMenuItemCheckMarkPathData}" />
         </Template>
       </Setter>
     </Style>
@@ -257,7 +256,7 @@
     </Style>
   </ControlTheme>
 
-  <ControlTheme x:Key="FluentMenuItemIconTheme" TargetType="ContentControl">
+  <ControlTheme x:Key="DevExMenuItemIconTheme" TargetType="ContentControl">
     <Setter Property="Width"
             Value="16" />
     <Setter Property="Height"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
@@ -1,0 +1,21 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <MergeResourceInclude Source="/Accents/Icons.axaml" />
+        <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
+        <MergeResourceInclude Source="/Controls/ContextMenu.axaml" />
+        <MergeResourceInclude Source="/Controls/MenuFlyoutPresenter.axaml" />
+        <MergeResourceInclude Source="/Controls/Menu.axaml" />
+        <MergeResourceInclude Source="/Controls/MenuItem.axaml" />
+        <MergeResourceInclude Source="/Controls/Separator.axaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
+
+  <StyleInclude Source="/Controls/MenuSvg.styles.axaml" />
+  <StyleInclude Source="/Controls/Separator.styles.axaml" />
+  <StyleInclude Source="/Controls/Menu.styles.axaml" />
+</Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
@@ -4,13 +4,19 @@
   <Styles.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
-        <MergeResourceInclude Source="/Accents/Icons.axaml" />
-        <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
+        <MergeResourceInclude Source="/Accents/MenuResources.axaml" />
         <MergeResourceInclude Source="/Controls/ContextMenu.axaml" />
         <MergeResourceInclude Source="/Controls/MenuFlyoutPresenter.axaml" />
         <MergeResourceInclude Source="/Controls/Menu.axaml" />
         <MergeResourceInclude Source="/Controls/MenuItem.axaml" />
-        <MergeResourceInclude Source="/Controls/Separator.axaml" />
+        <!--
+          Separator.axaml is deliberately NOT merged here. It is keyed
+          `{x:Type Separator}`, i.e. an implicit theme, so merging it would restyle
+          EVERY separator in the consuming app rather than just menu ones. Menu
+          separators instead use the host's template (identical across Fluent,
+          MacOS and Linux) with every bound property pinned in
+          Separator.styles.axaml.
+        -->
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
   </Styles.Resources>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuSvg.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuSvg.styles.axaml
@@ -1,0 +1,11 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Style Selector="MenuItem Svg">
+    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDefaultCss}" />
+  </Style>
+
+  <Style Selector="MenuItem Svg:disabled">
+    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDisabledCss}" />
+  </Style>
+</Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuSvg.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuSvg.styles.axaml
@@ -2,10 +2,10 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
   <Style Selector="MenuItem Svg">
-    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDefaultCss}" />
+    <Setter Property="Css" Value="{DynamicResource DevExMenuSvgItemDefaultCss}" />
   </Style>
 
   <Style Selector="MenuItem Svg:disabled">
-    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDisabledCss}" />
+    <Setter Property="Css" Value="{DynamicResource DevExMenuSvgItemDisabledCss}" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Separator.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Separator.styles.axaml
@@ -13,9 +13,27 @@
       </design:ThemePreviewer>
     </Design.PreviewWith>
 
+    <!--
+      Menu separators are sealed against the host theme.
+
+      The pack deliberately does NOT ship a Separator ControlTheme: doing so would
+      install an implicit `{x:Type Separator}` theme and restyle every separator in
+      the consuming app, not just menu ones. Instead we rely on the host's template
+      (Fluent's, which MacOS/Linux/DevExpress all copy verbatim) and pin every
+      property that template binds, so a host override cannot reach our menus.
+
+      If you add a TemplateBinding-visible property to Separator.axaml's template,
+      pin it here too.
+    -->
     <Style Selector="ContextMenu Separator, MenuFlyoutPresenter Separator, Menu Separator, MenuItem Separator">
-        <Setter Property="Background" Value="{DynamicResource MenuSeparatorBrush}" />
-        <Setter Property="Margin" Value="{DynamicResource SeparatorContextMenuMargin}" />
+        <Setter Property="Background" Value="{DynamicResource DevExMenuSeparatorBrush}" />
+        <Setter Property="Margin" Value="{DynamicResource DevExMenuSeparatorMargin}" />
+        <Setter Property="Height" Value="{DynamicResource DevExMenuSeparatorHeight}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="CornerRadius" Value="0" />
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="behaviors:MenuSeparatorAlignmentBehavior.Enable" Value="True" />
     </Style>
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/GlobalStyles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/GlobalStyles.axaml
@@ -23,13 +23,7 @@
     - sbergerondrouin 2025-06-09
   -->
 
-  <Style Selector="MenuItem Svg">
-    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDefaultCss}" />
-  </Style>
-
-  <Style Selector="MenuItem Svg:disabled">
-    <Setter Property="Css" Value="{DynamicResource SvgMenuItemDisabledCss}" />
-  </Style>
+  <StyleInclude Source="/Controls/MenuSvg.styles.axaml" />
 
   <StyleInclude Source="/Controls/TextBox.styles.axaml" />
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -88,6 +88,32 @@ In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<Simpl
 
 **Note:** Some global Styles will also be loaded by default, you can opt out by setting `GlobalStyles` to false (`<DevolutionsDevExpressTheme GlobalStyles="False" />`). GlobalStyles are also available as a separate tag `<DevolutionsDevExpressThemeGlobalStyles />` to cover scenarios where consumers would like to scope them to some control instead of including them globally. This is may be necessary to prevent styles from "bleeding out" in cases where that might be undesirable.
 
+### Menu pack (menu controls only)
+
+Use the menu pack when you only want DevExpress menu styling without importing the full `<DevolutionsDevExpressTheme />`.
+
+```xaml
+<Application ...>
+  <Application.Styles>
+    <!-- Required prerequisite -->
+    <FluentTheme />
+
+    <!-- DevExpress menu pack -->
+    <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+  </Application.Styles>
+</Application>
+```
+
+Exact menu pack URI:
+
+`avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`
+
+Prerequisites and caveats:
+
+- `FluentTheme` must be loaded first (the pack depends on Fluent menu resource keys).
+- This pack includes styling for `ContextMenu`, `MenuFlyoutPresenter`, `Menu`, `MenuItem`, `Separator`, and menu-specific helper styles (`Menu.styles.axaml`, `Separator.styles.axaml`, and `MenuItem Svg` global icon CSS styles).
+- If you need full control coverage, use `<DevolutionsDevExpressTheme />` instead.
+
 ## Styled Controls
 
 Most of the images below are screenshots from the [SampleApp test and demo pages](https://github.com/Devolutions/avalonia-extensions/tree/master/samples/SampleApp/DemoPages) - feel free to check out the code there for more detailed usage examples.

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -95,7 +95,7 @@ Use the menu pack when you only want DevExpress menu styling without importing t
 ```xaml
 <Application ...>
   <Application.Styles>
-    <!-- Required prerequisite -->
+    <!-- Required prerequisite: must be application-wide, not scoped to a subtree -->
     <FluentTheme />
 
     <!-- DevExpress menu pack -->
@@ -110,9 +110,63 @@ Exact menu pack URI:
 
 Prerequisites and caveats:
 
-- `FluentTheme` must be loaded first (the pack depends on Fluent menu resource keys).
-- This pack includes styling for `ContextMenu`, `MenuFlyoutPresenter`, `Menu`, `MenuItem`, `Separator`, and menu-specific helper styles (`Menu.styles.axaml`, `Separator.styles.axaml`, and `MenuItem Svg` global icon CSS styles).
+- **`FluentTheme` must be loaded application-wide, in `Application.Styles` — not scoped to a subtree.** Adding
+  `<FluentTheme />` to the `Styles` of a `Window`, `UserControl`, or other container is *not* sufficient, even though
+  the resource appears reachable from that subtree. The pack reuses Fluent's `MenuScrollViewer` control theme, which is
+  resolved when the menu template is built; if `FluentTheme` is not application-wide this fails with an
+  `InvalidCastException` during template construction. The exception surfaces on any menu — including a single-item
+  menu that never needs to scroll — and its message does not mention scrolling, so it is easy to misdiagnose. If you
+  see an unexplained `InvalidCastException` when a menu first opens, check this first.
+- The pack reuses the Fluent base control templates and deliberately inherits a small set of keys from the host so
+  menus still feel native to the surrounding app (see "Inherited from the host" below).
+- This pack includes styling for `ContextMenu`, `MenuFlyoutPresenter`, `Menu`, `MenuItem`, `Separator`, and
+  menu-specific helper styles (`Menu.styles.axaml`, `Separator.styles.axaml`, and the `MenuItem` Svg icon CSS styles).
 - If you need full control coverage, use `<DevolutionsDevExpressTheme />` instead.
+
+#### Resource contract
+
+All menu tokens live in a single shared file, `Accents/MenuResources.axaml`, which is included by **both** the full
+theme and the menu pack. There is one source of truth, so the pack can never drift from the full theme.
+
+Two rules make the pack safe to layer over a host theme you do not control:
+
+1. **Every key the pack owns is prefixed `DevExMenu`** — it cannot collide with, or be silently overridden by, the host
+   theme's keys.
+2. **Values are pinned literals, never aliases.** Menu tokens do not resolve through generic theme-wide or Fluent-owned
+   keys. A host theme that redefines e.g. `MenuFlyoutPresenterBorderThemeThickness` or `FlyoutThemeMaxWidth` cannot move
+   menu visuals.
+
+**Inherited from the host (by design):**
+
+| Key | Why |
+|-----|-----|
+| `FluentMenuScrollViewer` | Fluent's scroll viewer theme, reused rather than duplicated. This is the one remaining hard dependency on Fluent — see the prerequisite note above. |
+
+**Typography is pinned, not inherited.** `DevExMenuFontFamily` / `DevExMenuFontSize` /
+`DevExMenuFontWeight` are owned by the pack. The point of the pack is that menus in a branded or
+opted-out section still match the platform-themed menus elsewhere in the same app; inheriting the
+host's font defeated that, because the branded section rendered its menus in the branded font and
+size. Pinning also keeps menu geometry identical across hosts.
+
+**The pack styles menu content only.** It deliberately does not ship a `Separator` `ControlTheme`:
+that resource is keyed `{x:Type Separator}`, so merging it would restyle *every* separator in your
+app rather than just menu ones. Menu separators instead reuse the host's separator template — which
+is identical across Fluent, MacOS, Linux and DevExpress — with every template-bound property pinned
+inside the menu-scoped selector. A guard test asserts that adding the pack leaves non-menu
+separators byte-identical.
+
+**Overriding a token.** Because tokens are prefixed, you can retarget any single value without affecting the rest of
+your app:
+
+```xaml
+<StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+<!-- ... later in your own resources ... -->
+<SolidColorBrush x:Key="DevExMenuSeparatorBrush" Color="#ff0000" />
+```
+
+Both rules are enforced by `MenuPackContractTests` in the visual test project, which asserts that every `DevExMenu*`
+token resolves identically under the full theme and under "pack over a foreign host", and that a hostile host theme
+cannot leak into any of them.
 
 ## Styled Controls
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/ThemeRoot.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/ThemeRoot.axaml
@@ -11,6 +11,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <MergeResourceInclude Source="/Accents/Icons.axaml" />
+        <MergeResourceInclude Source="/Accents/MenuResources.axaml" />
         <MergeResourceInclude Source="/Accents/ThemeResources.axaml" />
         <MergeResourceInclude Source="/Controls/_index.axaml" />
       </ResourceDictionary.MergedDictionaries>

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -1,0 +1,337 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Styling;
+using AvaloniaFluentTheme = Avalonia.Themes.Fluent.FluentTheme;
+using Avalonia.Threading;
+using Devolutions.AvaloniaTheme.DevExpress;
+using SampleApp;
+using SampleApp.DemoPages;
+using Xunit;
+
+namespace Devolutions.AvaloniaControls.VisualTests;
+
+/// <summary>
+/// Guards the DevExpress menu pack contract.
+///
+/// The full theme and the externally consumable menu pack both source their menu
+/// tokens from <c>Accents/MenuResources.axaml</c>. Historically these were two
+/// separate files, which silently drifted apart twice (a 1px item offset from
+/// mismatched popup padding, and a 816-vs-456 popup max width). These tests make
+/// that class of regression impossible to merge:
+///
+///   1. Every DevExMenu* token resolves to the SAME value under the full theme
+///      and under "host theme + menu pack".
+///   2. Menu tokens are immune to host-theme overrides — a host that redefines
+///      the generic Fluent keys we used to alias must not move our menus.
+/// </summary>
+[Collection("VisualTests")]
+public class MenuPackContractTests
+{
+    private const string PackUri = "avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml";
+
+    /// <summary>
+    /// Every resource key the menu templates depend on. Keys here are owned by the
+    /// pack and must be prefixed; anything intentionally inherited from the host
+    /// (currently only FluentMenuScrollViewer) is deliberately excluded.
+    ///
+    /// Typography is owned, not inherited: menus in a branded section must match the
+    /// platform-themed menus elsewhere in the app, and pinning it also keeps menu
+    /// geometry identical across hosts.
+    /// </summary>
+    private static readonly string[] MenuTokens =
+    {
+        "DevExMenuFontFamily",
+        "DevExMenuFontSize",
+        "DevExMenuFontWeight",
+        "DevExMenuBackgroundBrush",
+        "DevExMenuPopupBorderBrush",
+        "DevExMenuItemBackground",
+        "DevExMenuItemForeground",
+        "DevExMenuItemKeyboardAcceleratorTextForeground",
+        "DevExMenuItemForegroundPointerOver",
+        "DevExMenuItemKeyboardAcceleratorTextForegroundPointerOver",
+        "DevExMenuItemBackgroundPressed",
+        "DevExMenuItemForegroundPressed",
+        "DevExMenuItemKeyboardAcceleratorTextForegroundPressed",
+        "DevExMenuItemBackgroundDisabled",
+        "DevExMenuItemForegroundDisabled",
+        "DevExMenuItemKeyboardAcceleratorTextForegroundDisabled",
+        "DevExMenuItemPointerOverBackground",
+        "DevExMenuSeparatorBrush",
+        "DevExMenuItemChevronBrush",
+        "DevExMenuSvgItemDefaultCss",
+        "DevExMenuSvgItemDisabledCss",
+        "DevExMenuBarHeight",
+        "DevExMenuPopupBorderThickness",
+        "DevExMenuPopupPadding",
+        "DevExMenuFlyoutPresenterPadding",
+        "DevExMenuTopLevelPopupPadding",
+        "DevExMenuPopupMargin",
+        "DevExMenuPopupCornerRadius",
+        "DevExMenuTopLevelPopupCornerRadius",
+        "DevExMenuPopupShadow",
+        "DevExMenuPopupMaxWidth",
+        "DevExMenuPopupMinHeight",
+        "DevExMenuHorizontalFlyoutMinWidth",
+        "DevExMenuSubMenuPopupHorizontalOffset",
+        "DevExMenuSeparatorMargin",
+        "DevExMenuSeparatorHeight",
+        "DevExMenuSeparatorIconColumnWidth",
+        "DevExMenuBarSeparatorMargin",
+        "DevExMenuBarSeparatorWidth",
+        "DevExMenuNestedItemMinHeight",
+        "DevExMenuNestedItemPadding",
+        "DevExMenuIconPresenterMargin",
+        "DevExMenuInputGestureTextMargin",
+        "DevExMenuItemChevronPathData",
+        "DevExMenuItemCheckMarkPathData",
+    };
+
+    private static Window ShowWithFullTheme(ThemeVariant variant)
+    {
+        var theme = new DevolutionsDevExpressTheme();
+        theme.BeginInit();
+        theme.EndInit();
+
+        var window = new Window { RequestedThemeVariant = variant };
+        window.Styles.Add(theme);
+        window.Show();
+        return window;
+    }
+
+    private static Window ShowWithPackOverHostTheme(ThemeVariant variant, Action<Window>? applyHostOverrides = null)
+    {
+        var window = new Window { RequestedThemeVariant = variant };
+        window.Styles.Add(new AvaloniaFluentTheme());
+        applyHostOverrides?.Invoke(window);
+
+        // Resolved exactly the way an external consumer would: by avares URI only,
+        // with no reference to the theme object itself.
+        var uri = new Uri(PackUri);
+        window.Styles.Add(new StyleInclude(uri) { Source = uri });
+
+        window.Show();
+        return window;
+    }
+
+    private static Dictionary<string, string> Resolve(Window window, ThemeVariant variant)
+    {
+        var result = new Dictionary<string, string>();
+        foreach (string key in MenuTokens)
+        {
+            Assert.True(window.TryFindResource(key, variant, out object? value),
+                $"Menu token '{key}' did not resolve ({variant}). Every token the menu templates " +
+                "consume must be defined in Accents/MenuResources.axaml.");
+            result[key] = value?.ToString() ?? "<null>";
+        }
+
+        return result;
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Pack_and_full_theme_resolve_identical_menu_tokens(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+
+        Window fullWindow = ShowWithFullTheme(variant);
+        Window packWindow = ShowWithPackOverHostTheme(variant);
+
+        try
+        {
+            Dictionary<string, string> full = Resolve(fullWindow, variant);
+            Dictionary<string, string> pack = Resolve(packWindow, variant);
+
+            var drift = MenuTokens
+                .Where(key => full[key] != pack[key])
+                .Select(key => $"{key}: fullTheme='{full[key]}' packOverFluent='{pack[key]}'")
+                .ToList();
+
+            Assert.True(drift.Count == 0,
+                "Menu pack has drifted from the full DevExpress theme:\n  " + string.Join("\n  ", drift));
+        }
+        finally
+        {
+            fullWindow.Close();
+            packWindow.Close();
+        }
+    }
+
+    /// <summary>
+    /// The menu pack is layered over a host theme we do not control. A host that
+    /// defines the generic Fluent/theme keys the menus used to alias must not be
+    /// able to move menu visuals. This reproduces the MacOS regression where a
+    /// host-defined zero border thickness erased the popup outline.
+    /// </summary>
+    [AvaloniaFact]
+    public void Host_theme_overrides_do_not_leak_into_menu_tokens()
+    {
+        ThemeVariant variant = ThemeVariant.Light;
+
+        Window baseline = ShowWithPackOverHostTheme(variant);
+        Window hostile = ShowWithPackOverHostTheme(variant, window =>
+        {
+            // Values a foreign host theme might plausibly define.
+            window.Resources["MenuFlyoutPresenterBorderThemeThickness"] = new Thickness(0);
+            window.Resources["ComboBoxDropdownBorderPadding"] = new Thickness(12);
+            window.Resources["MenuFlyoutPresenterThemePadding"] = new Thickness(12);
+            window.Resources["FlyoutThemeMaxWidth"] = 1234d;
+            window.Resources["MenuFlyoutThemeMinHeight"] = 99d;
+            window.Resources["HorizontalMenuFlyoutThemeMinWidth"] = 99d;
+            window.Resources["ContextMenuBorderPadding"] = new Thickness(9);
+            window.Resources["ContextMenuCornerRadius"] = new CornerRadius(20);
+            window.Resources["OverlayCornerRadius"] = new CornerRadius(20);
+            window.Resources["MenuFlyoutSeparatorThemeHeight"] = 7d;
+        });
+
+        try
+        {
+            Dictionary<string, string> expected = Resolve(baseline, variant);
+            Dictionary<string, string> actual = Resolve(hostile, variant);
+
+            var leaks = MenuTokens
+                .Where(key => expected[key] != actual[key])
+                .Select(key => $"{key}: expected='{expected[key]}' underHostileHost='{actual[key]}'")
+                .ToList();
+
+            Assert.True(leaks.Count == 0,
+                "Host theme resources leaked into menu tokens. Tokens in MenuResources.axaml must be " +
+                "pinned literals, never StaticResource aliases to host-owned keys:\n  " + string.Join("\n  ", leaks));
+        }
+        finally
+        {
+            baseline.Close();
+            hostile.Close();
+        }
+    }
+
+    /// <summary>
+    /// The pack is consumed page-scoped in the SampleApp (a StyleInclude inside
+    /// UserControl.Styles) while a full theme is loaded application-wide. Merging a
+    /// resource dictionary into a scope that already contains the same key throws at
+    /// construction time ("An item with the same key has already been added"), which
+    /// is exactly how this pack broke repeatedly while the token contract was being
+    /// built. Layering the pack over each supported host theme reproduces that path.
+    /// </summary>
+    [AvaloniaTheory]
+    [MemberData(nameof(PackPageCases))]
+    public void MenuPack_demo_pages_layer_over_host_theme_without_collisions(Type pageType, string hostThemeName)
+    {
+        // Themes must be applied application-wide before any UI is created, exactly
+        // as VisualRegressionTests does.
+        App.CurrentTheme = null;
+        App.SetTheme(hostThemeName switch
+        {
+            "MacClassic" => new MacOsClassicTheme(),
+            "LiquidGlass" => new MacOsLiquidGlassTheme(),
+            "Linux" => new LinuxYaruTheme(),
+            "DevExpress" => new DevExpressTheme(),
+            _ => throw new ArgumentOutOfRangeException(nameof(hostThemeName), hostThemeName, "Unknown theme"),
+        });
+
+        var content = (Control)Activator.CreateInstance(pageType)!;
+        var window = new Window { Width = 1200, Height = 920, Content = content };
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            if (Application.Current != null)
+            {
+                Application.Current.RequestedThemeVariant = ThemeVariant.Dark;
+            }
+
+            Dispatcher.UIThread.RunJobs();
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// The pack must not restyle controls OUTSIDE menus.
+    ///
+    /// Regression guard: the pack used to merge Separator.axaml, which is keyed
+    /// `{x:Type Separator}` — an implicit ControlTheme. Merging it silently made
+    /// DevExpress's separator the default for the whole consuming app, and because
+    /// its values (SeparatorBrush / SeparatorMargin) ship only with the full theme,
+    /// a plain separator over a Fluent host rendered opaque black and full-bleed
+    /// instead of the host's subtle inset line.
+    ///
+    /// This is a differential test: it needs no baseline image, only the assertion
+    /// that adding the pack changes nothing outside menus.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Pack_does_not_restyle_controls_outside_menus(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+
+        static string DescribePlainSeparator(Window window)
+        {
+            var separator = new Separator();
+            var panel = new StackPanel { Width = 200 };
+            panel.Children.Add(new TextBlock { Text = "above" });
+            panel.Children.Add(separator);
+            panel.Children.Add(new TextBlock { Text = "below" });
+            window.Content = panel;
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            string description =
+                $"background={separator.Background?.ToString() ?? "<null>"} " +
+                $"margin={separator.Margin} height={separator.Height} bounds={separator.Bounds}";
+
+            window.Close();
+            return description;
+        }
+
+        var hostOnly = new Window { RequestedThemeVariant = variant, Width = 400, Height = 300 };
+        hostOnly.Styles.Add(new AvaloniaFluentTheme());
+        string withoutPack = DescribePlainSeparator(hostOnly);
+
+        var hostPlusPack = new Window { RequestedThemeVariant = variant, Width = 400, Height = 300 };
+        hostPlusPack.Styles.Add(new AvaloniaFluentTheme());
+        var uri = new Uri(PackUri);
+        hostPlusPack.Styles.Add(new StyleInclude(uri) { Source = uri });
+        string withPack = DescribePlainSeparator(hostPlusPack);
+
+        Assert.True(withoutPack == withPack,
+            "The menu pack changed a Separator that is not inside any menu. The pack must only " +
+            "style menu content.\n" +
+            $"  host only        : {withoutPack}\n" +
+            $"  host + menu pack : {withPack}");
+    }
+
+    public static IEnumerable<object[]> PackPageCases()
+    {
+        Type[] pages =
+        {
+            typeof(MenuPackAbout),
+            typeof(MenuPackMenuDemo),
+            typeof(MenuPackContextMenuDemo),
+            typeof(MenuPackMenuFlyoutDemo),
+        };
+
+        // DevExpress is the highest collision risk (pack merged alongside the full
+        // theme that already defines every DevExMenu* key). The others are the
+        // "foreign host" cases that previously leaked into menu visuals.
+        string[] hostThemes = { "DevExpress", "MacClassic", "LiquidGlass", "Linux" };
+
+        foreach (Type page in pages)
+        {
+            foreach (string host in hostThemes)
+            {
+                yield return [page, host];
+            }
+        }
+    }
+}


### PR DESCRIPTION

## Summary

This PR adds an externally consumable **DevExpress Menu Pack** so apps can import menu styling where they might not want to use the full `DevolutionsDevExpressTheme` (e.g. areas with brand-based styling) to provide consistent Menu chrome.

### What’s included

- Added new menu-pack entrypoint:
  - `avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml`
- Menu pack composes existing source-of-truth resources (no template duplication):
  - `ContextMenu`, `MenuFlyoutPresenter`, `Menu`, `MenuItem`, `Separator`
  - menu helper styles (`Menu.styles.axaml`, `Separator.styles.axaml`)
- Extracted reusable SVG menu helper styles into:
  - `Controls/MenuSvg.styles.axaml`
  - Included from `GlobalStyles.axaml` (behavior preserved for full-theme consumers)
- Updated DevExpress README with:
  - full-theme usage
  - menu-pack-only usage
  - prerequisites/caveats
  - exact `avares://` URI and snippet
- Added dedicated SampleApp **DevExpress Menu Pack** section with:
  - `About` page
  - MenuPack versions of Menu / ContextMenu / MenuFlyout pages
  - MenuPack pages embed the original demo pages to stay in sync for visual comparison

## Behavior notes

- Full-theme behavior remains intact (`DevolutionsDevExpressTheme` / `GlobalStyles` paths preserved).
- Menu pack usage is intended with Fluent loaded first (documented prerequisite).

## Validation

- `dotnet build` passed
- `dotnet test` passed (visual tests)
- `dotnet build samples/SampleApp/SampleApp.csproj` passed