### PR TITLE
[Controls] Extract RectangleSelectionMarquee control with per-theme colours

### DIFF
--- a/src/Devolutions.AvaloniaControls/Controls/GroupedTileListBox/GroupedTileListBox.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/GroupedTileListBox/GroupedTileListBox.axaml
@@ -2,13 +2,6 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Marquee (drag-to-select rectangle) brushes. Accent-tinted to match the Explorer-style
-         rubber-band; theme-aware via SystemAccentColor, so no per-theme override is required. -->
-    <SolidColorBrush x:Key="GroupedTileListBoxSelectionRectangleFill"
-                     Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
-    <SolidColorBrush x:Key="GroupedTileListBoxSelectionRectangleBorderBrush"
-                     Color="{DynamicResource SystemAccentColor}" Opacity="0.8" />
-
     <ControlTheme x:Key="{x:Type GroupedTileListBox}" TargetType="GroupedTileListBox">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="Padding" Value="4" />
@@ -48,11 +41,7 @@
                                 scrolls with content and never intercepts pointer input.
                             -->
                             <Canvas Name="PART_SelectionLayer" IsHitTestVisible="False">
-                                <Border Name="PART_SelectionRectangle"
-                                        IsVisible="False"
-                                        BorderThickness="1"
-                                        Background="{DynamicResource GroupedTileListBoxSelectionRectangleFill}"
-                                        BorderBrush="{DynamicResource GroupedTileListBoxSelectionRectangleBorderBrush}" />
+                              <RectangleSelectionMarquee Name="PART_SelectionRectangle" IsVisible="False" />
                             </Canvas>
                         </Panel>
                     </Border>

--- a/src/Devolutions.AvaloniaControls/Controls/GroupedTileListBox/GroupedTileListBox.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/GroupedTileListBox/GroupedTileListBox.axaml.cs
@@ -21,7 +21,7 @@ using Devolutions.AvaloniaControls.Helpers;
 /// Items are displayed in a wrapping grid with uniform tile sizes.
 /// </summary>
 [TemplatePart("PART_ScrollViewer", typeof(ScrollViewer), IsRequired = true)]
-[TemplatePart("PART_SelectionRectangle", typeof(Border))]
+[TemplatePart("PART_SelectionRectangle", typeof(RectangleSelectionMarquee))]
 [RequiresUnreferencedCode("BindingEvaluator require preserved types")]
 public class GroupedTileListBox : TemplatedControl
 {
@@ -112,7 +112,7 @@ public class GroupedTileListBox : TemplatedControl
     private ItemsRepeater? itemsRepeater;
     private ScrollViewer? scrollViewer;
     private Control? content;
-    private Border? selectionRectangle;
+    private RectangleSelectionMarquee? selectionRectangle;
 
     // --- Marquee (drag-to-select rectangle) state ---
     // Pixels the pointer must travel from the press point before a press becomes a marquee drag
@@ -362,7 +362,7 @@ public class GroupedTileListBox : TemplatedControl
         this.scrollViewer = e.NameScope.Get<ScrollViewer>("PART_ScrollViewer");
 
         // Optional: templates that omit the marquee overlay simply have no rubber-band visual.
-        this.selectionRectangle = e.NameScope.Find<Border>("PART_SelectionRectangle");
+        this.selectionRectangle = e.NameScope.Find<RectangleSelectionMarquee>("PART_SelectionRectangle");
 
         // Always create ItemsRepeater(s) dynamically in UpdateItemsRepeater
         this.UpdateItemsRepeater();

--- a/src/Devolutions.AvaloniaControls/Controls/RectangleSelectionMarquee.axaml
+++ b/src/Devolutions.AvaloniaControls/Controls/RectangleSelectionMarquee.axaml
@@ -1,0 +1,20 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <Design.PreviewWith>
+    <RectangleSelectionMarquee Width="100" Height="100" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type RectangleSelectionMarquee}" TargetType="RectangleSelectionMarquee">
+    <Setter Property="Background" Value="{DynamicResource RectangleSelectionMarqueeFill}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource RectangleSelectionMarqueeBorderBrush}" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border
+          Background="{TemplateBinding Background}"
+          BorderBrush="{TemplateBinding BorderBrush}"
+          BorderThickness="{TemplateBinding BorderThickness}" />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Devolutions.AvaloniaControls/Controls/RectangleSelectionMarquee.axaml.cs
+++ b/src/Devolutions.AvaloniaControls/Controls/RectangleSelectionMarquee.axaml.cs
@@ -1,0 +1,5 @@
+using Avalonia.Controls.Primitives;
+
+namespace Devolutions.AvaloniaControls.Controls;
+
+public class RectangleSelectionMarquee : TemplatedControl;

--- a/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
+++ b/src/Devolutions.AvaloniaControls/DefaultControlTemplates.axaml
@@ -33,6 +33,8 @@
         <MergeResourceInclude Source="Controls/GroupedComboBox/GroupedComboBoxHeaderItem.axaml" />
 
         <MergeResourceInclude Source="Controls/EnumPicker/EnumPicker.axaml" />
+        
+        <MergeResourceInclude Source="Controls/RectangleSelectionMarquee.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>
 

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/ThemeResources.axaml
@@ -408,6 +408,12 @@
   <converters:CornerRadiusToDoubleConverter x:Key="BottomRightCornerRadiusConverter" Corner="BottomRight" />
 
 
+  <!-- RectangleSelectionMarquee colors -->
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeFill"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeBorderBrush"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.8" />
+  
   <!--
     TextBox context menu strings. Cut/Copy/Paste come from Avalonia.Themes.Fluent's
     InvariantResources.xaml, which also is English-only with no per-culture

--- a/src/Devolutions.AvaloniaTheme.Linux/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Accents/ThemeResources.axaml
@@ -317,6 +317,13 @@
   <converters:CornerRadiusToDoubleConverter x:Key="BottomRightCornerRadiusConverter" Corner="BottomRight" />
 
 
+  <!-- RectangleSelectionMarquee colors -->
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeFill"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeBorderBrush"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.8" />
+
+
   <!--
     TextBox context menu strings. Cut/Copy/Paste come from Avalonia.Themes.Fluent's
     InvariantResources.xaml, which also is English-only with no per-culture

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -231,6 +231,12 @@
       <SolidColorBrush x:Key="HyperlinkButtonBorderPointerOverBrush" Color="Transparent" />
       <SolidColorBrush x:Key="HyperlinkButtonBorderPressedBrush" Color="Transparent" />
       <SolidColorBrush x:Key="HyperlinkButtonBorderDisabledBrush" Color="Transparent" />
+      
+      <!-- RectangleSelectionMarquee colors -->
+      <SolidColorBrush x:Key="RectangleSelectionMarqueeFill"
+                       Color="Black" Opacity="0.1" />
+      <SolidColorBrush x:Key="RectangleSelectionMarqueeBorderBrush"
+                       Color="Black" Opacity="0.3" />
 
     </ResourceDictionary>
 
@@ -461,6 +467,12 @@
       <SolidColorBrush x:Key="HyperlinkButtonBorderPointerOverBrush" Color="Transparent" />
       <SolidColorBrush x:Key="HyperlinkButtonBorderPressedBrush" Color="Transparent" />
       <SolidColorBrush x:Key="HyperlinkButtonBorderDisabledBrush" Color="Transparent" />
+      
+      <!-- RectangleSelectionMarquee colors -->
+      <SolidColorBrush x:Key="RectangleSelectionMarqueeFill"
+                       Color="White" Opacity="0.1" />
+      <SolidColorBrush x:Key="RectangleSelectionMarqueeBorderBrush"
+                       Color="White" Opacity="0.3" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 

--- a/src/Devolutions.AvaloniaTheme.WinUI/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.WinUI/Accents/ThemeResources.axaml
@@ -94,5 +94,12 @@
 
   <!-- DEVELOPMENT ONLY -->
   <SolidColorBrush x:Key="SampleAppBackground" Color="{DynamicResource SystemAltHighColor}" />
+
+
+  <!-- RectangleSelectionMarquee colors -->
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeFill"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.2" />
+  <SolidColorBrush x:Key="RectangleSelectionMarqueeBorderBrush"
+                   Color="{DynamicResource SystemAccentColor}" Opacity="0.8" />
   
 </ResourceDictionary>


### PR DESCRIPTION
## Summary

Extracts the `GroupedTileListBox` drag-to-select rubber-band into a dedicated, reusable `RectangleSelectionMarquee` templated control, and gives each theme control over the marquee's fill and border colours.

Previously the marquee was an inline `Border` in the `GroupedTileListBox` template, tinted with `SystemAccentColor` via brushes defined locally in `GroupedTileListBox.axaml`. This meant the marquee looked identical across all themes and couldn't be restyled independently. This PR:

- Adds `RectangleSelectionMarquee` (`TemplatedControl`) with its own `ControlTheme` in `Devolutions.AvaloniaControls`, registered through `DefaultControlTemplates.axaml`.
- Replaces the inline `Border` in `GroupedTileListBox` with the new control (template part type updated accordingly).
- Introduces `RectangleSelectionMarqueeFill` / `RectangleSelectionMarqueeBorderBrush` resources per theme:
  - **DevExpress** and **Linux (Yaru)**: accent-tinted (`SystemAccentColor`), matching the previous Explorer-style rubber-band.
  - **macOS**: neutral black/white tint (light/dark) for a more native AppKit-style selection rectangle.

Builds on the drag-to-select marquee introduced in #602.

## Changes

- `RectangleSelectionMarquee.axaml` / `.axaml.cs` — new control + default template
- `GroupedTileListBox.axaml` / `.axaml.cs` — use the new control; drop local brush definitions
- `DefaultControlTemplates.axaml` — register the new control theme
- `ThemeResources.axaml` (DevExpress, Linux, macOS) — per-theme marquee brushes
