### PR TITLE
[MacOS] Derive focus-ring corner radius from control radius

### DIFF
--- a/src/Devolutions.AvaloniaControls/Converters/FocusRingCornerRadiusConverter.cs
+++ b/src/Devolutions.AvaloniaControls/Converters/FocusRingCornerRadiusConverter.cs
@@ -1,0 +1,31 @@
+namespace Devolutions.AvaloniaControls.Converters;
+
+using System;
+using Avalonia;
+using Avalonia.Data.Converters;
+
+public static partial class DevoConverters
+{
+    /// <summary>
+    /// Inflates a corner radius by an offset in px (the <c>ConverterParameter</c>), clamped to
+    /// <c>&gt;= 0</c> on every corner. Bind a focus ring's radius to the control's own radius through
+    /// this so the ring tracks it automatically instead of hard-coding a per-control ring radius:
+    /// <code>
+    /// CornerRadius="{TemplateBinding CornerRadius,
+    ///                Converter={x:Static conv:DevoConverters.InflateCornerRadius},
+    ///                ConverterParameter={StaticResource FocusRingRadiusOffset}}"
+    /// </code>
+    /// </summary>
+    /// <remarks>
+    /// The offset is an <em>optical</em> value, not a geometric one. A mathematically-parallel ring
+    /// (offset = the ring's outward <c>Margin</c>) reads as too round against high-contrast fills
+    /// (accent buttons, selected tabs); native macOS draws the ring a touch tighter, so the theme
+    /// uses a slightly smaller offset.
+    /// </remarks>
+    public static FuncValueConverter<CornerRadius, double, CornerRadius> InflateCornerRadius { get; } =
+        new(static (radius, offset) => new CornerRadius(
+            Math.Max(0, radius.TopLeft + offset),
+            Math.Max(0, radius.TopRight + offset),
+            Math.Max(0, radius.BottomRight + offset),
+            Math.Max(0, radius.BottomLeft + offset)));
+}

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -564,6 +564,10 @@
   <SolidColorBrush x:Key="FocusBorderBrush" Color="{DynamicResource SystemAccentColor}" Opacity="0.5" />
   <Thickness x:Key="FocusBorderThickness">3.5</Thickness>
   <Thickness x:Key="FocusBorderMargin">-3</Thickness>
+  <!-- Px added to a control's own corner radius to get its focus-ring radius (via
+       DevoConverters.InflateCornerRadius). Optical, not geometric: a mathematically-parallel ring
+       (= |FocusBorderMargin|) reads too round on high-contrast fills, so it's tuned a touch tighter. -->
+  <x:Double x:Key="FocusRingRadiusOffset">2</x:Double>
 
   <!-- TODO: Button Resources -->
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -694,7 +694,6 @@
   <SolidColorBrush x:Key="TagInputTagBackgroundBrush" Color="{DynamicResource TagInputTagBackgroundColor}" />
   <Thickness x:Key="TextBoxBorderThickness">0.6</Thickness>
   <CornerRadius x:Key="TextBoxCornerRadius">0</CornerRadius>
-  <CornerRadius x:Key="TextBoxFocusCornerRadius">2</CornerRadius>
   <BoxShadows x:Key="TextBoxBoxShadow">0 0 0 0 Transparent</BoxShadows>
   <x:Double x:Key="TextBoxMinDimensions">22</x:Double>
   <StaticResource x:Key="TimePickerUpDownMinHeight" ResourceKey="TextBoxMinDimensions" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -395,7 +395,6 @@
   <StaticResource x:Key="EditableComboBoxHeight" ResourceKey="ControlSize24" />
   <StaticResource x:Key="CalendarControlHeight" ResourceKey="ControlSize24" />
   <StaticResource x:Key="TextBoxCornerRadius" ResourceKey="ButtonCornerRadius" />
-  <StaticResource x:Key="TextBoxFocusCornerRadius" ResourceKey="Radius9" />
   <!-- Use BoxShadow instead of BorderThickness for LiquidGlass to ensure border is drawn "outside" 
        and avoids anti-aliasing artifacts with semi-transparent borders overlapping TextBox background -->
   <StaticResource x:Key="TextBoxBorderThickness" ResourceKey="Thickness0" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Button.axaml
@@ -64,7 +64,7 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
+                  CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CheckBox.axaml
@@ -85,7 +85,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="5" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
           <ContentPresenter
             Name="PART_ContentPresenter"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -329,7 +329,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/DropDownButton.axaml
@@ -77,7 +77,7 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
+                  CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
         </Panel>
       </ControlTemplate>
     </Setter>
@@ -167,7 +167,7 @@
                       Margin="{StaticResource FocusBorderMargin}"
                       BorderThickness="{StaticResource FocusBorderThickness}"
                       BorderBrush="{DynamicResource FocusBorderBrush}"
-                      CornerRadius="7" />
+                      CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
             </Panel>
           </ControlTemplate>
         </Setter.Value>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -350,7 +350,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
@@ -251,7 +251,11 @@
       <ControlTemplate>
         <DockPanel MinWidth="{TemplateBinding MinWidth}"
                    MaxWidth="{TemplateBinding MaxWidth}">
+          <!-- ZIndex keeps the header (and its focus ring) above the content tray so the ring's
+               outward overhang is not occluded by the expanded content's background (see the -3
+               FocusBorderMargin on the ring inside ExpanderToggleButtonTheme). -->
           <ToggleButton x:Name="ExpanderHeader"
+                        ZIndex="1"
                         MinHeight="{TemplateBinding MinHeight}"
                         CornerRadius="{TemplateBinding CornerRadius}"
                         IsEnabled="{TemplateBinding IsEnabled}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Expander.axaml
@@ -166,7 +166,7 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="{Binding $parent[ToggleButton].CornerRadius}" />
+                  CornerRadius="{Binding $parent[ToggleButton].CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBoxItem.axaml
@@ -72,7 +72,7 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
+                  CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -281,7 +281,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/RadioButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/RadioButton.axaml
@@ -71,7 +71,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="10" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
 
           <ContentPresenter

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/SplitButton.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/SplitButton.axaml
@@ -160,7 +160,7 @@
                   Margin="{StaticResource FocusBorderMargin}"
                   BorderThickness="{StaticResource FocusBorderThickness}"
                   BorderBrush="{DynamicResource FocusBorderBrush}"
-                  CornerRadius="7" />
+                  CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
         </Panel>
       </ControlTemplate>
     </Setter>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TabItem.axaml
@@ -113,7 +113,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </ControlTemplate>
       </Setter>
@@ -168,7 +168,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="7" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </ControlTemplate>
       </Setter>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TagInput.axaml
@@ -111,7 +111,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -270,7 +270,7 @@
                     Margin="{StaticResource FocusBorderMargin}"
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{DynamicResource FocusBorderBrush}"
-                    CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
+                    CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
           </Panel>
         </DataValidationErrors>
       </ControlTemplate>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TextBox.axaml
@@ -329,13 +329,6 @@
       <Style Selector="^ /template/ Border#BottomBorder">
         <Setter Property="BorderBrush" Value="{DynamicResource SystemAccentColor}" />
       </Style>
-
-      <Style Selector="^[AcceptsReturn=True]">
-        <!-- Revert to default focus radius (2) for square multiline textboxes -->
-        <Style Selector="^ /template/ Border#FocusRing">
-          <Setter Property="CornerRadius" Value="2" />
-        </Style>
-      </Style>
     </Style>
 
     <!-- Read-only State -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/TimePickerUpDown.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/TimePickerUpDown.axaml
@@ -198,7 +198,7 @@
                       Margin="{StaticResource FocusBorderMargin}"
                       BorderThickness="{StaticResource FocusBorderThickness}"
                       BorderBrush="{DynamicResource FocusBorderBrush}"
-                      CornerRadius="{DynamicResource TextBoxFocusCornerRadius}" />
+                      CornerRadius="{TemplateBinding CornerRadius, Converter={x:Static DevoConverters.InflateCornerRadius}, ConverterParameter={StaticResource FocusRingRadiusOffset}}" />
             </Grid>
           </ButtonSpinner>
         </DataValidationErrors>


### PR DESCRIPTION
## Summary

Unifies how the macOS theme sizes in-template focus rings. Instead of each control hard-coding its focus-ring `CornerRadius`, the ring now derives it from the control's own `CornerRadius` via a shared converter plus a single tunable offset. This removes drift between a control's radius and its ring, and makes future radius changes automatic.

Follows on from #612 and #614 (which moved these rings off the `AdornerLayer` into the template).

## How it works

- **`DevoConverters.InflateCornerRadius`** (new value converter, `Devolutions.AvaloniaControls`) inflates a `CornerRadius` by a px offset, clamped `>= 0` per corner.
- **`FocusRingRadiusOffset`** (new theme resource, `2`) is the single place the offset lives. It's an *optical* value, not geometric: a mathematically-parallel ring (offset = `|FocusBorderMargin|` = 3) reads as too round against high-contrast fills (accent buttons, selected tabs), so it's tuned a touch tighter to match native macOS.
- Each ring binds directly:
  ```xml
  CornerRadius="{TemplateBinding CornerRadius,
                 Converter={x:Static DevoConverters.InflateCornerRadius},
                 ConverterParameter={StaticResource FocusRingRadiusOffset}}"
  ```

## Controls converted

Button, CheckBox, ComboBox, DropDownButton (both variants), EditableComboBox, Expander, ListBoxItem, MultiComboBox, RadioButton, SplitButton, TabItem (both orientations), TagInput, TextBox, TimePickerUpDown.

**ToggleSwitch is intentionally excluded** — its ring is the fully-round pill (`100`) and the control defines no `CornerRadius`, so a `TemplateBinding` would collapse it.

## Resulting radius shifts

Rings that change vs. their old hand-tuned values (all others unchanged at control-radius + 2):

| Control | Classic | LiquidGlass |
|---|---|---|
| DropDownButton (default) | tracks control | 7 → 8 |
| SplitButton | tracks control | 7 → 8 |
| CheckBox | 5 (no change) | 5 → 7 |
| Expander (header) | 5 → 7 | 5 → 7 |
| TextBox / TagInput / TimePickerUpDown | 2 (no change) | 9 → 8 |
| RadioButton | 10 → 9 | 10 (no change) |

## Also in this PR

**Expander focus-ring occlusion fix** — the header ring extends `-3` outside the header; when expanded, the content tray (a later sibling) painted over the ring's overhang on the seam side, clipping that edge. Giving `ExpanderHeader` `ZIndex="1"` lifts the header subtree (and its ring) above the content so the ring closes fully, consistent with every other control. Keyboard-only gating is unchanged and it works for all four expand directions.

## Testing

- `dotnet build` clean.
- Manually validated in the SampleApp (LiquidGlass): tabbed through all converted controls and the Expander in all expand directions.