### PR TITLE
Merge menu icon and check/radio column (single-icon-slot)

### DIFF
--- a/samples/SampleApp/DemoPages/MenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuDemo.axaml
@@ -231,32 +231,107 @@
                 • <TextBlock Classes="code" Text="ContentPresenter#PART_HeaderPresenter" /> of the top-level menu items has a class
                 <TextBlock Classes="code" Text="TopLevelMenuItem" /> attached that allows easier styling without affecting sub-menu items. E.g. setting MaxWidth to force long names to wrap
               </TextBlock>
-              <TextBlock Classes="section-title">Open Menu example for Visual Regression testing</TextBlock>
-              <Border HorizontalAlignment="Left">
-                <MenuFlyoutPresenter>
-                  <MenuItem Header="Open session" InputGesture="&#x2318;+O" />
-                  <MenuItem Header="Open with parameters" IsSubMenuOpen="True">
-                    <MenuItem Header="Open (embedded/tabbed)" />
-                    <MenuItem Header="Open embedded SFTP connection" />
-                    <MenuItem Header="Open embedded SCP connection" InputGesture="&#x2318;+S" IsEnabled="False" />
-                    <MenuItem Header="-" />
-                    <MenuItem Header="Open (select credentials)..." />
-                  </MenuItem>
-                  <MenuItem Header="View password" />
-                  <MenuItem Header="Copy name" />
-                  <MenuItem Header="Copy password" />
-                  <Separator />
-                  <MenuItem Header="Focus session" />
-                  <MenuItem Header="Edit" IsEnabled="False">
-                    <MenuItem Header="Dummy1" />
-                    <MenuItem Header="Dummy2" />
-                  </MenuItem>
-                  <MenuItem Header="Toggle Options" IsSubMenuOpen="True">
-                    <MenuItem Header="Option 1" ToggleType="CheckBox" />
-                    <MenuItem Header="Option 2" ToggleType="CheckBox" IsChecked="True" />
-                  </MenuItem>
-                </MenuFlyoutPresenter>
-              </Border>
+              <StackPanel Orientation="Horizontal" Spacing="40" HorizontalAlignment="Left">
+                <StackPanel Spacing="20">
+                  <TextBlock Classes="section-title">Open Menu example for Visual Regression testing</TextBlock>
+                  <Border HorizontalAlignment="Left">
+                    <MenuFlyoutPresenter>
+                      <MenuItem Header="Open session" InputGesture="&#x2318;+O" />
+                      <MenuItem Header="Open with parameters" IsSubMenuOpen="True">
+                        <MenuItem Header="Open (embedded/tabbed)" />
+                        <MenuItem Header="Open embedded SFTP connection" />
+                        <MenuItem Header="Open embedded SCP connection" InputGesture="&#x2318;+S" IsEnabled="False" />
+                        <MenuItem Header="-" />
+                        <MenuItem Header="Open (select credentials)..." />
+                      </MenuItem>
+                      <MenuItem Header="View password" />
+                      <MenuItem Header="Copy name" />
+                      <MenuItem Header="Copy password" />
+                      <Separator />
+                      <MenuItem Header="Focus session" />
+                      <MenuItem Header="Edit" IsEnabled="False">
+                        <MenuItem Header="Dummy1" />
+                        <MenuItem Header="Dummy2" />
+                      </MenuItem>
+                      <MenuItem Header="Toggle Options" IsSubMenuOpen="True">
+                        <MenuItem Header="Option 1" ToggleType="CheckBox" />
+                        <MenuItem Header="Option 2" ToggleType="CheckBox" IsChecked="True" />
+                      </MenuItem>
+                    </MenuFlyoutPresenter>
+                  </Border>
+                </StackPanel>
+
+                <StackPanel Spacing="10" MaxWidth="560">
+                  <TextBlock Classes="section-title">Icon &amp; check/radio column merging (single-icon-slot)</TextBlock>
+                  <TextBlock FontSize="12" LineSpacing="2" TextWrapping="Wrap" HorizontalAlignment="Left">
+                    Add the <TextBlock Classes="code" Text="single-icon-slot" /> class to a Menu, ContextMenu,
+                    MenuFlyoutPresenter or parent MenuItem so the check/radio indicator shares the same leading
+                    column as item icons, instead of reserving a separate column for each. Flip the switch to
+                    compare — the right-hand menu always stays in the default (separate-column) mode.
+                  </TextBlock>
+                  <ToggleSwitch x:Name="SingleIconSlotToggle" IsChecked="True"
+                                OnContent="single-icon-slot: ON" OffContent="single-icon-slot: OFF"
+                                HorizontalAlignment="Left" />
+                  <StackPanel Orientation="Horizontal" Spacing="24" HorizontalAlignment="Left">
+                    <StackPanel Spacing="6">
+                      <TextBlock FontSize="12" Text="Bound to toggle (ON by default)" />
+                      <Border HorizontalAlignment="Left">
+                        <MenuFlyoutPresenter Classes.single-icon-slot="{Binding #SingleIconSlotToggle.IsChecked}">
+                          <MenuItem Header="Normal item" />
+                          <MenuItem Header="Normal item with icon">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/Folder.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                          <Separator />
+                          <MenuItem Header="Checkbox off" ToggleType="CheckBox" />
+                          <MenuItem Header="Checkbox on" ToggleType="CheckBox" IsChecked="True" />
+                          <MenuItem Header="Checkbox on, with icon" ToggleType="CheckBox" IsChecked="True">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/User.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                          <Separator />
+                          <MenuItem Header="Radio on" ToggleType="Radio" IsChecked="True" />
+                          <MenuItem Header="Radio off, with icon" ToggleType="Radio">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/Properties.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                        </MenuFlyoutPresenter>
+                      </Border>
+                    </StackPanel>
+                    <StackPanel Spacing="6">
+                      <TextBlock FontSize="12" Text="Default (always separate columns)" />
+                      <Border HorizontalAlignment="Left">
+                        <MenuFlyoutPresenter>
+                          <MenuItem Header="Normal item" />
+                          <MenuItem Header="Normal item with icon">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/Folder.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                          <Separator />
+                          <MenuItem Header="Checkbox off" ToggleType="CheckBox" />
+                          <MenuItem Header="Checkbox on" ToggleType="CheckBox" IsChecked="True" />
+                          <MenuItem Header="Checkbox on, with icon" ToggleType="CheckBox" IsChecked="True">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/User.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                          <Separator />
+                          <MenuItem Header="Radio on" ToggleType="Radio" IsChecked="True" />
+                          <MenuItem Header="Radio off, with icon" ToggleType="Radio">
+                            <MenuItem.Icon>
+                              <Svg Path="/Assets/Properties.svg" />
+                            </MenuItem.Icon>
+                          </MenuItem>
+                        </MenuFlyoutPresenter>
+                      </Border>
+                    </StackPanel>
+                  </StackPanel>
+                </StackPanel>
+              </StackPanel>
             </StackPanel>
           </Border>
         </DockPanel>

--- a/src/Devolutions.AvaloniaControls/Behaviors/MenuSharedSizeRefreshBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/MenuSharedSizeRefreshBehavior.cs
@@ -1,0 +1,201 @@
+namespace Devolutions.AvaloniaControls.Behaviors;
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+/// <summary>
+/// Works around an Avalonia limitation where a <see cref="Grid"/> shared-size group never
+/// shrinks once it has measured a width.
+///
+/// <para>
+/// Menu item templates align their leading toggle (check/radio) and icon columns across
+/// sibling items using <c>Grid.IsSharedSizeScope</c> + <c>SharedSizeGroup</c>. When the set of
+/// occupied leading columns shrinks — the last checked item is unchecked, the last item with an
+/// icon is removed, or the <c>single-icon-slot</c> class is toggled off/on — the vacated column
+/// keeps its previously measured width, leaving a phantom empty column that pushes the header
+/// text across.
+/// </para>
+///
+/// <para>
+/// This behavior is attached to every <see cref="MenuItem"/> (via the control theme). All items
+/// that live under the same shared-size scope share a single <see cref="ScopeState"/>, which
+/// watches the scope for layout changes and, whenever the "occupied columns" signature changes,
+/// rebuilds the scope by toggling <c>Grid.IsSharedSizeScope</c> off and back on. Rebuilding forces
+/// a fresh measurement pass so columns that are no longer needed collapse to zero.
+/// </para>
+/// </summary>
+public static class MenuSharedSizeRefreshBehavior
+{
+    private const string SingleIconSlotClass = "single-icon-slot";
+
+    public static readonly AttachedProperty<bool> EnableProperty =
+        AvaloniaProperty.RegisterAttached<MenuItem, bool>("Enable", typeof(MenuSharedSizeRefreshBehavior));
+
+    // One state per shared-size scope owner, shared by every menu item under it.
+    private static readonly ConditionalWeakTable<Control, ScopeState> states = new();
+
+    static MenuSharedSizeRefreshBehavior()
+    {
+        EnableProperty.Changed.Subscribe(static args =>
+        {
+            if (args.Sender is not MenuItem menuItem)
+            {
+                return;
+            }
+
+            if (args.NewValue.GetValueOrDefault<bool>())
+            {
+                menuItem.AttachedToVisualTree += OnItemAttached;
+                if (menuItem.GetVisualParent() is not null)
+                {
+                    Register(menuItem);
+                }
+            }
+            else
+            {
+                menuItem.AttachedToVisualTree -= OnItemAttached;
+            }
+        });
+    }
+
+    public static void SetEnable(MenuItem element, bool value) => element.SetValue(EnableProperty, value);
+
+    public static bool GetEnable(MenuItem element) => element.GetValue(EnableProperty);
+
+    private static void OnItemAttached(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (sender is MenuItem menuItem)
+        {
+            Register(menuItem);
+        }
+    }
+
+    private static void Register(MenuItem menuItem)
+    {
+        Control? scopeOwner = FindScopeOwner(menuItem);
+        if (scopeOwner is null)
+        {
+            return;
+        }
+
+        if (!states.TryGetValue(scopeOwner, out _))
+        {
+            states.Add(scopeOwner, new ScopeState(scopeOwner));
+        }
+    }
+
+    private static Control? FindScopeOwner(Visual from)
+    {
+        foreach (Visual ancestor in from.GetVisualAncestors())
+        {
+            if (ancestor is Control control && Grid.GetIsSharedSizeScope(control))
+            {
+                return control;
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class ScopeState
+    {
+        private readonly Control scopeOwner;
+        private string lastSignature = string.Empty;
+        private DispatcherOperation? scheduled;
+        private bool rescoping;
+
+        public ScopeState(Control scopeOwner)
+        {
+            this.scopeOwner = scopeOwner;
+            this.scopeOwner.LayoutUpdated += this.OnLayoutUpdated;
+            this.scopeOwner.DetachedFromVisualTree += this.OnDetached;
+        }
+
+        private void OnDetached(object? sender, VisualTreeAttachmentEventArgs e)
+        {
+            this.scopeOwner.LayoutUpdated -= this.OnLayoutUpdated;
+            this.scopeOwner.DetachedFromVisualTree -= this.OnDetached;
+            this.scheduled?.Abort();
+            states.Remove(this.scopeOwner);
+        }
+
+        private void OnLayoutUpdated(object? sender, EventArgs e)
+        {
+            if (this.rescoping)
+            {
+                return;
+            }
+
+            string signature = this.ComputeSignature();
+            if (signature == this.lastSignature)
+            {
+                return;
+            }
+
+            this.lastSignature = signature;
+            this.ScheduleRescope();
+        }
+
+        private string ComputeSignature()
+        {
+            var builder = new StringBuilder();
+
+            // Whether the single-icon-slot mode is active for this scope (class typically sits on
+            // the menu container that is templated with this shared-size scope, or an ancestor).
+            bool singleIconSlot = this.scopeOwner.GetVisualAncestors()
+                .Prepend(this.scopeOwner)
+                .Any(v => v is StyledElement styled and (ContextMenu or Menu or MenuFlyoutPresenter or MenuItem) 
+                          && styled.Classes.Contains(SingleIconSlotClass));
+            builder.Append(singleIconSlot ? 'S' : '-').Append('|');
+
+            foreach (MenuItem item in this.scopeOwner.GetVisualDescendants().OfType<MenuItem>())
+            {
+                // Only consider items that belong directly to this scope, not items nested in a
+                // deeper scope (their own submenu popup).
+                if (FindScopeOwner(item) != this.scopeOwner)
+                {
+                    continue;
+                }
+
+                builder.Append(item.Icon is not null ? 'I' : '-');
+                builder.Append(item.IsChecked ? 'C' : '-');
+            }
+
+            return builder.ToString();
+        }
+
+        private void ScheduleRescope()
+        {
+            this.scheduled?.Abort();
+            this.scheduled = Dispatcher.UIThread.InvokeAsync(this.Rescope, DispatcherPriority.Render);
+        }
+
+        private void Rescope()
+        {
+            this.scheduled = null;
+
+            if (!Grid.GetIsSharedSizeScope(this.scopeOwner))
+            {
+                return;
+            }
+
+            // Drop and recreate the shared-size scope so every column is measured from scratch;
+            // columns with no content this pass collapse instead of keeping a stale width.
+            this.rescoping = true;
+            Grid.SetIsSharedSizeScope(this.scopeOwner, false);
+            Dispatcher.UIThread.Post(
+                () =>
+                {
+                    Grid.SetIsSharedSizeScope(this.scopeOwner, true);
+                    this.rescoping = false;
+                },
+                DispatcherPriority.Background);
+        }
+    }
+}

--- a/src/Devolutions.AvaloniaControls/Behaviors/MenuSharedSizeRefreshBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/MenuSharedSizeRefreshBehavior.cs
@@ -1,9 +1,10 @@
 namespace Devolutions.AvaloniaControls.Behaviors;
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
@@ -17,17 +18,19 @@ using Avalonia.VisualTree;
 /// Menu item templates align their leading toggle (check/radio) and icon columns across
 /// sibling items using <c>Grid.IsSharedSizeScope</c> + <c>SharedSizeGroup</c>. When the set of
 /// occupied leading columns shrinks — the last checked item is unchecked, the last item with an
-/// icon is removed, or the <c>single-icon-slot</c> class is toggled off/on — the vacated column
-/// keeps its previously measured width, leaving a phantom empty column that pushes the header
-/// text across.
+/// icon is removed or hidden, or the <c>single-icon-slot</c> class is toggled off/on — the vacated
+/// column keeps its previously measured width, leaving a phantom empty column that pushes the
+/// header text across.
 /// </para>
 ///
 /// <para>
 /// This behavior is attached to every <see cref="MenuItem"/> (via the control theme). All items
 /// that live under the same shared-size scope share a single <see cref="ScopeState"/>, which
-/// watches the scope for layout changes and, whenever the "occupied columns" signature changes,
-/// rebuilds the scope by toggling <c>Grid.IsSharedSizeScope</c> off and back on. Rebuilding forces
-/// a fresh measurement pass so columns that are no longer needed collapse to zero.
+/// observes the inputs that decide the occupied leading columns — each item's <c>Icon</c>,
+/// <c>IsChecked</c> and <c>IsVisible</c>, the item collection, and the owner's <c>single-icon-slot</c>
+/// class — and, whenever that "needed columns" signature changes, rebuilds the scope by toggling
+/// <c>Grid.IsSharedSizeScope</c> off and back on. Rebuilding forces a fresh measurement pass so
+/// columns that are no longer needed collapse to zero.
 /// </para>
 /// </summary>
 public static class MenuSharedSizeRefreshBehavior
@@ -103,71 +106,150 @@ public static class MenuSharedSizeRefreshBehavior
         return null;
     }
 
+    /// <summary>The leading columns/modes a shared-size scope currently needs to reserve.</summary>
+    [Flags]
+    private enum LeadingColumns
+    {
+        None = 0,
+        SingleIconSlot = 1 << 0,
+        Icon = 1 << 1,
+        Check = 1 << 2,
+    }
+
     private sealed class ScopeState
     {
         private readonly Control scopeOwner;
-        private string lastSignature = string.Empty;
+        private readonly ItemsControl? owner;
+        private readonly Dictionary<MenuItem, IDisposable[]> itemSubscriptions = new();
+        private LeadingColumns? lastColumns;
         private DispatcherOperation? scheduled;
         private bool rescoping;
+        private bool disposed;
 
         public ScopeState(Control scopeOwner)
         {
             this.scopeOwner = scopeOwner;
-            this.scopeOwner.LayoutUpdated += this.OnLayoutUpdated;
-            this.scopeOwner.DetachedFromVisualTree += this.OnDetached;
+            this.owner = scopeOwner.TemplatedParent as ItemsControl ?? scopeOwner.FindAncestorOfType<ItemsControl>();
+
+            this.scopeOwner.DetachedFromVisualTree += this.OnScopeOwnerDetached;
+
+            if (this.owner is not null)
+            {
+                this.owner.ContainerPrepared += this.OnContainerPrepared;
+                this.owner.ContainerClearing += this.OnContainerClearing;
+                ((INotifyCollectionChanged)this.owner.Classes).CollectionChanged += this.OnClassesChanged;
+
+                foreach (Control container in this.owner.GetRealizedContainers())
+                {
+                    this.Observe(container);
+                }
+            }
+
+            this.Evaluate();
         }
 
-        private void OnDetached(object? sender, VisualTreeAttachmentEventArgs e)
+        private void OnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
         {
-            this.scopeOwner.LayoutUpdated -= this.OnLayoutUpdated;
-            this.scopeOwner.DetachedFromVisualTree -= this.OnDetached;
-            this.scheduled?.Abort();
-            states.Remove(this.scopeOwner);
+            this.Observe(e.Container);
+            this.Evaluate();
         }
 
-        private void OnLayoutUpdated(object? sender, EventArgs e)
+        private void OnContainerClearing(object? sender, ContainerClearingEventArgs e)
         {
-            if (this.rescoping)
+            this.Unobserve(e.Container);
+            this.Evaluate();
+        }
+
+        private void OnClassesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            // The Classes collection also churns for pseudo-classes (:pointerover, :selected, ...);
+            // only react when the single-icon-slot class itself is added or removed.
+            if (e.Action == NotifyCollectionChangedAction.Reset
+                || e.NewItems?.OfType<string>().Contains(SingleIconSlotClass) == true
+                || e.OldItems?.OfType<string>().Contains(SingleIconSlotClass) == true)
+            {
+                this.Evaluate();
+            }
+        }
+
+        private void Observe(Control container)
+        {
+            if (container is not MenuItem menuItem || this.itemSubscriptions.ContainsKey(menuItem))
             {
                 return;
             }
 
-            string signature = this.ComputeSignature();
-            if (signature == this.lastSignature)
+            // Anything that changes which leading columns an item occupies.
+            this.itemSubscriptions[menuItem] = new[]
+            {
+                menuItem.GetObservable(Visual.IsVisibleProperty).Subscribe(_ => this.Evaluate()),
+                menuItem.GetObservable(MenuItem.IconProperty).Subscribe(_ => this.Evaluate()),
+                menuItem.GetObservable(MenuItem.IsCheckedProperty).Subscribe(_ => this.Evaluate()),
+            };
+        }
+
+        private void Unobserve(Control container)
+        {
+            if (container is MenuItem menuItem && this.itemSubscriptions.Remove(menuItem, out IDisposable[]? subscriptions))
+            {
+                foreach (IDisposable subscription in subscriptions)
+                {
+                    subscription.Dispose();
+                }
+            }
+        }
+
+        private void Evaluate()
+        {
+            if (this.disposed || this.rescoping)
             {
                 return;
             }
 
-            this.lastSignature = signature;
+            LeadingColumns columns = this.ComputeColumns();
+            if (columns == this.lastColumns)
+            {
+                return;
+            }
+
+            this.lastColumns = columns;
             this.ScheduleRescope();
         }
 
-        private string ComputeSignature()
+        private LeadingColumns ComputeColumns()
         {
-            var builder = new StringBuilder();
+            LeadingColumns columns = LeadingColumns.None;
 
             // Whether the single-icon-slot mode is active for this scope (class typically sits on
-            // the menu container that is templated with this shared-size scope, or an ancestor).
+            // the menu container that owns these items, or an ancestor menu).
             bool singleIconSlot = this.scopeOwner.GetVisualAncestors()
                 .Prepend(this.scopeOwner)
-                .Any(v => v is StyledElement styled and (ContextMenu or Menu or MenuFlyoutPresenter or MenuItem) 
+                .Any(v => v is StyledElement styled and (ContextMenu or Menu or MenuFlyoutPresenter or MenuItem)
                           && styled.Classes.Contains(SingleIconSlotClass));
-            builder.Append(singleIconSlot ? 'S' : '-').Append('|');
-
-            foreach (MenuItem item in this.scopeOwner.GetVisualDescendants().OfType<MenuItem>())
+            if (singleIconSlot)
             {
-                // Only consider items that belong directly to this scope, not items nested in a
-                // deeper scope (their own submenu popup).
-                if (FindScopeOwner(item) != this.scopeOwner)
+                columns |= LeadingColumns.SingleIconSlot;
+            }
+
+            foreach (MenuItem item in this.itemSubscriptions.Keys)
+            {
+                if (!item.IsVisible)
                 {
                     continue;
                 }
 
-                builder.Append(item.Icon is not null ? 'I' : '-');
-                builder.Append(item.IsChecked ? 'C' : '-');
+                if (item.Icon is not null)
+                {
+                    columns |= LeadingColumns.Icon;
+                }
+
+                if (item.IsChecked)
+                {
+                    columns |= LeadingColumns.Check;
+                }
             }
 
-            return builder.ToString();
+            return columns;
         }
 
         private void ScheduleRescope()
@@ -180,7 +262,7 @@ public static class MenuSharedSizeRefreshBehavior
         {
             this.scheduled = null;
 
-            if (!Grid.GetIsSharedSizeScope(this.scopeOwner))
+            if (this.disposed || !Grid.GetIsSharedSizeScope(this.scopeOwner))
             {
                 return;
             }
@@ -192,10 +274,52 @@ public static class MenuSharedSizeRefreshBehavior
             Dispatcher.UIThread.Post(
                 () =>
                 {
-                    Grid.SetIsSharedSizeScope(this.scopeOwner, true);
+                    if (!this.disposed)
+                    {
+                        Grid.SetIsSharedSizeScope(this.scopeOwner, true);
+                    }
+
                     this.rescoping = false;
                 },
                 DispatcherPriority.Background);
+        }
+
+        private void OnScopeOwnerDetached(object? sender, VisualTreeAttachmentEventArgs e) => this.Dispose();
+
+        private void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.disposed = true;
+            this.scheduled?.Abort();
+            this.scopeOwner.DetachedFromVisualTree -= this.OnScopeOwnerDetached;
+
+            if (this.owner is not null)
+            {
+                this.owner.ContainerPrepared -= this.OnContainerPrepared;
+                this.owner.ContainerClearing -= this.OnContainerClearing;
+                ((INotifyCollectionChanged)this.owner.Classes).CollectionChanged -= this.OnClassesChanged;
+            }
+
+            foreach (IDisposable[] subscriptions in this.itemSubscriptions.Values)
+            {
+                foreach (IDisposable subscription in subscriptions)
+                {
+                    subscription.Dispose();
+                }
+            }
+
+            this.itemSubscriptions.Clear();
+
+            // Register keeps a single state per scope owner, so this is the only entry; drop it only
+            // if it is still ours (never clobber a newer state registered after a detach/re-attach).
+            if (states.TryGetValue(this.scopeOwner, out ScopeState? current) && current == this)
+            {
+                states.Remove(this.scopeOwner);
+            }
         }
     }
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
@@ -2,7 +2,8 @@
 
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:conv="using:Avalonia.Controls.Converters">
+                    xmlns:conv="using:Avalonia.Controls.Converters"
+                    xmlns:behaviors="clr-namespace:Devolutions.AvaloniaControls.Behaviors;assembly=Devolutions.AvaloniaControls">
 
   <Design.PreviewWith>
     <Border Padding="20" Width="320">
@@ -67,7 +68,9 @@
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <!-- Block inheritance of LineHeight from parent controls -->
     <Setter Property="TextBlock.LineHeight" Value="NaN" />
-    
+    <!-- Collapse vacated leading columns when icons/checks change (see MenuSharedSizeRefreshBehavior) -->
+    <Setter Property="behaviors:MenuSharedSizeRefreshBehavior.Enable" Value="True" />
+
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Separator.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Separator.styles.axaml
@@ -20,12 +20,14 @@
 
     <Style Selector="ContextMenu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
                      Menu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                     MenuFlyoutPresenter.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
                      MenuItem.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter">
         <Setter Property="Grid.Column" Value="0" />
     </Style>
 
     <Style Selector="ContextMenu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
                      Menu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                     MenuFlyoutPresenter.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
                      MenuItem.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter">
         <Setter Property="IsVisible" Value="False" />
     </Style>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuItem.axaml
@@ -5,6 +5,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:conv="using:Avalonia.Controls.Converters"
+                    xmlns:behaviors="clr-namespace:Devolutions.AvaloniaControls.Behaviors;assembly=Devolutions.AvaloniaControls"
                     x:ClassModifier="internal">
   <Design.PreviewWith>
     <Border Padding="20" Width="320">
@@ -67,6 +68,8 @@
     <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
     <Setter Property="Padding" Value="{DynamicResource MenuFlyoutItemThemePadding}" />
     <Setter Property="MinHeight" Value="{DynamicResource MenuFlyoutItemMinHeight}" />
+    <!-- Collapse vacated leading columns when icons/checks change (see MenuSharedSizeRefreshBehavior) -->
+    <Setter Property="behaviors:MenuSharedSizeRefreshBehavior.Enable" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>
@@ -89,18 +92,25 @@
                                   SharedSizeGroup="MenuItemChevron" />
               </Grid.ColumnDefinitions>
 
+              <!--
+                Toggle (check/radio) and icon live in separate columns by default so that toggling a
+                check does not resize a shared column and shift sibling icons. The leading gutter is
+                preserved via the toggle column's MinWidth. Opt into "single-icon-slot" (see
+                Separator.styles.axaml) to collapse them into one shared leading column.
+              -->
               <StackPanel Grid.Column="0" Orientation="Horizontal" MinWidth="25">
                 <ContentControl Name="PART_ToggleIconPresenter"
                                 IsVisible="False"
                                 Theme="{StaticResource FluentMenuItemIconTheme}"
                                 Margin="{StaticResource MenuIconPresenterMargin}" />
-
-                <ContentControl Name="PART_IconPresenter"
-                                IsVisible="False"
-                                Theme="{StaticResource FluentMenuItemIconTheme}"
-                                Content="{TemplateBinding Icon}"
-                                Margin="{StaticResource MenuIconPresenterMargin}" />
               </StackPanel>
+
+              <ContentControl Name="PART_IconPresenter"
+                              Grid.Column="1"
+                              IsVisible="False"
+                              Theme="{StaticResource FluentMenuItemIconTheme}"
+                              Content="{TemplateBinding Icon}"
+                              Margin="{StaticResource MenuIconPresenterMargin}" />
 
               <ContentPresenter Name="PART_HeaderPresenter"
                                 Content="{TemplateBinding Header}"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/Separator.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/Separator.styles.axaml
@@ -16,4 +16,24 @@
         <Setter Property="Margin" Value="0" />
         <Setter Property="Separator.Background" Value="{DynamicResource MenuFlyoutPresenterBorderBrush}" />
     </Style>
+
+    <!--
+      Opt-in "single-icon-slot" mode: the check/radio indicator and the icon share a single
+      leading column instead of reserving one column each. The icon moves into the toggle column,
+      and is hidden while the item is checked so the check/bullet takes the shared slot (only one
+      is ever visible, which keeps the column width stable).
+    -->
+    <Style Selector="ContextMenu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                     Menu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                     MenuFlyoutPresenter.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                     MenuItem.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter">
+        <Setter Property="Grid.Column" Value="0" />
+    </Style>
+
+    <Style Selector="ContextMenu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                     Menu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                     MenuFlyoutPresenter.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                     MenuItem.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.styles.axaml
@@ -24,4 +24,24 @@
       <Setter Property="VerticalAlignment" Value="Stretch" />
     </Style>
   </Style>
+
+  <!--
+    Opt-in "single-icon-slot" mode: the check/radio indicator and the icon share a single
+    leading column instead of reserving one column each. The icon moves into the toggle column,
+    and is hidden while the item is checked so the check/bullet takes the shared slot (only one
+    is ever visible, which keeps the column width stable).
+  -->
+  <Style Selector="ContextMenu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                   Menu.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                   MenuFlyoutPresenter.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter,
+                   MenuItem.single-icon-slot MenuItem /template/ ContentControl#PART_IconPresenter">
+    <Setter Property="Grid.Column" Value="0" />
+  </Style>
+
+  <Style Selector="ContextMenu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                   Menu.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                   MenuFlyoutPresenter.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter,
+                   MenuItem.single-icon-slot MenuItem:checked /template/ ContentControl#PART_IconPresenter">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:conv="using:Avalonia.Controls.Converters"
+                    xmlns:behaviors="clr-namespace:Devolutions.AvaloniaControls.Behaviors;assembly=Devolutions.AvaloniaControls"
                     xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
 
   <Design.PreviewWith>
@@ -78,6 +79,8 @@
     <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
     <Setter Property="Padding" Value="{DynamicResource MenuItemPadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <!-- Collapse vacated leading columns when icons/checks change (see MenuSharedSizeRefreshBehavior) -->
+    <Setter Property="behaviors:MenuSharedSizeRefreshBehavior.Enable" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>


### PR DESCRIPTION
## Summary

Adds an opt-in **`single-icon-slot`** mode so a menu item's check/radio indicator shares the same leading column as item icons (instead of reserving a separate column for each), and fixes the underlying Avalonia shared-size limitation so unused leading columns collapse dynamically.

This mirrors the behavior DevExpress already had (opt-in class) and brings it to macOS and Linux, rather than making Yaru's old always-on merge the default (which jittered when a sibling check toggled).

## How `single-icon-slot` works

Add the `single-icon-slot` class to a `Menu`, `ContextMenu`, `MenuFlyoutPresenter`, or parent `MenuItem`. The icon presenter moves into the toggle column and is hidden while the item is checked, so only one indicator ever occupies the shared slot — no jitter.

## Changes

- **`[Controls]` `MenuSharedSizeRefreshBehavior`** (new) — attached to every `MenuItem`; one shared state per shared-size scope. Observes the inputs that decide the occupied leading columns — each item's `Icon` / `IsChecked` / `IsVisible`, container add/remove, and the `single-icon-slot` class — and rebuilds the scope (toggling `Grid.IsSharedSizeScope`) only when the needed columns actually change.
- **`[MacOS]` / `[Linux]`** — opt-in `single-icon-slot` styles (icon shares the check column, hidden when checked); behavior wired into the `MenuItem` control theme.
- **`[DevExpress]`** — extended the existing `single-icon-slot` selectors to `MenuFlyoutPresenter`; behavior wired into the `MenuItem` control theme.
- **`[Linux]`** — un-merged the default two-column layout (toggle and icon now live in separate columns) so toggling a sibling's check no longer shifts icons. ⚠️ **Note:** in the default (non-`single-icon-slot`) layout, Linux icon-bearing items now get slightly more leading space; Linux baselines will shift.
- **`[SampleApp]`** — new demo showcase beside the open-menu example: a toggle-driven `single-icon-slot` menu next to an always-default menu, covering normal / checkbox / radio items with and without icons.

## Why the shared-size fix is needed

Avalonia's `Grid` shared-size groups never shrink once they've measured a width. So when the last checked item is unchecked, the last item with an icon is removed/hidden, or the class is toggled, the vacated column keeps a phantom width that pushes the header text across. The behavior forces a fresh measurement pass so those columns collapse to zero.

## Testing

- Full solution builds clean (0 warnings in the touched projects).
- Runtime smoke test on the Menu page: no exceptions/binding errors, and CPU idles at ~0% (the behavior does no per-layout work).
- ⚠️ Still needs a visual pass across MacOS / Linux / DevExpress (screen capture wasn't available in the dev environment).
- Visual-regression baselines will change (Linux default spacing + the new demo section).

## Known limitation

- DevExpress's `MenuSeparatorAlignmentBehavior` recomputes separator indentation on load, not on a live class toggle — only affects the demo's live switch, not static usage.

## Excluded

- An unrelated local change to `Devolutions.AvaloniaControls.csproj` (adds `AvaloniaUI.DiagnosticsSupport`) was intentionally left out of this branch.
