### PR TITLE
[MacOS] Fix focus ring bleeding past scroll viewports

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -56,21 +56,22 @@
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                             FontSize="{TemplateBinding FontSize}"
                             FontWeight="{TemplateBinding FontWeight}" />
+          <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+               clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+          <Border Name="FocusRing"
+                  IsVisible="False"
+                  IsHitTestVisible="False"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  BorderBrush="{DynamicResource FocusBorderBrush}"
+                  CornerRadius="7" />
         </Panel>
       </ControlTemplate>
     </Setter>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^:pressed">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -36,44 +36,57 @@
     <Setter Property="Template">
       <ControlTemplate>
         <Grid ColumnDefinitions="Auto,5,*" MinHeight="20" ClipToBounds="False">
-          <Border
-            Name="ControlBorder"
-            Width="{DynamicResource CheckBoxSize}"
-            Height="{DynamicResource CheckBoxSize}"
-            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-            Background="{TemplateBinding Background}"
-            BorderBrush="{TemplateBinding BorderBrush}"
-            BorderThickness="{TemplateBinding BorderThickness}"
-            CornerRadius="{TemplateBinding CornerRadius}"
-            BoxShadow="{DynamicResource CheckBoxBoxShadow}">
-            <Panel>
-              <Path
-                Name="CheckMark"
-                IsVisible="False"
-                Width="{DynamicResource CheckBoxCheckMarkSize}"
-                Height="{DynamicResource CheckBoxCheckMarkSize}"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Data="{DynamicResource CheckMarkPath}"
-                FlowDirection="LeftToRight"
-                Stretch="Fill"
-                Fill="{WindowActiveBindingToggler
-                    {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxCheckMarkBrush, CheckBoxDisabledCheckMarkBrush},
-                    {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxInactiveCheckMarkBrush, CheckBoxDisabledInactiveCheckMarkBrush}}" />
+          <!-- Wrapper sizes to the check box so the focus ring (overlay sibling) hugs the box,
+               not the whole control, while being clipped by ancestor scroll viewers. -->
+          <Panel Grid.Column="0"
+                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                 ClipToBounds="False">
+            <Border
+              Name="ControlBorder"
+              Width="{DynamicResource CheckBoxSize}"
+              Height="{DynamicResource CheckBoxSize}"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              BoxShadow="{DynamicResource CheckBoxBoxShadow}">
+              <Panel>
+                <Path
+                  Name="CheckMark"
+                  IsVisible="False"
+                  Width="{DynamicResource CheckBoxCheckMarkSize}"
+                  Height="{DynamicResource CheckBoxCheckMarkSize}"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Data="{DynamicResource CheckMarkPath}"
+                  FlowDirection="LeftToRight"
+                  Stretch="Fill"
+                  Fill="{WindowActiveBindingToggler
+                      {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxCheckMarkBrush, CheckBoxDisabledCheckMarkBrush},
+                      {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxInactiveCheckMarkBrush, CheckBoxDisabledInactiveCheckMarkBrush}}" />
 
-              <Rectangle
-                Name="IndeterminateMark"
-                IsVisible="False"
-                Width="{DynamicResource CheckBoxIndeterminateMarkWidth}"
-                Height="{DynamicResource CheckBoxIndeterminateMarkHeight}"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Stretch="Uniform"
-                Fill="{WindowActiveBindingToggler
-                    {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxCheckMarkBrush, CheckBoxDisabledCheckMarkBrush},
-                    {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxInactiveCheckMarkBrush, CheckBoxDisabledInactiveCheckMarkBrush}}" />
-            </Panel>
-          </Border>
+                <Rectangle
+                  Name="IndeterminateMark"
+                  IsVisible="False"
+                  Width="{DynamicResource CheckBoxIndeterminateMarkWidth}"
+                  Height="{DynamicResource CheckBoxIndeterminateMarkHeight}"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Stretch="Uniform"
+                  Fill="{WindowActiveBindingToggler
+                      {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxCheckMarkBrush, CheckBoxDisabledCheckMarkBrush},
+                      {DynamicResourceToggler {Binding $parent[CheckBox].IsEnabled}, CheckBoxInactiveCheckMarkBrush, CheckBoxDisabledInactiveCheckMarkBrush}}" />
+              </Panel>
+            </Border>
+            <!-- In-template focus ring (see TextBox.axaml). -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="5" />
+          </Panel>
           <ContentPresenter
             Name="PART_ContentPresenter"
             Grid.Column="2"
@@ -91,16 +104,8 @@
     </Setter>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible /template/ Border#ControlBorder">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="5" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <!--  Checked State  -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -321,6 +321,15 @@
                 </Border>
               </Border>
             </Popup>
+            <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+                 clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="7" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -337,16 +346,8 @@
     </Style>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^:disabled">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
@@ -69,21 +69,22 @@
               </PathIcon.RenderTransform>
             </PathIcon>
           </Grid>
+          <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+               clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+          <Border Name="FocusRing"
+                  IsVisible="False"
+                  IsHitTestVisible="False"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  BorderBrush="{DynamicResource FocusBorderBrush}"
+                  CornerRadius="7" />
         </Panel>
       </ControlTemplate>
     </Setter>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^:pressed">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
@@ -158,6 +158,16 @@
                   </PathIcon>
                 </Border>
               </Grid>
+              <!-- In-template focus ring (see TextBox.axaml). The ValuePicker variant supplies its
+                   own template, so it needs its own ring; the ^:focus-visible toggle below matches
+                   any FocusRing in the active template. -->
+              <Border Name="FocusRing"
+                      IsVisible="False"
+                      IsHitTestVisible="False"
+                      Margin="{StaticResource FocusBorderMargin}"
+                      BorderThickness="{StaticResource FocusBorderThickness}"
+                      BorderBrush="{DynamicResource FocusBorderBrush}"
+                      CornerRadius="7" />
             </Panel>
           </ControlTemplate>
         </Setter.Value>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -340,6 +340,17 @@
                 </Border>
               </Popup>
             </Grid>
+            <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+                 clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer.
+                 ZIndex 2 keeps it above BorderHighlightElement (ZIndex 1). -->
+            <Border Name="FocusRing"
+                    ZIndex="2"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="7" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -357,16 +368,8 @@
     </Style>
 
     <!--  Focused State  -->
-    <Style Selector="^:focus-within, ^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-within /template/ Border#FocusRing, ^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^ /template/ Border#DropDownGlyphBackground:pointerover">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
@@ -158,21 +158,22 @@
               </MultiBinding>
             </Border.BorderThickness>
           </Border>
+          <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+               clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+          <Border Name="FocusRing"
+                  IsVisible="False"
+                  IsHitTestVisible="False"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  BorderBrush="{DynamicResource FocusBorderBrush}"
+                  CornerRadius="{Binding $parent[ToggleButton].CornerRadius}" />
         </Panel>
       </ControlTemplate>
     </Setter>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="{Binding $parent[ToggleButton].CornerRadius}" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^[Tag=expanded]">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
@@ -31,36 +31,49 @@
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="RootPanel"
-                CornerRadius="{TemplateBinding CornerRadius}"
-                Background="Transparent">
-          <DockPanel Margin="{TemplateBinding Padding}">
-            <Path Name="CheckMark"
-                  DockPanel.Dock="Left"
-                  Width="10"
-                  Height="10"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Center"
-                  Data="{DynamicResource CheckMarkPath}"
-                  Fill="Transparent"
-                  FlowDirection="LeftToRight"
-                  Stretch="Fill">
-              <Path.IsVisible>
-                <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ListBox}" Path="Classes" Converter="{x:Static DevoConverters.HasNotClass}"
-                         ConverterParameter="selection_checkmark_off" />
-              </Path.IsVisible>
-            </Path>
-            <ContentPresenter Name="PART_ContentPresenter"
-                              Padding=" 4 0 2 0"
-                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                              Foreground="{TemplateBinding Foreground}"
-                              BorderBrush="{TemplateBinding BorderBrush}"
-                              BorderThickness="{TemplateBinding BorderThickness}"
-                              Content="{TemplateBinding Content}"
-                              ContentTemplate="{TemplateBinding ContentTemplate}" />
-          </DockPanel>
-        </Border>
+        <!-- Wrapper hosts the focus ring as an overlay sibling so it is clipped by ancestor
+             scroll viewers (e.g. the list's own ScrollViewer) instead of bleeding via the
+             AdornerLayer. -->
+        <Panel ClipToBounds="False">
+          <Border Name="RootPanel"
+                  CornerRadius="{TemplateBinding CornerRadius}"
+                  Background="Transparent">
+            <DockPanel Margin="{TemplateBinding Padding}">
+              <Path Name="CheckMark"
+                    DockPanel.Dock="Left"
+                    Width="10"
+                    Height="10"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Data="{DynamicResource CheckMarkPath}"
+                    Fill="Transparent"
+                    FlowDirection="LeftToRight"
+                    Stretch="Fill">
+                <Path.IsVisible>
+                  <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=ListBox}" Path="Classes" Converter="{x:Static DevoConverters.HasNotClass}"
+                           ConverterParameter="selection_checkmark_off" />
+                </Path.IsVisible>
+              </Path>
+              <ContentPresenter Name="PART_ContentPresenter"
+                                Padding=" 4 0 2 0"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                Foreground="{TemplateBinding Foreground}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+            </DockPanel>
+          </Border>
+          <!-- In-template focus ring (see TextBox.axaml). -->
+          <Border Name="FocusRing"
+                  IsVisible="False"
+                  IsHitTestVisible="False"
+                  Margin="{StaticResource FocusBorderMargin}"
+                  BorderThickness="{StaticResource FocusBorderThickness}"
+                  BorderBrush="{DynamicResource FocusBorderBrush}"
+                  CornerRadius="7" />
+        </Panel>
       </ControlTemplate>
     </Setter>
     <Style Selector="^:selected /template/ Path#CheckMark">
@@ -84,16 +97,9 @@
 
     <Style Selector="^:focus-visible">
       <Setter Property="ZIndex" Value="1" />
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  IsHitTestVisible="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+      <Style Selector="^ /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
     </Style>
 
   </ControlTheme>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -273,6 +273,15 @@
                 </DockPanel>
               </Border>
             </Popup>
+            <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+                 clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="7" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -297,16 +306,8 @@
     </Style>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^:disabled">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/RadioButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/RadioButton.axaml
@@ -40,26 +40,39 @@
     <Setter Property="Template">
       <ControlTemplate TargetType="RadioButton">
         <Grid ColumnDefinitions="Auto,5,*">
-          <Border
-            Name="ControlBorder"
-            Width="{DynamicResource RadioButtonSize}"
-            Height="{DynamicResource RadioButtonSize}"
-            VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-            Background="{TemplateBinding Background}"
-            BorderBrush="{TemplateBinding BorderBrush}"
-            BorderThickness="{TemplateBinding BorderThickness}"
-            CornerRadius="{TemplateBinding CornerRadius}"
-            BoxShadow="{DynamicResource RadioButtonBoxShadow}">
-            <Ellipse
-              Name="CheckGlyph"
-              IsVisible="False"
-              Width="{DynamicResource RadioButtonCheckMarkSize}"
-              Height="{DynamicResource RadioButtonCheckMarkSize}"
-              Fill="{WindowActiveBindingToggler
-                    {DynamicResourceToggler {Binding $parent[RadioButton].IsEnabled}, RadioButtonCheckMarkBrush, RadioButtonDisabledCheckMarkBrush},
-                    {DynamicResourceToggler {Binding $parent[RadioButton].IsEnabled}, RadioButtonInactiveCheckMarkBrush, RadioButtonDisabledInactiveCheckMarkBrush}}"
-              UseLayoutRounding="False" />
-          </Border>
+          <!-- Wrapper sizes to the radio button so the focus ring (overlay sibling) hugs the circle,
+               not the whole control, while being clipped by ancestor scroll viewers. -->
+          <Panel Grid.Column="0"
+                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                 ClipToBounds="False">
+            <Border
+              Name="ControlBorder"
+              Width="{DynamicResource RadioButtonSize}"
+              Height="{DynamicResource RadioButtonSize}"
+              Background="{TemplateBinding Background}"
+              BorderBrush="{TemplateBinding BorderBrush}"
+              BorderThickness="{TemplateBinding BorderThickness}"
+              CornerRadius="{TemplateBinding CornerRadius}"
+              BoxShadow="{DynamicResource RadioButtonBoxShadow}">
+              <Ellipse
+                Name="CheckGlyph"
+                IsVisible="False"
+                Width="{DynamicResource RadioButtonCheckMarkSize}"
+                Height="{DynamicResource RadioButtonCheckMarkSize}"
+                Fill="{WindowActiveBindingToggler
+                      {DynamicResourceToggler {Binding $parent[RadioButton].IsEnabled}, RadioButtonCheckMarkBrush, RadioButtonDisabledCheckMarkBrush},
+                      {DynamicResourceToggler {Binding $parent[RadioButton].IsEnabled}, RadioButtonInactiveCheckMarkBrush, RadioButtonDisabledInactiveCheckMarkBrush}}"
+                UseLayoutRounding="False" />
+            </Border>
+            <!-- In-template focus ring (see TextBox.axaml). -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="10" />
+          </Panel>
 
           <ContentPresenter
             Name="PART_ContentPresenter"
@@ -79,16 +92,8 @@
     </Setter>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible /template/ Border#ControlBorder">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="10" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <!--  Checked State  -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/SplitButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/SplitButton.axaml
@@ -152,20 +152,21 @@
               </PathIcon>
             </Button>
           </Grid>
-        </Panel>
-      </ControlTemplate>
-    </Setter>
-
-    <Style Selector="^:focus-visible">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
+          <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+               clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+          <Border Name="FocusRing"
+                  IsVisible="False"
+                  IsHitTestVisible="False"
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
                   CornerRadius="7" />
-        </Template>
-      </Setter>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^ /template/ Button#PART_PrimaryButton, ^ /template/ Button#PART_SecondaryButton">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
@@ -109,7 +109,8 @@
         </ControlTemplate>
       </Setter>
 
-      <!-- Tabbing focus -->
+      <!-- Tabbing focus. Kept on the AdornerLayer: the tab header's own horizontal ScrollViewer
+           clips its viewport to the tab height, which would crop an in-template ring top/bottom. -->
       <Style Selector="^:focus-visible">
         <Setter Property="AdornerLayer.Adorner">
           <Template>
@@ -161,7 +162,8 @@
         </ControlTemplate>
       </Setter>
 
-      <!-- Tabbing focus -->
+      <!-- Tabbing focus. Kept on the AdornerLayer: the tab header's own horizontal ScrollViewer
+           clips its viewport to the tab height, which would crop an in-template ring top/bottom. -->
       <Style Selector="^:focus-visible">
         <Setter Property="AdornerLayer.Adorner">
           <Template>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
@@ -111,7 +111,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="2" />
+                    CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
@@ -103,6 +103,15 @@
                     CornerRadius="{TemplateBinding CornerRadius}"
                     BoxShadow="{DynamicResource TextBoxBorderShadows}"
                     Margin="0.6 0 0.6 -0.6 " />
+            <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+                 clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="2" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -115,15 +124,9 @@
 
     <!-- Focus state -->
     <Style Selector="^:focus-within">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="2" />
-        </Template>
-      </Setter>
+      <Style Selector="^ /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
       </Style>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -260,6 +260,17 @@
                     CornerRadius="{TemplateBinding CornerRadius}"
                     BoxShadow="{DynamicResource TextBoxBorderShadows}"
                     Margin="0.6 0 0.6 -0.6 " />
+            <!-- In-template focus ring (Option B). Drawn last so it paints on top of the borders.
+                 Unlike the AdornerLayer approach, this lives in the normal visual tree, so it is
+                 clipped by an ancestor ScrollViewer instead of bleeding over content above it.
+                 Relies on ClipToBounds="False" on the control/template to allow the -3 overflow. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>
@@ -312,30 +323,18 @@
 
     <!-- Focused State -->
     <Style Selector="^[IsReadOnly=False]:focus:not(.no-focus-border)">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
-        </Template>
-      </Setter>
+      <Style Selector="^ /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
+      </Style>
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
       </Style>
 
       <Style Selector="^[AcceptsReturn=True]">
         <!-- Revert to default focus radius (2) for square multiline textboxes -->
-        <Setter Property="AdornerLayer.Adorner">
-          <Template>
-            <Border AdornerLayer.IsClipEnabled="False"
-                    Margin="{StaticResource FocusBorderMargin}"
-                    BorderThickness="{StaticResource FocusBorderThickness}"
-                    BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="2" />
-          </Template>
-        </Setter>
+        <Style Selector="^ /template/ Border#FocusRing">
+          <Setter Property="CornerRadius" Value="2" />
+        </Style>
       </Style>
     </Style>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TimePickerUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TimePickerUpDown.axaml
@@ -190,6 +190,15 @@
                       BoxShadow="{DynamicResource TextBoxBorderShadows}"
                       Margin="0.6 0 0.6 -0.6"
                       IsHitTestVisible="False" />
+              <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is
+                   clipped by an ancestor ScrollViewer instead of bleeding via the AdornerLayer. -->
+              <Border Name="FocusRing"
+                      IsVisible="False"
+                      IsHitTestVisible="False"
+                      Margin="{StaticResource FocusBorderMargin}"
+                      BorderThickness="{StaticResource FocusBorderThickness}"
+                      BorderBrush="{DynamicResource FocusBorderBrush}"
+                      CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
             </Grid>
           </ButtonSpinner>
         </DataValidationErrors>
@@ -238,17 +247,8 @@
     </Style>
 
     <Style Selector="^:focus-within">
-      <Style Selector="^ /template/ Grid#PART_InputChrome">
-        <Setter Property="AdornerLayer.Adorner">
-          <Template>
-            <Border AdornerLayer.IsClipEnabled="False"
-                    IsHitTestVisible="False"
-                    Margin="{StaticResource FocusBorderMargin}"
-                    BorderThickness="{StaticResource FocusBorderThickness}"
-                    BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
-          </Template>
-        </Setter>
+      <Style Selector="^ /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
       </Style>
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ToggleSwitch.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ToggleSwitch.axaml
@@ -22,6 +22,7 @@
     <Setter Property="VerticalContentAlignment" Value="Center" />
 
     <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="KnobTransitions">
       <Transitions>
         <DoubleTransition
@@ -32,71 +33,81 @@
     </Setter>
     <Setter Property="Template">
       <ControlTemplate TargetType="ToggleSwitch">
-        <DockPanel HorizontalAlignment="Stretch">
-          <!-- Dock switch on right first -->
-          <Border
-            Name="SwitchBackgroundBorder"
-            DockPanel.Dock="Right"
-            TemplatedControl.IsTemplateFocusTarget="True"
-            Width="{DynamicResource ToggleSwitchDefaultWidth}"
-            Height="{DynamicResource ToggleSwitchDefaultHeight}"
-            BorderBrush="{DynamicResource ToggleSwitchDefaultBorderBrush}"
-            BorderThickness="1"
-            CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}">
-            <Border.Transitions>
-              <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.2" />
-              </Transitions>
-            </Border.Transitions>
-            <Canvas
-              Name="PART_SwitchKnob"
-              Width="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
-              Height="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
-              HorizontalAlignment="Left">
-              <Grid
-                Name="PART_MovingKnobs"
+        <DockPanel HorizontalAlignment="Stretch" ClipToBounds="False">
+          <!-- Dock switch on right first. Wrapper sizes to the switch so the focus ring (overlay
+               sibling) hugs the track while being clipped by ancestor scroll viewers. -->
+          <Panel DockPanel.Dock="Right" VerticalAlignment="Center" ClipToBounds="False">
+            <Border
+              Name="SwitchBackgroundBorder"
+              TemplatedControl.IsTemplateFocusTarget="True"
+              Width="{DynamicResource ToggleSwitchDefaultWidth}"
+              Height="{DynamicResource ToggleSwitchDefaultHeight}"
+              BorderBrush="{DynamicResource ToggleSwitchDefaultBorderBrush}"
+              BorderThickness="1"
+              CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}">
+              <Border.Transitions>
+                <Transitions>
+                  <BrushTransition Property="Background" Duration="0:0:0.2" />
+                </Transitions>
+              </Border.Transitions>
+              <Canvas
+                Name="PART_SwitchKnob"
                 Width="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
                 Height="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
-                Margin="{DynamicResource ToggleSwitchIndicatorDefaultMargin}">
-                <Border
-                  Name="SwitchKnobIndicator"
-                  Background="{DynamicResource ToggleSwitchKnobBackground}"
-                  BoxShadow="{DynamicResource ToggleSwitchIndicatorBoxShadow}"
-                  CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}" />
-                <Arc
-                  Name="SwitchKnobLoadingIndicator"
-                  IsVisible="False"
-                  StrokeThickness="2"
-                  StartAngle="0"
-                  SweepAngle="140"
-                  StrokeJoin="Round"
-                  StrokeLineCap="Round">
-                  <Arc.Stroke>
-                    <ConicGradientBrush>
-                      <GradientStops>
-                        <GradientStop Offset="0.1" Color="Transparent" />
-                        <GradientStop Offset="0.7" Color="White" />
-                      </GradientStops>
-                    </ConicGradientBrush>
-                  </Arc.Stroke>
-                  <Arc.Styles>
-                    <Style Selector="Arc[IsVisible=True]">
-                      <Style.Animations>
-                        <Animation IterationCount="Infinite" Duration="0:0:0.6">
-                          <KeyFrame Cue="0%">
-                            <Setter Property="RotateTransform.Angle" Value="0.0" />
-                          </KeyFrame>
-                          <KeyFrame Cue="100%">
-                            <Setter Property="RotateTransform.Angle" Value="360.0" />
-                          </KeyFrame>
-                        </Animation>
-                      </Style.Animations>
-                    </Style>
-                  </Arc.Styles>
-                </Arc>
-              </Grid>
-            </Canvas>
-          </Border>
+                HorizontalAlignment="Left">
+                <Grid
+                  Name="PART_MovingKnobs"
+                  Width="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                  Height="{DynamicResource ToggleSwitchIndicatorDefaultWidth}"
+                  Margin="{DynamicResource ToggleSwitchIndicatorDefaultMargin}">
+                  <Border
+                    Name="SwitchKnobIndicator"
+                    Background="{DynamicResource ToggleSwitchKnobBackground}"
+                    BoxShadow="{DynamicResource ToggleSwitchIndicatorBoxShadow}"
+                    CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}" />
+                  <Arc
+                    Name="SwitchKnobLoadingIndicator"
+                    IsVisible="False"
+                    StrokeThickness="2"
+                    StartAngle="0"
+                    SweepAngle="140"
+                    StrokeJoin="Round"
+                    StrokeLineCap="Round">
+                    <Arc.Stroke>
+                      <ConicGradientBrush>
+                        <GradientStops>
+                          <GradientStop Offset="0.1" Color="Transparent" />
+                          <GradientStop Offset="0.7" Color="White" />
+                        </GradientStops>
+                      </ConicGradientBrush>
+                    </Arc.Stroke>
+                    <Arc.Styles>
+                      <Style Selector="Arc[IsVisible=True]">
+                        <Style.Animations>
+                          <Animation IterationCount="Infinite" Duration="0:0:0.6">
+                            <KeyFrame Cue="0%">
+                              <Setter Property="RotateTransform.Angle" Value="0.0" />
+                            </KeyFrame>
+                            <KeyFrame Cue="100%">
+                              <Setter Property="RotateTransform.Angle" Value="360.0" />
+                            </KeyFrame>
+                          </Animation>
+                        </Style.Animations>
+                      </Style>
+                    </Arc.Styles>
+                  </Arc>
+                </Grid>
+              </Canvas>
+            </Border>
+            <!-- In-template focus ring (see TextBox.axaml). -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}" />
+          </Panel>
 
           <!-- Content fills remaining space on left -->
           <ContentPresenter
@@ -168,16 +179,8 @@
     </Style>
 
     <!-- Tabbing focus -->
-    <Style Selector="^:focus-visible /template/ Border#SwitchBackgroundBorder">
-      <Setter Property="AdornerLayer.Adorner">
-        <Template>
-          <Border AdornerLayer.IsClipEnabled="False"
-                  Margin="{StaticResource FocusBorderMargin}"
-                  BorderThickness="{StaticResource FocusBorderThickness}"
-                  BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="{DynamicResource ToggleSwitchIndicatorCornerRadius}" />
-        </Template>
-      </Setter>
+    <Style Selector="^:focus-visible /template/ Border#FocusRing">
+      <Setter Property="IsVisible" Value="True" />
     </Style>
 
     <Style Selector="^.Loading">


### PR DESCRIPTION
## Problem

The macOS theme drew the focus ring via `AdornerLayer.Adorner`, which reparents the ring into the single top-level adorner layer that sits above **all** content. When a focused control lived inside a `ScrollViewer` and was scrolled out of view, its ring kept painting over whatever content sat above/beside the scroller — the adorner is never clipped by the intermediate scroll viewport.

## Fix

Replace the adorner with an in-template `FocusRing` border, toggled by the focus state:

- Hidden by default, `IsHitTestVisible="False"`, with the same margin / thickness / brush / corner-radius the adorner used.
- Because it lives in the normal visual tree, an ancestor `ScrollViewer` clips it — while it still draws *outside* the control bounds via `ClipToBounds="False"`. It is an empty overlay, so it does not affect layout or resize the control.

For controls whose ring hugs a small inner element (CheckBox box, RadioButton circle, ToggleSwitch track) or whose template root wasn't a `Panel` (ListBoxItem), the focus target is wrapped in a `Panel` that hosts the ring as an overlay sibling, so the ring stays anchored to the right element.

## Controls converted (14)

`TextBox`, `Button`, `DropDownButton` (incl. its `.ValuePicker` template), `SplitButton`, `ComboBox`, `MultiComboBox`, `EditableComboBox`, `TagInput`, `Expander`, `TimePickerUpDown`, `CheckBox`, `RadioButton`, `ToggleSwitch`, `ListBoxItem`.

Per-control specifics preserved: corner radii, TagInput's bottom-border accent + LiquidGlass radius, Expander's radius binding to its `ToggleButton`, EditableComboBox's `ZIndex` above its highlight border, TimePickerUpDown's ring anchored to `PART_InputChrome`, ListBoxItem's `ZIndex` bump so a focused item's ring isn't overpainted by neighbors. ToggleSwitch also gained the control-level `ClipToBounds="False"` it was missing.

## Intentionally kept on the AdornerLayer: `TabItem`

TabItem headers live inside the TabControl's own horizontal `ScrollViewer`, whose `ScrollContentPresenter` clips its viewport to the tab height (loose horizontally so tabs can scroll, tight vertically). An in-template ring there is cropped top/bottom, and there's no per-axis clip that would fix it without reintroducing horizontal bleed. Tabs are effectively never scrolled out of an ancestor `ScrollViewer`, so TabItem keeps the adorner. Documented inline so it isn't "fixed" back later.

## Testing

Validated manually in the SampleApp (macOS Classic), including a horizontal scroll-viewer repro on the TextBox page: rings now clip at scroll viewport edges, still render correctly outside the control bounds, and aren't overpainted by neighbors. Checked the wrapped controls (CheckBox / RadioButton / ToggleSwitch / ListBoxItem) for correct ring placement and no layout shift.
