### PR TITLE
Hide menu pack demo from simple

### DIFF
--- a/samples/SampleApp/DemoPages/MenuPackAbout.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackAbout.axaml
@@ -44,7 +44,8 @@
 
     <TextBlock Classes="h1">Isolation Demo</TextBlock>
 
-    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+    <Border x:Name="SimpleThemePrerequisiteNote"
+            IsVisible="{ext:ThemeIsOneOf 'Simple'}"
             Padding="12"
             CornerRadius="6"
             BorderBrush="{DynamicResource LayoutBorderMidBrush}"
@@ -55,81 +56,83 @@
       </TextBlock>
     </Border>
 
-    <Border IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}"
-            BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
-      <StackPanel Spacing="10">
-        <TextBlock Classes="section-title">Non-menu controls stay host-themed</TextBlock>
-        <TextBlock TextWrapping="Wrap">
-          These controls are outside any menu scope and remain styled by the selected host theme.
-        </TextBlock>
+    <StackPanel x:Name="SupportedDemoRoot"
+                IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}"
+                Spacing="14">
+      <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+        <StackPanel Spacing="10">
+          <TextBlock Classes="section-title">Non-menu controls stay host-themed</TextBlock>
+          <TextBlock TextWrapping="Wrap">
+            These controls are outside any menu scope and remain styled by the selected host theme.
+          </TextBlock>
 
-        <Separator />
+          <Separator />
 
-        <WrapPanel ItemWidth="180" Orientation="Horizontal">
-          <Button Margin="0 0 10 10" Content="Button" />
+          <WrapPanel ItemWidth="180" Orientation="Horizontal">
+            <Button Margin="0 0 10 10" Content="Button" />
 
-          <ComboBox Margin="0 0 10 10" SelectedIndex="2" Width="170">
-            <ComboBoxItem>Option 1</ComboBoxItem>
-            <ComboBoxItem IsEnabled="False">Option 2</ComboBoxItem>
-            <ComboBoxItem>ComobBox</ComboBoxItem>
-            <ComboBoxItem>Option 4</ComboBoxItem>
-          </ComboBox>
+            <ComboBox Margin="0 0 10 10" SelectedIndex="2" Width="170">
+              <ComboBoxItem>Option 1</ComboBoxItem>
+              <ComboBoxItem IsEnabled="False">Option 2</ComboBoxItem>
+              <ComboBoxItem>ComobBox</ComboBoxItem>
+              <ComboBoxItem>Option 4</ComboBoxItem>
+            </ComboBox>
 
-          <TextBox Margin="0 0 10 10" Width="170" Watermark="TextBox" />
+            <TextBox Margin="0 0 10 10" Width="170" Watermark="TextBox" />
 
-          <CheckBox Margin="0 0 10 10" Content="CheckBox" IsChecked="True" />
-        </WrapPanel>
-      </StackPanel>
-    </Border>
-
-    <Border IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}"
-            BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
-      <StackPanel Spacing="10">
-        <TextBlock Classes="section-title">Menus get the DevExpress theme from the MenuPack</TextBlock>
-
-        <StackPanel Orientation="Horizontal" Spacing="30">
-
-          <StackPanel Spacing="10" VerticalAlignment="Top">
-            <Button Content="Right-click for ContextMenu">
-              <Button.ContextMenu>
-                <ContextMenu>
-                  <MenuItem Header="Refresh" />
-                  <MenuItem Header="Rename" />
-                  <Separator />
-                  <MenuItem Header="Delete" />
-                </ContextMenu>
-              </Button.ContextMenu>
-            </Button>
-
-            <Button Content="Click for MenuFlyout">
-              <Button.Flyout>
-                <MenuFlyout>
-                  <MenuItem Header="Settings" />
-                  <MenuItem Header="Profile" />
-                  <Separator />
-                  <MenuItem Header="Sign out" />
-                </MenuFlyout>
-              </Button.Flyout>
-            </Button>
-          </StackPanel>
-
-            <MenuFlyoutPresenter>
-              <MenuItem Header="Open session" />
-              <MenuItem Header="Open with parameters" IsSubMenuOpen="True">
-                <MenuItem Header="Embedded/tabbed" />
-                <MenuItem Header="Embedded SFTP connection" />
-                <MenuItem Header="Embedded SCP connection" IsEnabled="False" />
-              </MenuItem>
-              <MenuItem Header="Copy name" />
-              <Separator />
-              <MenuItem Header="Toggle Options" IsSubMenuOpen="True">
-                <MenuItem Header="Option 1" ToggleType="CheckBox" />
-                <MenuItem Header="Option 2" ToggleType="CheckBox" IsChecked="True" />
-              </MenuItem>
-            </MenuFlyoutPresenter>
-
+            <CheckBox Margin="0 0 10 10" Content="CheckBox" IsChecked="True" />
+          </WrapPanel>
         </StackPanel>
-      </StackPanel>
-    </Border>
+      </Border>
+
+      <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+        <StackPanel Spacing="10">
+          <TextBlock Classes="section-title">Menus get the DevExpress theme from the MenuPack</TextBlock>
+
+          <StackPanel Orientation="Horizontal" Spacing="30">
+
+            <StackPanel Spacing="10" VerticalAlignment="Top">
+              <Button Content="Right-click for ContextMenu">
+                <Button.ContextMenu>
+                  <ContextMenu>
+                    <MenuItem Header="Refresh" />
+                    <MenuItem Header="Rename" />
+                    <Separator />
+                    <MenuItem Header="Delete" />
+                  </ContextMenu>
+                </Button.ContextMenu>
+              </Button>
+
+              <Button Content="Click for MenuFlyout">
+                <Button.Flyout>
+                  <MenuFlyout>
+                    <MenuItem Header="Settings" />
+                    <MenuItem Header="Profile" />
+                    <Separator />
+                    <MenuItem Header="Sign out" />
+                  </MenuFlyout>
+                </Button.Flyout>
+              </Button>
+            </StackPanel>
+
+              <MenuFlyoutPresenter>
+                <MenuItem Header="Open session" />
+                <MenuItem Header="Open with parameters" IsSubMenuOpen="True">
+                  <MenuItem Header="Embedded/tabbed" />
+                  <MenuItem Header="Embedded SFTP connection" />
+                  <MenuItem Header="Embedded SCP connection" IsEnabled="False" />
+                </MenuItem>
+                <MenuItem Header="Copy name" />
+                <Separator />
+                <MenuItem Header="Toggle Options" IsSubMenuOpen="True">
+                  <MenuItem Header="Option 1" ToggleType="CheckBox" />
+                  <MenuItem Header="Option 2" ToggleType="CheckBox" IsChecked="True" />
+                </MenuItem>
+              </MenuFlyoutPresenter>
+
+          </StackPanel>
+        </StackPanel>
+      </Border>
+    </StackPanel>
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackAbout.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackAbout.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ext="clr-namespace:SampleApp.MarkupExtensions"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackAbout">
 
@@ -43,7 +44,19 @@
 
     <TextBlock Classes="h1">Isolation Demo</TextBlock>
 
-    <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+            Padding="12"
+            CornerRadius="6"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="1"
+            Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <TextBlock TextWrapping="Wrap">
+        MenuPack demos require Fluent or a Fluent-based theme. The Simple theme is not supported because MenuPack depends on Fluent menu infrastructure.
+      </TextBlock>
+    </Border>
+
+    <Border IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}"
+            BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
       <StackPanel Spacing="10">
         <TextBlock Classes="section-title">Non-menu controls stay host-themed</TextBlock>
         <TextBlock TextWrapping="Wrap">
@@ -69,7 +82,8 @@
       </StackPanel>
     </Border>
 
-    <Border BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
+    <Border IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}"
+            BorderBrush="{DynamicResource SeparatorBrush}" BorderThickness="1" CornerRadius="6" Padding="10">
       <StackPanel Spacing="10">
         <TextBlock Classes="section-title">Menus get the DevExpress theme from the MenuPack</TextBlock>
 

--- a/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ext="clr-namespace:SampleApp.MarkupExtensions"
              xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackContextMenuDemo">
@@ -10,5 +11,19 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <demo:ContextMenuDemo />
+  <StackPanel>
+    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+            Margin="20"
+            Padding="12"
+            CornerRadius="6"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="1"
+            Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <TextBlock TextWrapping="Wrap">
+        MenuPack demos require Fluent or a Fluent-based theme. The Simple theme is not supported because MenuPack depends on Fluent menu infrastructure.
+      </TextBlock>
+    </Border>
+
+    <demo:ContextMenuDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+  </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackContextMenuDemo.axaml
@@ -12,7 +12,8 @@
   </UserControl.Styles>
 
   <StackPanel>
-    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+    <Border x:Name="SimpleThemePrerequisiteNote"
+            IsVisible="{ext:ThemeIsOneOf 'Simple'}"
             Margin="20"
             Padding="12"
             CornerRadius="6"
@@ -24,6 +25,7 @@
       </TextBlock>
     </Border>
 
-    <demo:ContextMenuDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+    <demo:ContextMenuDemo x:Name="SupportedDemoRoot"
+                          IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
@@ -12,7 +12,8 @@
   </UserControl.Styles>
 
   <StackPanel>
-    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+    <Border x:Name="SimpleThemePrerequisiteNote"
+            IsVisible="{ext:ThemeIsOneOf 'Simple'}"
             Margin="20"
             Padding="12"
             CornerRadius="6"
@@ -24,6 +25,7 @@
       </TextBlock>
     </Border>
 
-    <demo:MenuDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+    <demo:MenuDemo x:Name="SupportedDemoRoot"
+                   IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
   </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ext="clr-namespace:SampleApp.MarkupExtensions"
              xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackMenuDemo">
@@ -10,5 +11,19 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <demo:MenuDemo />
+  <StackPanel>
+    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+            Margin="20"
+            Padding="12"
+            CornerRadius="6"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="1"
+            Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <TextBlock TextWrapping="Wrap">
+        MenuPack demos require Fluent or a Fluent-based theme. The Simple theme is not supported because MenuPack depends on Fluent menu infrastructure.
+      </TextBlock>
+    </Border>
+
+    <demo:MenuDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+  </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ext="clr-namespace:SampleApp.MarkupExtensions"
              xmlns:demo="clr-namespace:SampleApp.DemoPages"
              mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="640"
              x:Class="SampleApp.DemoPages.MenuPackMenuFlyoutDemo">
@@ -10,5 +11,19 @@
     <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
   </UserControl.Styles>
 
-  <demo:MenuFlyoutDemo />
+  <StackPanel>
+    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+            Margin="20"
+            Padding="12"
+            CornerRadius="6"
+            BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+            BorderThickness="1"
+            Background="{DynamicResource LayoutBackgroundLowBrush}">
+      <TextBlock TextWrapping="Wrap">
+        MenuPack demos require Fluent or a Fluent-based theme. The Simple theme is not supported because MenuPack depends on Fluent menu infrastructure.
+      </TextBlock>
+    </Border>
+
+    <demo:MenuFlyoutDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+  </StackPanel>
 </UserControl>

--- a/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
+++ b/samples/SampleApp/DemoPages/MenuPackMenuFlyoutDemo.axaml
@@ -12,7 +12,8 @@
   </UserControl.Styles>
 
   <StackPanel>
-    <Border IsVisible="{ext:ThemeIsOneOf 'Simple'}"
+    <Border x:Name="SimpleThemePrerequisiteNote"
+            IsVisible="{ext:ThemeIsOneOf 'Simple'}"
             Margin="20"
             Padding="12"
             CornerRadius="6"
@@ -24,6 +25,7 @@
       </TextBlock>
     </Border>
 
-    <demo:MenuFlyoutDemo IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
+    <demo:MenuFlyoutDemo x:Name="SupportedDemoRoot"
+                         IsVisible="{ext:ThemeIsOneOf 'Fluent, MacClassic, LiquidGlass, DevExpress, Linux, WinUI'}" />
   </StackPanel>
 </UserControl>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -90,7 +90,7 @@ In your App.axaml, replace the existing theme (e.g. `<FluentTheme />` or `<Simpl
 
 ### Menu pack (menu controls only)
 
-Use the menu pack when you only want DevExpress menu styling without importing the full `<DevolutionsDevExpressTheme />`.
+Use the menu pack when you only want DevExpress menu styling but not the full `<DevolutionsDevExpressTheme />` (e.g. to give consistent Menu chrome to custom-branded sections of your app).
 
 ```xaml
 <Application ...>

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -311,6 +311,33 @@ public class MenuPackContractTests
             $"  host + menu pack : {withPack}");
     }
 
+    /// <summary>
+    /// MenuPack demo pages should stay navigable under SimpleTheme and show
+    /// prerequisite guidance instead of crashing.
+    /// </summary>
+    [AvaloniaTheory]
+    [MemberData(nameof(SimplePackPageCases))]
+    public void MenuPack_demo_pages_do_not_crash_on_simple_theme(Type pageType)
+    {
+        App.CurrentTheme = null;
+        App.SetTheme(new SimpleTheme());
+
+        var content = (Control)Activator.CreateInstance(pageType)!;
+        var window = new Window { Width = 1200, Height = 920, Content = content };
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
     public static IEnumerable<object[]> PackPageCases()
     {
         Type[] pages =
@@ -333,5 +360,13 @@ public class MenuPackContractTests
                 yield return [page, host];
             }
         }
+    }
+
+    public static IEnumerable<object[]> SimplePackPageCases()
+    {
+        yield return [typeof(MenuPackAbout)];
+        yield return [typeof(MenuPackMenuDemo)];
+        yield return [typeof(MenuPackContextMenuDemo)];
+        yield return [typeof(MenuPackMenuFlyoutDemo)];
     }
 }

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -329,6 +329,14 @@ public class MenuPackContractTests
         {
             window.Show();
             Dispatcher.UIThread.RunJobs();
+
+            var note = content.FindControl<Control>("SimpleThemePrerequisiteNote");
+            var supportedContent = content.FindControl<Control>("SupportedDemoRoot");
+
+            Assert.NotNull(note);
+            Assert.NotNull(supportedContent);
+            Assert.True(note.IsVisible, $"{pageType.Name}: Simple prerequisite note should be visible.");
+            Assert.False(supportedContent.IsVisible, $"{pageType.Name}: MenuPack demo content should be hidden on Simple.");
         }
         finally
         {


### PR DESCRIPTION
This just hides the MenuPack demos from #597 when the SampleApp is switched to Simple, since the MenuPack requires a Fluent-based theme as the base theme