### PR TITLE
[MacOS] Move TabItem/TabPane focus rings off the AdornerLayer

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -621,10 +621,10 @@
 
   <!-- TabControl & TabItem Resources -->
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
-  <!-- Re-insets tabs against PART_TabHeaderScrollViewer's "-6 -6 0 -6" margin so the in-template
-       TabItem focus ring has viewport slack (base positioning value is 0; right stays 0 to avoid
-       the overflow scroll buttons). -->
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">6 6 0 6</Thickness>
+  <!-- 6px all round re-insets tabs against PART_TabHeaderScrollViewer's -6 margin so the
+       in-template TabItem focus ring has viewport slack (base positioning value is 0; the scroll
+       viewer drops its own right slack when the overflow buttons show). -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-2 0 4 0 #40000000</BoxShadows>
   <Thickness x:Key="TabControlTabStripBorderThickness">0.5 0.5 0.5 0.6</Thickness>
   <x:Double x:Key="TabItemDividerHeight">12</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -621,7 +621,9 @@
 
   <!-- TabControl & TabItem Resources -->
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">0</Thickness>
+  <!-- 6px all round re-insets tabs against PART_TabHeaderScrollViewer's -6 margin so the
+       in-template TabItem focus ring has viewport slack (base positioning value is 0). -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-2 0 4 0 #40000000</BoxShadows>
   <Thickness x:Key="TabControlTabStripBorderThickness">0.5 0.5 0.5 0.6</Thickness>
   <x:Double x:Key="TabItemDividerHeight">12</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -621,9 +621,10 @@
 
   <!-- TabControl & TabItem Resources -->
   <Thickness x:Key="TabControlTopPlacementItemMargin">0 0 0 2</Thickness>
-  <!-- 6px all round re-insets tabs against PART_TabHeaderScrollViewer's -6 margin so the
-       in-template TabItem focus ring has viewport slack (base positioning value is 0). -->
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">6</Thickness>
+  <!-- Re-insets tabs against PART_TabHeaderScrollViewer's "-6 -6 0 -6" margin so the in-template
+       TabItem focus ring has viewport slack (base positioning value is 0; right stays 0 to avoid
+       the overflow scroll buttons). -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">6 6 0 6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-2 0 4 0 #40000000</BoxShadows>
   <Thickness x:Key="TabControlTabStripBorderThickness">0.5 0.5 0.5 0.6</Thickness>
   <x:Double x:Key="TabItemDividerHeight">12</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -317,9 +317,10 @@
   <!-- TabControl & TabItem -->
   <Thickness x:Key="TabControlBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0</Thickness>
-  <!-- Base positioning is "2 0 0 0"; +6 all round re-insets tabs against
-       PART_TabHeaderScrollViewer's -6 margin so the in-template TabItem focus ring has slack. -->
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">8 6 6 6</Thickness>
+  <!-- Base positioning is "2 0 0 0"; re-insets tabs against PART_TabHeaderScrollViewer's
+       "-6 -6 0 -6" margin so the in-template TabItem focus ring has slack (right stays 0 to
+       avoid the overflow scroll buttons). -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">8 6 0 6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-1 0 4 0 #40000000</BoxShadows>
   <StaticResource x:Key="TabItemDividerBorderBrush" ResourceKey="SurfaceT10" />
   <Thickness x:Key="TabItemPadding">16 4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -317,10 +317,10 @@
   <!-- TabControl & TabItem -->
   <Thickness x:Key="TabControlBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0</Thickness>
-  <!-- Base positioning is "2 0 0 0"; re-insets tabs against PART_TabHeaderScrollViewer's
-       "-6 -6 0 -6" margin so the in-template TabItem focus ring has slack (right stays 0 to
-       avoid the overflow scroll buttons). -->
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">8 6 0 6</Thickness>
+  <!-- Base positioning is "2 0 0 0"; +6 all round re-insets tabs against
+       PART_TabHeaderScrollViewer's -6 margin so the in-template TabItem focus ring has slack
+       (the scroll viewer drops its own right slack when the overflow buttons show). -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">8 6 6 6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-1 0 4 0 #40000000</BoxShadows>
   <StaticResource x:Key="TabItemDividerBorderBrush" ResourceKey="SurfaceT10" />
   <Thickness x:Key="TabItemPadding">16 4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -317,7 +317,9 @@
   <!-- TabControl & TabItem -->
   <Thickness x:Key="TabControlBorderThickness">0</Thickness>
   <Thickness x:Key="TabControlTabStripBorderThickness">0</Thickness>
-  <Thickness x:Key="TabControlTopItemsPresenterMargin">2 0 0 0</Thickness>
+  <!-- Base positioning is "2 0 0 0"; +6 all round re-insets tabs against
+       PART_TabHeaderScrollViewer's -6 margin so the in-template TabItem focus ring has slack. -->
+  <Thickness x:Key="TabControlTopItemsPresenterMargin">8 6 6 6</Thickness>
   <BoxShadows x:Key="TabControlScrollButtonBoxShadow">-1 0 4 0 #40000000</BoxShadows>
   <StaticResource x:Key="TabItemDividerBorderBrush" ResourceKey="SurfaceT10" />
   <Thickness x:Key="TabItemPadding">16 4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -79,8 +79,14 @@
                         Padding="2 0 0 0">
                   <Grid ColumnDefinitions="*,Auto,Auto"
                         ClipToBounds="False">
+                    <!-- The header viewport otherwise clips to the tab height/width, which would
+                         crop an in-template TabItem focus ring. This negative margin enlarges the
+                         viewport by 6px each side; TabControlTopItemsPresenterMargin re-insets the
+                         tabs by the same 6px so they stay in place, leaving transparent slack
+                         inside the viewport where the ring can draw. Keep the two amounts in sync. -->
                     <ScrollViewer Name="PART_TabHeaderScrollViewer"
                                   Grid.Column="0"
+                                  Margin="-6"
                                   ClipToBounds="False"
                                   HorizontalScrollBarVisibility="Hidden"
                                   VerticalScrollBarVisibility="Hidden">
@@ -185,6 +191,8 @@
         </ControlTemplate>
       </Setter>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter">
+        <!-- Includes +6px on every side to re-inset the tabs against PART_TabHeaderScrollViewer's
+             -6 margin (see there), which keeps them in place while the ring gets viewport slack. -->
         <Setter Property="Margin" Value="{DynamicResource TabControlTopItemsPresenterMargin}" />
       </Style>
       <Style Selector="^/template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -79,16 +79,15 @@
                         Padding="2 0 0 0">
                   <Grid ColumnDefinitions="*,Auto,Auto"
                         ClipToBounds="False">
-                    <!-- The header viewport otherwise clips to the tab height/width, which would
-                         crop an in-template TabItem focus ring. This negative margin enlarges the
-                         viewport by 6px on the left/top/bottom; TabControlTopItemsPresenterMargin
-                         re-insets the tabs by the same amounts so they stay in place, leaving
-                         transparent slack inside the viewport where the ring can draw. The right
-                         side is left at 0 so the viewport does not overlap the overflow scroll
-                         buttons in Column 1. Keep the two amounts in sync. -->
+                    <!-- The header viewport otherwise clips to the tab bounds, cropping an
+                         in-template TabItem focus ring. Enlarge it 6px so the ring has slack;
+                         TabControlTopItemsPresenterMargin re-insets the tabs by the same 6px so
+                         they stay put. The right slack is kept only while the overflow scroll
+                         buttons are hidden; once they appear (Column 1), drop the right side to 0
+                         so the viewport does not overlap them. Keep these amounts in sync. -->
                     <ScrollViewer Name="PART_TabHeaderScrollViewer"
                                   Grid.Column="0"
-                                  Margin="-6 -6 0 -6"
+                                  Margin="{BindingToggler {Binding IsVisible, ElementName=PART_TabScrollLeftButton}, '-6 -6 0 -6', '-6'}"
                                   ClipToBounds="False"
                                   HorizontalScrollBarVisibility="Hidden"
                                   VerticalScrollBarVisibility="Hidden">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabControl.axaml
@@ -81,12 +81,14 @@
                         ClipToBounds="False">
                     <!-- The header viewport otherwise clips to the tab height/width, which would
                          crop an in-template TabItem focus ring. This negative margin enlarges the
-                         viewport by 6px each side; TabControlTopItemsPresenterMargin re-insets the
-                         tabs by the same 6px so they stay in place, leaving transparent slack
-                         inside the viewport where the ring can draw. Keep the two amounts in sync. -->
+                         viewport by 6px on the left/top/bottom; TabControlTopItemsPresenterMargin
+                         re-insets the tabs by the same amounts so they stay in place, leaving
+                         transparent slack inside the viewport where the ring can draw. The right
+                         side is left at 0 so the viewport does not overlap the overflow scroll
+                         buttons in Column 1. Keep the two amounts in sync. -->
                     <ScrollViewer Name="PART_TabHeaderScrollViewer"
                                   Grid.Column="0"
-                                  Margin="-6"
+                                  Margin="-6 -6 0 -6"
                                   ClipToBounds="False"
                                   HorizontalScrollBarVisibility="Hidden"
                                   VerticalScrollBarVisibility="Hidden">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
@@ -105,22 +105,22 @@
                                 CornerRadius="{TemplateBinding CornerRadius}"
                                 RecognizesAccessKey="True" />
             </Border>
+            <!-- In-template focus ring (see TextBox.axaml). The Top/Bottom header ScrollViewer
+                 provides viewport slack (see TabControl.axaml) so this is not clipped. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
+                    Margin="{StaticResource FocusBorderMargin}"
+                    BorderThickness="{StaticResource FocusBorderThickness}"
+                    BorderBrush="{DynamicResource FocusBorderBrush}"
+                    CornerRadius="7" />
           </Panel>
         </ControlTemplate>
       </Setter>
 
-      <!-- Tabbing focus. Kept on the AdornerLayer: the tab header's own horizontal ScrollViewer
-           clips its viewport to the tab height, which would crop an in-template ring top/bottom. -->
-      <Style Selector="^:focus-visible">
-        <Setter Property="AdornerLayer.Adorner">
-          <Template>
-            <Border AdornerLayer.IsClipEnabled="False"
-                    Margin="-3"
-                    BorderThickness="{StaticResource FocusBorderThickness}"
-                    BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
-          </Template>
-        </Setter>
+      <!-- Tabbing focus -->
+      <Style Selector="^:focus-visible /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
       </Style>
 
       <Style Selector="^:nth-last-child(1) /template/ Border#TabDivider">
@@ -150,30 +150,32 @@
       <Setter Property="Padding" Value="8 4" />
       <Setter Property="Template">
         <ControlTemplate>
-          <ContentPresenter Name="PART_ContentPresenter"
-                            Padding="{TemplateBinding Padding}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Background="{TemplateBinding Background}"
-                            Content="{TemplateBinding Header}"
-                            ContentTemplate="{TemplateBinding HeaderTemplate}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            RecognizesAccessKey="True" />
-        </ControlTemplate>
-      </Setter>
-
-      <!-- Tabbing focus. Kept on the AdornerLayer: the tab header's own horizontal ScrollViewer
-           clips its viewport to the tab height, which would crop an in-template ring top/bottom. -->
-      <Style Selector="^:focus-visible">
-        <Setter Property="AdornerLayer.Adorner">
-          <Template>
-            <Border AdornerLayer.IsClipEnabled="False"
+          <Panel ClipToBounds="False">
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Padding="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              Background="{TemplateBinding Background}"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding HeaderTemplate}"
+                              CornerRadius="{TemplateBinding CornerRadius}"
+                              RecognizesAccessKey="True" />
+            <!-- In-template focus ring (see TextBox.axaml). The Top/Bottom header ScrollViewer
+                 provides viewport slack (see TabControl.axaml) so this is not clipped. -->
+            <Border Name="FocusRing"
+                    IsVisible="False"
+                    IsHitTestVisible="False"
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
                     CornerRadius="7" />
-          </Template>
-        </Setter>
+          </Panel>
+        </ControlTemplate>
+      </Setter>
+
+      <!-- Tabbing focus -->
+      <Style Selector="^:focus-visible /template/ Border#FocusRing">
+        <Setter Property="IsVisible" Value="True" />
       </Style>
 
       <Style Selector="^:selected /template/ ContentPresenter#PART_ContentPresenter">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabPane.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabPane.axaml
@@ -31,22 +31,30 @@
     <Setter Property="Padding" Value="10" />
     <Setter Property="Background" Value="{DynamicResource TabControlBackground}" />
     <Setter Property="CornerRadius" Value="0" />
+    <!-- Let the in-template TabItem focus ring overflow the strip instead of being clipped. -->
+    <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="Template">
       <ControlTemplate>
         <Border BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
                 CornerRadius="{TemplateBinding CornerRadius}"
                 Background="{TemplateBinding Background}"
+                ClipToBounds="False"
                 HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                 VerticalAlignment="{TemplateBinding VerticalAlignment}">
-          <DockPanel>
+          <DockPanel ClipToBounds="False">
+            <!-- ZIndex keeps the strip (and thus a focused tab's ring) above the content host,
+                 so the ring's 3px overflow toward the content edge isn't overpainted. -->
             <Border Name="PART_ItemsPresenterBorder"
+                    ZIndex="1"
+                    ClipToBounds="False"
                     DockPanel.Dock="{TemplateBinding TabStripPlacement}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="0 0 0 1"
                     Padding="4, 0, 4, -1"
                     CornerRadius="0">
               <ItemsPresenter Name="PART_ItemsPresenter"
+                              ClipToBounds="False"
                               ItemsPanel="{TemplateBinding ItemsPanel}" />
             </Border>
             <ContentPresenter Name="PART_SelectedContentHost"


### PR DESCRIPTION
## Summary

Follow-up to #612 (moving the macOS focus ring off the `AdornerLayer`), completing the migration for the tab controls — `TabItem` and `TabPane` were the last ones still using `AdornerLayer.Adorner`.

## Changes

**TabItem** — both templates (Top/Bottom and Left/Right) now use an in-template `FocusRing` border toggled by `:focus-visible`, like the other controls. The Left/Right template's root was a bare `ContentPresenter`, so it's wrapped in a `Panel` to host the ring.

**TabPane** (custom control that reuses the `TabItem` theme) — its strip didn't sit above the content host, so the ring's overflow was overpainted. Added `ZIndex="1"` on the strip and `ClipToBounds="False"` down the chain, matching what `TabControl` already does.

**TabControl** — the Top/Bottom header lives in a horizontal `ScrollViewer` whose `ScrollContentPresenter` clips its viewport to the tab bounds, which would crop an in-template ring. Handled without changing the visible strip:
- The header `ScrollViewer` gets a negative margin that enlarges its viewport ~6px; `TabControlTopItemsPresenterMargin` re-insets the tabs by the same amount so they stay in place, leaving transparent slack inside the viewport where the ring can draw.
- The right-side slack is **conditional on the overflow scroll buttons**: kept while they're hidden (so the last tab's ring shows), dropped once they appear (so the viewport doesn't overlap them). The Left/Right template has no header scroller and already had room.

## Testing

Manual validation in the SampleApp (macOS Classic + LiquidGlass), horizontal and vertical tabs, `TabPane`, and the overflow demo:
- Focus rings clip correctly inside ancestor scrollers instead of bleeding.
- Tabs stay in the same position; strip chrome unchanged.
- First and last tab rings show; the last tab's ring isn't clipped when the strip is at its right edge, and doesn't overlap the `<`/`>` overflow buttons when they appear.

## Follow-up (not in this PR)

The focus-ring corner radius is still a hardcoded per-control value. A separate PR will bind each focus ring's `CornerRadius` to its control's `CornerRadius` via a converter that accounts for the ring's larger size, so rings stay correct automatically (and if a control's radius ever changes).
