### PR TITLE
[Controls] Add CalendarDatePicker inner content slots

### DIFF
--- a/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml
+++ b/samples/SampleApp/DemoPages/CalendarDatePickerDemo.axaml
@@ -27,7 +27,7 @@
           RowSpacing="30">
       <Grid Grid.Column="0" Grid.Row="0"
             ColumnDefinitions="Auto, 250"
-            RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+            RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
             ColumnSpacing="15"
             RowSpacing="14">
         <TextBlock Grid.Row="0" Grid.Column="0" Text="Placeholder"   VerticalAlignment="Center" />
@@ -37,6 +37,7 @@
         <TextBlock Grid.Row="4" Grid.Column="0" Text="Custom Format" VerticalAlignment="Center" />
         <TextBlock Grid.Row="5" Grid.Column="0" Text="Reset"         VerticalAlignment="Center" />
         <TextBlock Grid.Row="6" Grid.Column="0" Text="Error"         VerticalAlignment="Center" />
+        <TextBlock Grid.Row="7" Grid.Column="0" Text="Inner slots"   VerticalAlignment="Center" />
 
         <CalendarDatePicker Grid.Row="0" Grid.Column="1" HorizontalAlignment="Left" />
         <CalendarDatePicker Grid.Row="1" Grid.Column="1" Name="DatePicker"  HorizontalAlignment="Left" />
@@ -58,6 +59,20 @@
             </system:Exception>
           </DataValidationErrors.Error>
         </CalendarDatePicker>
+        <StackPanel Grid.Row="7" Grid.Column="1" Orientation="Horizontal" Spacing="10">
+          <CalendarDatePicker HorizontalAlignment="Left">
+            <CalendarDatePickerContent.InnerLeftContent>
+              <Button Command="{Binding GreenCommand}"><Border Width="8" Height="8" Background="Green" /></Button>
+            </CalendarDatePickerContent.InnerLeftContent>
+            <CalendarDatePickerContent.InnerLeftOfCalendarButtonContent>
+              <Button Command="{Binding OrangeCommand}"><Border Width="8" Height="8" Background="Orange" /></Button>
+            </CalendarDatePickerContent.InnerLeftOfCalendarButtonContent>
+            <CalendarDatePickerContent.InnerRightContent>
+              <Button Command="{Binding RedCommand}"><Border Width="8" Height="8" Background="Red" /></Button>
+            </CalendarDatePickerContent.InnerRightContent>
+          </CalendarDatePicker>
+          <Border Width="12" Height="12" VerticalAlignment="Center" Background="{Binding SelectedBrush}" />
+        </StackPanel>
       </Grid>
 
       <StackPanel Grid.Row="0" Grid.Column="1"

--- a/samples/SampleApp/ViewModels/CalendarDatePickerViewModel.cs
+++ b/samples/SampleApp/ViewModels/CalendarDatePickerViewModel.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -15,4 +16,16 @@ public partial class CalendarDatePickerViewModel : ObservableObject
     {
         this.SelectedDate = DateTime.Today;
     }
+
+    [ObservableProperty]
+    private IBrush selectedBrush = Brushes.Transparent;
+
+    [RelayCommand]
+    private void Green() => this.SelectedBrush = Brushes.Green;
+
+    [RelayCommand]
+    private void Orange() => this.SelectedBrush = Brushes.Orange;
+
+    [RelayCommand]
+    private void Red() => this.SelectedBrush = Brushes.Red;
 }

--- a/src/Devolutions.AvaloniaControls/AttachedProperties/CalendarDatePickerContent.cs
+++ b/src/Devolutions.AvaloniaControls/AttachedProperties/CalendarDatePickerContent.cs
@@ -1,0 +1,48 @@
+namespace Devolutions.AvaloniaControls.AttachedProperties;
+
+using System.Collections;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+
+public static class CalendarDatePickerContent
+{
+    public static readonly AttachedProperty<IEnumerable> InnerLeftContentProperty =
+        AvaloniaProperty.RegisterAttached<CalendarDatePicker, IEnumerable>("InnerLeftContent", typeof(CalendarDatePickerContent));
+
+    public static readonly AttachedProperty<IEnumerable> InnerLeftOfCalendarButtonContentProperty =
+        AvaloniaProperty.RegisterAttached<CalendarDatePicker, IEnumerable>("InnerLeftOfCalendarButtonContent", typeof(CalendarDatePickerContent));
+
+    public static readonly AttachedProperty<IEnumerable> InnerRightContentProperty =
+        AvaloniaProperty.RegisterAttached<CalendarDatePicker, IEnumerable>("InnerRightContent", typeof(CalendarDatePickerContent));
+
+    public static IEnumerable GetInnerLeftContent(CalendarDatePicker element) => GetOrCreate(element, InnerLeftContentProperty);
+
+    public static void SetInnerLeftContent(CalendarDatePicker element, IEnumerable value) => element.SetValue(InnerLeftContentProperty, value);
+
+    public static IEnumerable GetInnerLeftOfCalendarButtonContent(CalendarDatePicker element) =>
+        GetOrCreate(element, InnerLeftOfCalendarButtonContentProperty);
+
+    public static void SetInnerLeftOfCalendarButtonContent(CalendarDatePicker element, IEnumerable value) =>
+        element.SetValue(InnerLeftOfCalendarButtonContentProperty, value);
+
+    public static IEnumerable GetInnerRightContent(CalendarDatePicker element) => GetOrCreate(element, InnerRightContentProperty);
+
+    public static void SetInnerRightContent(CalendarDatePicker element, IEnumerable value) => element.SetValue(InnerRightContentProperty, value);
+
+    // Attached-property defaults are shared across all instances, which is not what we want for
+    // mutable collections. Lazily create a per-instance AvaloniaList<Control> on first read so
+    // XAML element-syntax (<CalendarDatePickerContent.InnerLeftContent>...</...>) can Add into it.
+    private static IEnumerable GetOrCreate(CalendarDatePicker element, AttachedProperty<IEnumerable> property)
+    {
+        if (element.GetValue(property) is { } existing)
+        {
+            return existing;
+        }
+
+        // ReSharper disable once CollectionNeverUpdated.Local
+        AvaloniaList<Control> list = [];
+        element.SetValue(property, list);
+        return list;
+    }
+}

--- a/src/Devolutions.AvaloniaControls/Behaviors/CalendarDatePickerBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/CalendarDatePickerBehavior.cs
@@ -1,9 +1,12 @@
-﻿using Avalonia;
+using Avalonia;
 
 namespace Devolutions.AvaloniaControls.Behaviors;
 
+using System;
+using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 
 public static class CalendarDatePickerBehavior
@@ -15,30 +18,62 @@ public static class CalendarDatePickerBehavior
     {
         OpenOnSelectedDateProperty.Changed.Subscribe(args =>
         {
-            if (args.Sender is CalendarDatePicker datePicker)
+            if (args.Sender is not CalendarDatePicker datePicker) return;
+
+            if (args.NewValue.GetValueOrDefault<bool>())
             {
-                if (args.NewValue.GetValueOrDefault<bool>())
-                {
-                    datePicker.CalendarOpened += OnCalendarOpen;
-                }
-                else
-                {
-                    datePicker.CalendarOpened -= OnCalendarOpen;
-                }
+                datePicker.CalendarOpened += OnCalendarOpened;
+                datePicker.CalendarClosed += OnCalendarClosed;
+            }
+            else
+            {
+                datePicker.CalendarOpened -= OnCalendarOpened;
+                datePicker.CalendarClosed -= OnCalendarClosed;
             }
         });
     }
 
-    private static void OnCalendarOpen(object? sender, EventArgs e)
+    private static void OnCalendarOpened(object? sender, EventArgs e)
     {
-        if (sender is CalendarDatePicker datePicker)
+        if (sender is not CalendarDatePicker datePicker) return;
+
+        Popup? popup = datePicker.GetVisualDescendants().OfType<Popup>().FirstOrDefault();
+        Calendar? calendar = popup?.Child?.FindDescendantOfType<Calendar>() ?? popup?.Child as Calendar;
+
+        if (calendar == null) return;
+
+        calendar.DisplayDate = datePicker.SelectedDate ?? DateTime.Now;
+
+        // Move keyboard focus into the calendar when the popup opens. The calendar button now lives inside
+        // PART_TextBox (to host inner-content slots), so opening no longer takes focus off the text box on
+        // its own — focus would otherwise stay in the box and its segmented arrow-keys would look like
+        // calendar input. Focusing the popup also lets Avalonia's light-dismiss close it on Tab again.
+        // (PART_Calendar sets Focusable="True" in each theme so this Focus() takes effect.)
+        Dispatcher.UIThread.Post(() => calendar.Focus(), DispatcherPriority.Input);
+    }
+
+    private static void OnCalendarClosed(object? sender, EventArgs e)
+    {
+        if (sender is not CalendarDatePicker datePicker) return;
+
+        // Focus was moved into the popup calendar on open (see OnCalendarOpened). The calendar lives in the
+        // popup's own tree, outside the window's tab order, so once the popup closes we return focus to the
+        // picker's text box — restoring the original tab flow (Tab then continues from the picker).
+        Dispatcher.UIThread.Post(() => ReturnFocusToPicker(datePicker), DispatcherPriority.Background);
+    }
+
+    // Returns focus to the picker's primary control. Prefers the text box, but on themes where it is hidden
+    // and non-focusable (Yaru shows a button instead) falls back to the button.
+    private static void ReturnFocusToPicker(CalendarDatePicker picker)
+    {
+        TextBox? textBox = picker.GetVisualDescendants().OfType<TextBox>().FirstOrDefault(tb => tb.Name == "PART_TextBox");
+        if (textBox is { Focusable: true, IsVisible: true })
         {
-            Popup? popup = datePicker.GetVisualDescendants().OfType<Popup>().FirstOrDefault();
-            Calendar? calendar = popup?.Child?.FindDescendantOfType<Calendar>() ?? popup?.Child as Calendar;
-
-            if (calendar == null) return;
-
-            calendar.DisplayDate = datePicker.SelectedDate ?? DateTime.Now;
+            textBox.Focus();
+            return;
         }
+
+        Button? button = picker.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "PART_Button");
+        button?.Focus();
     }
 }

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
@@ -85,6 +85,9 @@
                   <Style Selector="TextBox /template/ ContentPresenter#SufixContent">
                     <Setter Property="Padding" Value="0" />
                   </Style>
+                  <Style Selector="TextBox /template/ ContentPresenter Button">
+                    <Setter Property="MinHeight" Value="18" />
+                  </Style>
                 </TextBox.Styles>
                 <TextBox.InnerLeftContent>
                   <ItemsControl

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
@@ -31,6 +31,7 @@
 
   <x:Double x:Key="CalendarDatePickerCurrentDayFontSize">12</x:Double>
   <x:Double x:Key="CalendarDatePickerMinHeight">32</x:Double>
+  <SolidColorBrush x:Key="CalendarDatePickerGlyphOpenBrush" Color="#939393" />
 
   <ControlTheme x:Key="DatePickerButton"
                 TargetType="Button">
@@ -64,9 +65,6 @@
         <DataValidationErrors>
           <Panel x:Name="LayoutRoot"
                  HorizontalAlignment="Stretch">
-            <!-- Brittle Button placement! Placing the Button as TextBox.InnerRightContent breaks functionality,
-                       But this placement breaks if ValidationError text is positioned _above_ the TextBox 
-                       Also: centering the button via setting a top margin gives inconsistent results on different monitors -->
             <Panel>
               <TextBox Name="PART_TextBox"
                        PlaceholderText="{TemplateBinding PlaceholderText}"
@@ -76,8 +74,86 @@
                        BorderThickness="{TemplateBinding BorderThickness}"
                        CornerRadius="{TemplateBinding CornerRadius}"
                        Padding="{TemplateBinding Padding}">
+                <TextBox.InnerLeftContent>
+                  <ItemsControl
+                    VerticalAlignment="Center"
+                    Margin="4 2 0 2"
+                    ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                    IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                    <ItemsControl.ItemsPanel>
+                      <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="2" />
+                      </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                  </ItemsControl>
+                </TextBox.InnerLeftContent>
                 <TextBox.InnerRightContent>
-                  <Rectangle Width="22" Fill="Transparent" />
+                  <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                    <ItemsControl
+                      VerticalAlignment="Center"
+                      ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                      IsVisible="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                      <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                          <StackPanel Orientation="Horizontal" Spacing="2" />
+                        </ItemsPanelTemplate>
+                      </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                    <Button Name="PART_Button"
+                            Theme="{StaticResource DatePickerButton}"
+                            Focusable="False"
+                            VerticalAlignment="Center">
+                      <!-- DropDownGlyphBackground / DropDownGlyph live inside PART_TextBox.InnerRightContent,
+                           i.e. outside the CalendarDatePicker template namescope, so styles / TemplateBinding
+                           cannot reach them. Their state colours are bound to the parent via
+                           $parent[CalendarDatePicker] (open / disabled) and to the border's own IsPointerOver
+                           (hover), replacing the pointerover / flyout-open / disabled styles. -->
+                      <Border Name="DropDownGlyphBackground"
+                              Classes.dropdownOpen="{Binding $parent[CalendarDatePicker].IsDropDownOpen}"
+                              Margin="{DynamicResource DropdownButtonMargin}"
+                              Width="{DynamicResource DropdownButtonWidth}"
+                              Height="{DynamicResource DropdownButtonHeight}"
+                              CornerRadius="{DynamicResource ControlCornerRadius}"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Center">
+                        <!-- Hover (the border's own :pointerover) and open (a class bound to the parent's
+                             IsDropDownOpen) are styled locally on the Border, because a "/template/" style
+                             from the CalendarDatePicker cannot reach it inside PART_TextBox content. -->
+                        <Border.Styles>
+                          <Style Selector="Border#DropDownGlyphBackground">
+                            <Setter Property="Background" Value="{DynamicResource TransparentBrush}" />
+                          </Style>
+                          <Style Selector="Border#DropDownGlyphBackground:pointerover">
+                            <Setter Property="Background" Value="{DynamicResource ControlBackgroundPointerOverBrush}" />
+                          </Style>
+                          <Style Selector="Border#DropDownGlyphBackground.dropdownOpen">
+                            <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
+                          </Style>
+                        </Border.Styles>
+                        <PathIcon Name="DropDownGlyph"
+                                  UseLayoutRounding="False"
+                                  IsHitTestVisible="False"
+                                  Width="{DynamicResource DropdownButtonIconWidth}"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  Foreground="{BindingToggler {Binding $parent[CalendarDatePicker].IsDropDownOpen},
+                                    {DynamicResource CalendarDatePickerGlyphOpenBrush},
+                                    {DynamicResourceToggler {Binding $parent[CalendarDatePicker].IsEnabled}, ForegroundHighBrush, CalendarDatePickerCalendarGlyphForegroundDisabled}}"
+                                  Data="{StaticResource ChevronPath}" />
+                      </Border>
+                    </Button>
+                    <ItemsControl
+                      VerticalAlignment="Center"
+                      Margin="0 0 4 0"
+                      ItemsSource="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                      IsVisible="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                      <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                          <StackPanel Orientation="Horizontal" Spacing="2" />
+                        </ItemsPanelTemplate>
+                      </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                  </StackPanel>
                 </TextBox.InnerRightContent>
               </TextBox>
               <Border
@@ -86,30 +162,7 @@
                 BorderThickness="1"
                 CornerRadius="{DynamicResource ControlCornerRadius}"
                 IsVisible="False" />
-              <Panel Height="{DynamicResource TextBasedInputMinHeight}" VerticalAlignment="Top">
-                <Button Name="PART_Button"
-                        Theme="{StaticResource DatePickerButton}"
-                        Focusable="False">
-                  <Border Name="DropDownGlyphBackground"
-                          DockPanel.Dock="Right"
-                          Background="Transparent"
-                          Margin="{DynamicResource DropdownButtonMargin}"
-                          Width="{DynamicResource DropdownButtonWidth}"
-                          Height="{DynamicResource DropdownButtonHeight}"
-                          CornerRadius="{DynamicResource ControlCornerRadius}"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Center">
-                    <PathIcon Name="DropDownGlyph"
-                              UseLayoutRounding="False"
-                              IsHitTestVisible="False"
-                              Width="{DynamicResource DropdownButtonIconWidth}"
-                              HorizontalAlignment="Center"
-                              VerticalAlignment="Center"
-                              Foreground="{TemplateBinding Foreground}"
-                              Data="{StaticResource ChevronPath}" />
-                  </Border>
-                </Button>
-              </Panel>
+
               <Popup Name="PART_Popup"
                      PlacementTarget="{TemplateBinding}"
                      Placement="BottomEdgeAlignedLeft"
@@ -139,25 +192,9 @@
       </ControlTemplate>
     </Setter>
 
-    <!-- Disabled State -->
-    <Style Selector="^:disabled">
-      <Style Selector="^ /template/ Button#PART_Button PathIcon">
-        <Setter Property="TextElement.Foreground" Value="{DynamicResource CalendarDatePickerCalendarGlyphForegroundDisabled}" />
-      </Style>
-    </Style>
-
-    <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">
-      <Setter Property="Background" Value="{DynamicResource ControlBackgroundPointerOverBrush}" />
-    </Style>
-
-    <Style Selector="^:flyout-open">
-      <Style Selector="^ /template/ Border#DropDownGlyphBackground">
-        <Setter Property="Background" Value="{DynamicResource ControlBackgroundSelectedBrush}" />
-      </Style>
-      <Style Selector="^ /template/ PathIcon#DropDownGlyph">
-        <Setter Property="Foreground" Value="#939393" />
-      </Style>
-    </Style>
+    <!-- Chevron hover / open / disabled colours are handled by bindings on DropDownGlyphBackground and
+         DropDownGlyph in the template (see comment there); a "/template/" style cannot reach them because
+         they sit inside PART_TextBox.InnerRightContent. -->
 
     <!-- Focused State -->
     <Style Selector="^:focus-within:not(CalendarDatePicker:focus) /template/ Border#Background">

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
@@ -193,6 +193,7 @@
                         Margin="{DynamicResource ComboBoxPopupBorderMargin}"
                         BoxShadow="{DynamicResource ComboBoxDropDownShadow}">
                   <Calendar Name="PART_Calendar"
+                            Focusable="True"
                             FirstDayOfWeek="{TemplateBinding FirstDayOfWeek}"
                             IsTodayHighlighted="{TemplateBinding IsTodayHighlighted}"
                             SelectedDate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedDate, Mode=TwoWay}"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/CalendarDatePicker.axaml
@@ -74,10 +74,22 @@
                        BorderThickness="{TemplateBinding BorderThickness}"
                        CornerRadius="{TemplateBinding CornerRadius}"
                        Padding="{TemplateBinding Padding}">
+                <TextBox.Styles>
+                  <!-- The slots always assign content to Inner*Content, so these presenters are always
+                       visible and would apply their own padding even when a slot is empty, shifting the
+                       layout vs. a plain picker. Zero it here (an instance Styles collection allows a single
+                       /template/ selector, unlike a ControlTheme); slot spacing comes from the ItemsControls' margins. -->
+                  <Style Selector="TextBox /template/ ContentPresenter#PrefixContent">
+                    <Setter Property="Padding" Value="0" />
+                  </Style>
+                  <Style Selector="TextBox /template/ ContentPresenter#SufixContent">
+                    <Setter Property="Padding" Value="0" />
+                  </Style>
+                </TextBox.Styles>
                 <TextBox.InnerLeftContent>
                   <ItemsControl
                     VerticalAlignment="Center"
-                    Margin="4 2 0 2"
+                    Margin="4 0 0 0"
                     ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
                     IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
                     <ItemsControl.ItemsPanel>
@@ -88,7 +100,7 @@
                   </ItemsControl>
                 </TextBox.InnerLeftContent>
                 <TextBox.InnerRightContent>
-                  <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                  <StackPanel Margin="4 0 0 0" Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
                     <ItemsControl
                       VerticalAlignment="Center"
                       ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
@@ -195,7 +207,7 @@
     <!-- Chevron hover / open / disabled colours are handled by bindings on DropDownGlyphBackground and
          DropDownGlyph in the template (see comment there); a "/template/" style cannot reach them because
          they sit inside PART_TextBox.InnerRightContent. -->
-
+    
     <!-- Focused State -->
     <Style Selector="^:focus-within:not(CalendarDatePicker:focus) /template/ Border#Background">
       <Setter Property="Background" Value="{DynamicResource TextControlBackgroundFocused}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/TextBox.axaml
@@ -210,12 +210,6 @@
                                 Grid.Column="0"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding InnerLeftContent}"
-                                Padding="{Binding 
-                                    Padding, 
-                                    RelativeSource={RelativeSource TemplatedParent}, 
-                                    Converter={x:Static  DevoConverters.ThicknessExtractor},
-                                    ConverterParameter={x:Static ThicknessSubset.Left}
-                                  }"
                                 IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
               <ScrollViewer Name="PART_ScrollViewer"
                             Grid.Column="1"
@@ -277,11 +271,6 @@
               <ContentPresenter Name="SufixContent"
                                 Grid.Column="2"
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                Padding="{Binding 
-                                            Padding, 
-                                            RelativeSource={RelativeSource TemplatedParent}, 
-                                            Converter={x:Static DevoConverters.ThicknessToSelectiveThicknessConverter},
-                                            ConverterParameter={StaticResource TextBoxSufixPaddingFactors}}"
                                 Content="{TemplateBinding InnerRightContent}"
                                 IsVisible="{Binding Content, RelativeSource={RelativeSource Self}, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
             </Grid>
@@ -289,6 +278,18 @@
         </DataValidationErrors>
       </ControlTemplate>
     </Setter>
+
+    <!-- Inner-content (Prefix/Sufix) padding is applied via style rather than a direct attribute on the
+         presenters so that an instance can override it locally (e.g. CalendarDatePicker zeroes it because
+         it always assigns inner content and would otherwise get padding even when a slot is empty). -->
+    <Style Selector="^ /template/ ContentPresenter#PrefixContent">
+      <Setter Property="Padding"
+              Value="{Binding Padding, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.ThicknessExtractor}, ConverterParameter={x:Static ThicknessSubset.Left}}" />
+    </Style>
+    <Style Selector="^ /template/ ContentPresenter#SufixContent">
+      <Setter Property="Padding"
+              Value="{Binding Padding, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.ThicknessToSelectiveThicknessConverter}, ConverterParameter={StaticResource TextBoxSufixPaddingFactors}}" />
+    </Style>
 
     <Style Selector="^.borderless">
       <Setter Property="BorderThickness" Value="0" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
@@ -165,6 +165,7 @@
                   BoxShadow="0 1 1 1 #33000000">
                   <Calendar
                     Name="PART_Calendar"
+                    Focusable="True"
                     Margin="0"
                     BorderBrush="{DynamicResource InputBorder}"
                     BorderThickness="1 "

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
@@ -70,14 +70,72 @@
                        VerticalAlignment="Stretch"
                        HorizontalContentAlignment="Center" />
               <Button Name="PART_Button"
-                      Foreground="{Binding Path=#PART_TextBox.Foreground}">
-                <Button.Content>
-                  <MultiBinding Converter="{x:Static DevoMultiConverters.FirstNonEmptyStringMultiConverter}">
-                    <Binding Path="#PART_TextBox.Text" />
-                    <Binding Path="#PART_TextBox.PlaceholderText" />
-                  </MultiBinding>
-                </Button.Content>
-              </Button>
+                      Foreground="{Binding Path=#PART_TextBox.Foreground}"
+                      MinWidth="{Binding #SlotOverlay.Bounds.Width}"
+                      MinHeight="{Binding #SlotOverlay.Bounds.Height}" />
+              <!-- The date and the inner-content slots are overlaid ON TOP of PART_Button as siblings
+                   (not children), laid out in-flow so they never overlap. The date is hit-transparent and
+                   empty areas have no Background, so clicks on the date / empty space fall through to
+                   PART_Button and open the calendar; a click on a slot control bubbles up this Grid,
+                   not through PART_Button, so it does not open the calendar.
+                   PART_Button's Min size is bound to this overlay's bounds so the button always grows to
+                   cover the slots (they are siblings, so they cannot drive its size on their own). The
+                   overlay carries the normal input MinHeight floor so the button keeps its usual height
+                   when slots are small, and only grows when a slot is taller. -->
+              <Grid Name="SlotOverlay"
+                    MinHeight="{DynamicResource InputDefaultHeight}"
+                    ColumnDefinitions="Auto,*,Auto,Auto">
+                <ItemsControl
+                  Grid.Column="0"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Left"
+                  Margin="6 0 0 0"
+                  ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
+                <TextBlock Grid.Column="1"
+                           IsHitTestVisible="False"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Center"
+                           Margin="6 0"
+                           Foreground="{Binding Path=#PART_TextBox.Foreground}">
+                  <TextBlock.Text>
+                    <MultiBinding Converter="{x:Static DevoMultiConverters.FirstNonEmptyStringMultiConverter}">
+                      <Binding Path="#PART_TextBox.Text" />
+                      <Binding Path="#PART_TextBox.PlaceholderText" />
+                    </MultiBinding>
+                  </TextBlock.Text>
+                </TextBlock>
+                <ItemsControl
+                  Grid.Column="2"
+                  VerticalAlignment="Center"
+                  ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
+                <ItemsControl
+                  Grid.Column="3"
+                  VerticalAlignment="Center"
+                  HorizontalAlignment="Right"
+                  Margin="4 0 6 0"
+                  ItemsSource="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}}"
+                  IsVisible="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                  <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                      <StackPanel Orientation="Horizontal" Spacing="2" />
+                    </ItemsPanelTemplate>
+                  </ItemsControl.ItemsPanel>
+                </ItemsControl>
+              </Grid>
               <Border Name="ErrorBorderElement"
                       IsVisible="False"
                       BorderThickness="1"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
@@ -191,6 +191,10 @@
         </DataValidationErrors>
       </ControlTemplate>
     </Setter>
+    
+    <Style Selector="^:disabled /template/ TextBox#PART_TextBox">
+      <Setter Property="Foreground" Value="{DynamicResource InputDisabledForeground}" />
+    </Style>
 
     <Style Selector="^:flyout-open /template/ Button#PART_Button">
       <Setter Property="Tag" Value="noFocus" />

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
@@ -86,6 +86,11 @@
                     MinHeight="{DynamicResource InputDefaultHeight}"
                     ColumnDefinitions="Auto,*,Auto,Auto"
                     Margin="6 0">
+                <Grid.Styles>
+                  <Style Selector="ItemsControl Button">
+                    <Setter Property="MinHeight" Value="28" />
+                  </Style>
+                </Grid.Styles>
                 <ItemsControl
                   Grid.Column="0"
                   VerticalAlignment="Center"

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/CalendarDatePicker.axaml
@@ -84,12 +84,12 @@
                    when slots are small, and only grows when a slot is taller. -->
               <Grid Name="SlotOverlay"
                     MinHeight="{DynamicResource InputDefaultHeight}"
-                    ColumnDefinitions="Auto,*,Auto,Auto">
+                    ColumnDefinitions="Auto,*,Auto,Auto"
+                    Margin="6 0">
                 <ItemsControl
                   Grid.Column="0"
                   VerticalAlignment="Center"
                   HorizontalAlignment="Left"
-                  Margin="6 0 0 0"
                   ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}}"
                   IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
                   <ItemsControl.ItemsPanel>
@@ -126,7 +126,7 @@
                   Grid.Column="3"
                   VerticalAlignment="Center"
                   HorizontalAlignment="Right"
-                  Margin="4 0 6 0"
+                  Margin="4 0 0 0"
                   ItemsSource="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}}"
                   IsVisible="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
                   <ItemsControl.ItemsPanel>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -23,6 +23,7 @@
   </Design.PreviewWith>
 
   <ControlTheme x:Key="{x:Type Button}" TargetType="Button">
+    <Setter Property="MinHeight" Value="{DynamicResource ButtonMinHeight}" />
     <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrush}" />
@@ -40,7 +41,7 @@
       <ControlTemplate>
         <Panel>
           <Border Name="BackgroundElement"
-                  MinHeight="{DynamicResource ButtonMinHeight}"
+                  MinHeight="{TemplateBinding MinHeight}"
                   Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -70,10 +70,22 @@
                        BorderBrush="{TemplateBinding BorderBrush}"
                        BorderThickness="{TemplateBinding BorderThickness}"
                        CornerRadius="{TemplateBinding CornerRadius}">
+                <TextBox.Styles>
+                  <!-- The slots always assign content to Inner*Content, so these presenters are always
+                       visible and would apply their own padding even when a slot is empty, shifting the
+                       layout vs. a plain picker. Zero it here (an instance Styles collection allows a single
+                       /template/ selector, unlike a ControlTheme); slot spacing comes from the ItemsControls' margins. -->
+                  <Style Selector="TextBox /template/ ContentPresenter#PrefixContent">
+                    <Setter Property="Padding" Value="0" />
+                  </Style>
+                  <Style Selector="TextBox /template/ ContentPresenter#SuffixContent">
+                    <Setter Property="Padding" Value="0" />
+                  </Style>
+                </TextBox.Styles>
                 <TextBox.InnerLeftContent>
                   <ItemsControl
                     VerticalAlignment="Center"
-                    Margin="8 2 0 2"
+                    Margin="3 2 3 1"
                     ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
                     IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
                     <ItemsControl.ItemsPanel>
@@ -84,7 +96,7 @@
                   </ItemsControl>
                 </TextBox.InnerLeftContent>
                 <TextBox.InnerRightContent>
-                  <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                  <StackPanel Margin="3 2 3 1" Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
                     <ItemsControl
                       VerticalAlignment="Center"
                       ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
@@ -97,8 +109,7 @@
                     </ItemsControl>
                     <Button Name="PART_Button"
                             Theme="{StaticResource DatePickerButton}"
-                            VerticalAlignment="Center"
-                            Margin="2 0 6 0">
+                            VerticalAlignment="Center">
                       <Panel>
                         <!-- The icon lives inside PART_TextBox.InnerRightContent, so it is outside the
                              CalendarDatePicker template namescope: styles / TemplateBinding cannot reach it.
@@ -113,7 +124,6 @@
                     </Button>
                     <ItemsControl
                       VerticalAlignment="Center"
-                      Margin="0 0 4 0"
                       ItemsSource="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
                       IsVisible="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
                       <ItemsControl.ItemsPanel>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -70,27 +70,61 @@
                        BorderBrush="{TemplateBinding BorderBrush}"
                        BorderThickness="{TemplateBinding BorderThickness}"
                        CornerRadius="{TemplateBinding CornerRadius}">
+                <TextBox.InnerLeftContent>
+                  <ItemsControl
+                    VerticalAlignment="Center"
+                    Margin="8 2 0 2"
+                    ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                    IsVisible="{Binding (CalendarDatePickerContent.InnerLeftContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                    <ItemsControl.ItemsPanel>
+                      <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="2" />
+                      </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                  </ItemsControl>
+                </TextBox.InnerLeftContent>
                 <TextBox.InnerRightContent>
-                  <Rectangle Width="20" Fill="Transparent" />
+                  <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+                    <ItemsControl
+                      VerticalAlignment="Center"
+                      ItemsSource="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                      IsVisible="{Binding (CalendarDatePickerContent.InnerLeftOfCalendarButtonContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                      <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                          <StackPanel Orientation="Horizontal" Spacing="2" />
+                        </ItemsPanelTemplate>
+                      </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                    <Button Name="PART_Button"
+                            Theme="{StaticResource DatePickerButton}"
+                            VerticalAlignment="Center"
+                            Margin="2 0 6 0">
+                      <Panel>
+                        <!-- The icon lives inside PART_TextBox.InnerRightContent, so it is outside the
+                             CalendarDatePicker template namescope: styles / TemplateBinding cannot reach it.
+                             Drive its colour by binding to the parent via $parent[CalendarDatePicker]
+                             (open -> accent; otherwise enabled -> icon brush, disabled -> low). -->
+                        <PathIcon Data="{StaticResource CalendarIconPath}"
+                                  Height="13"
+                                  Foreground="{BindingToggler {Binding $parent[CalendarDatePicker].IsDropDownOpen},
+                                    {DynamicResource AccentButtonBackground},
+                                    {DynamicResourceToggler {Binding $parent[CalendarDatePicker].IsEnabled}, CalendarIconBrush, ForegroundLowBrush}}" />
+                      </Panel>
+                    </Button>
+                    <ItemsControl
+                      VerticalAlignment="Center"
+                      Margin="0 0 4 0"
+                      ItemsSource="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}}"
+                      IsVisible="{Binding (CalendarDatePickerContent.InnerRightContent), RelativeSource={RelativeSource AncestorType=CalendarDatePicker}, Converter={x:Static DevoConverters.IsNullOrEmptyConverter}, ConverterParameter={x:False}}">
+                      <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                          <StackPanel Orientation="Horizontal" Spacing="2" />
+                        </ItemsPanelTemplate>
+                      </ItemsControl.ItemsPanel>
+                    </ItemsControl>
+                  </StackPanel>
                 </TextBox.InnerRightContent>
               </TextBox>
-              <!-- Brittle Button placement! Placing the Button as TextBox.InnerRightContent breaks functionality,
-                       But this placement breaks if ValidationError text is positioned _above_ the TextBox 
-                       Also: centering the button via setting a top margin gives inconsistent results on different monitors -->
-              <Panel Height="{TemplateBinding Height}"
-                     MinHeight="{DynamicResource CalendarControlHeight}" VerticalAlignment="Top">
-                <Button Name="PART_Button"
-                        Theme="{StaticResource DatePickerButton}"
-                        ClipToBounds="False"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Margin="0 0 8 0">
-                  <Panel>
-                    <PathIcon Data="{StaticResource CalendarIconPath}"
-                              Height="13" />
-                  </Panel>
-                </Button>
-              </Panel>
 
               <Popup Name="PART_Popup"
                      PlacementTarget="{Binding ElementName=PART_TextBox}"
@@ -120,20 +154,6 @@
         </DataValidationErrors>
       </ControlTemplate>
     </Setter>
-
-    <Style Selector="^ /template/ Button#PART_Button PathIcon">
-      <Setter Property="Foreground"
-              Value="{DynamicResourceToggler 
-                                  {Binding IsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=CalendarDatePicker}
-                                  }, 
-                                  CalendarIconBrush,
-                                  ForegroundLowBrush
-                                }" />
-    </Style>
-
-    <Style Selector="^:flyout-open /template/ Button#PART_Button PathIcon">
-      <Setter Property="Foreground" Value="{DynamicResource AccentButtonBackground}" />
-    </Style>
 
     <!-- Error State -->
     <Style Selector="^:error /template/ TextBox#PART_TextBox">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -154,6 +154,7 @@
                         Padding="{DynamicResource PopupPadding}"
                         BoxShadow="{DynamicResource PopupShadow}">
                   <Calendar Name="PART_Calendar"
+                            Focusable="True"
                             FirstDayOfWeek="{TemplateBinding FirstDayOfWeek}"
                             IsTodayHighlighted="{TemplateBinding IsTodayHighlighted}"
                             SelectedDate="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedDate, Mode=TwoWay}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -81,6 +81,9 @@
                   <Style Selector="TextBox /template/ ContentPresenter#SuffixContent">
                     <Setter Property="Padding" Value="0" />
                   </Style>
+                  <Style Selector="TextBox /template/ ContentPresenter Button">
+                    <Setter Property="MinHeight" Value="20" />
+                  </Style>
                 </TextBox.Styles>
                 <TextBox.InnerLeftContent>
                   <ItemsControl

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -174,7 +174,6 @@
                 <ContentPresenter Name="PrefixContent"
                                   Grid.Column="0"
                                   Content="{TemplateBinding InnerLeftContent}"
-                                  Padding="3 2 3 1"
                                   VerticalAlignment="Center">
                   <ContentPresenter.IsVisible>
                     <Binding RelativeSource="{RelativeSource Self}" Path="Content"
@@ -241,7 +240,6 @@
                 </DockPanel>
                 <ContentPresenter Name="SuffixContent"
                                   Grid.Column="2"
-                                  Padding="3 2 3 1"
                                   Content="{TemplateBinding InnerRightContent}"
                                   VerticalAlignment="Center">
                   <ContentPresenter.IsVisible>
@@ -266,6 +264,16 @@
         </DataValidationErrors>
       </ControlTemplate>
     </Setter>
+
+    <!-- Inner-content (Prefix/Suffix) padding is applied via style rather than a direct attribute on the
+         presenters so that an instance can override it locally (e.g. CalendarDatePicker zeroes it because
+         it always assigns inner content and would otherwise get padding even when a slot is empty). -->
+    <Style Selector="^ /template/ ContentPresenter#PrefixContent">
+      <Setter Property="Padding" Value="3 2 3 1" />
+    </Style>
+    <Style Selector="^ /template/ ContentPresenter#SuffixContent">
+      <Setter Property="Padding" Value="3 2 3 1" />
+    </Style>
 
     <!-- These properties are defined as Styles so they can be overridden by derived ControlThemes (e.g. ComboBoxEditableTextBox) -->
     <Style Selector="^ /template/ Border#PART_BorderElement">


### PR DESCRIPTION
## Summary

Adds inner content slots to `CalendarDatePicker`, mirroring the existing `ComboBox` inner-content slots, so consumers can drop icons / badges / buttons into the control without subclassing.

New attached-property class `Devolutions.AvaloniaControls.AttachedProperties.CalendarDatePickerContent` with three slots:
- `InnerLeftContent` — before the date text
- `InnerLeftOfCalendarButtonContent` — between the date and the calendar button
- `InnerRightContent` — after the calendar button

Wired into all three themes (MacOS, DevExpress, Linux).

## Implementation notes

- **MacOS / DevExpress**: the calendar button moves into `PART_TextBox`'s `InnerRightContent`, between the slots. Because that content sits outside the `CalendarDatePicker` template namescope, the icon / chevron state colours are driven by `$parent[CalendarDatePicker]` bindings (and the DevExpress chevron background by local styles on the border) rather than `/template/` styles, which cannot reach it.
- **Linux (Yaru)**: the date and slots are overlaid on `PART_Button` as siblings, so a slot click bubbles up the overlay instead of opening the calendar; `PART_Button`'s min size follows the overlay bounds (with the normal input-height floor) so it always covers the slots.
- **TextBox theme tweak (MacOS + DevExpress)**: the inner Prefix/Suffix content presenters now apply their padding via a `/template/` style setter instead of a direct attribute, so an instance can override it. The picker always assigns inner content, which would otherwise leave the presenters padding the layout even when a slot is empty; the picker now locally zeroes that padding. No visual change to regular TextBoxes.
- **SampleApp**: the CalendarDatePicker demo page exercises the three slots.

## Testing

Built the solution and manually verified each theme in the SampleApp:
- slots render in the correct positions; the calendar still opens; slot controls act independently (a slot click does not open the calendar);
- icon / chevron hover / open / disabled colours; error state; empty slots no longer shift the layout;
- regular TextBoxes unaffected by the theme tweak.

> Note: visual-regression baselines were not regenerated (they fail wholesale on the author's local machine); verification was manual via the SampleApp.
