### PR TITLE
[DevExpress] Fix premature submenu dismissal

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/MenuItemSubmenuPointerExitBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Behaviors/MenuItemSubmenuPointerExitBehavior.cs
@@ -1,0 +1,44 @@
+namespace Devolutions.AvaloniaTheme.DevExpress.Behaviors;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+/// <summary>
+/// Prevents Avalonia from scheduling its one-shot submenu close when the pointer exits
+/// a menu item whose submenu is already open.
+/// </summary>
+internal static class MenuItemSubmenuPointerExitBehavior
+{
+    public static readonly AttachedProperty<bool> EnableProperty =
+        AvaloniaProperty.RegisterAttached<MenuItem, bool>("Enable", typeof(MenuItemSubmenuPointerExitBehavior));
+
+    static MenuItemSubmenuPointerExitBehavior()
+    {
+        EnableProperty.Changed.AddClassHandler<MenuItem>(OnEnableChanged);
+    }
+
+    public static bool GetEnable(MenuItem element) => element.GetValue(EnableProperty);
+
+    public static void SetEnable(MenuItem element, bool value) => element.SetValue(EnableProperty, value);
+
+    private static void OnEnableChanged(MenuItem menuItem, AvaloniaPropertyChangedEventArgs args)
+    {
+        menuItem.RemoveHandler(MenuItem.PointerExitedItemEvent, OnPointerExitedItem);
+
+        if (args.NewValue is true)
+        {
+            menuItem.AddHandler(MenuItem.PointerExitedItemEvent, OnPointerExitedItem, RoutingStrategies.Bubble);
+        }
+    }
+
+    private static void OnPointerExitedItem(object? sender, RoutedEventArgs args)
+    {
+        if (sender is MenuItem menuItem &&
+            ReferenceEquals(args.Source, menuItem) &&
+            menuItem.IsSubMenuOpen)
+        {
+            args.Handled = true;
+        }
+    }
+}

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
@@ -2,7 +2,8 @@
 
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:conv="using:Avalonia.Controls.Converters">
+                    xmlns:conv="using:Avalonia.Controls.Converters"
+                    xmlns:behaviors="using:Devolutions.AvaloniaTheme.DevExpress.Behaviors">
 
   <Design.PreviewWith>
     <Border Padding="20" Width="320">
@@ -66,6 +67,7 @@
     <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
     <!-- Block inheritance of LineHeight from parent controls -->
     <Setter Property="TextBlock.LineHeight" Value="NaN" />
+    <Setter Property="behaviors:MenuItemSubmenuPointerExitBehavior.Enable" Value="True" />
     
     <Setter Property="Template">
       <ControlTemplate>

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Platform;
 using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Styling;
 using AvaloniaFluentTheme = Avalonia.Themes.Fluent.FluentTheme;
@@ -205,6 +207,56 @@ public class MenuPackContractTests
         {
             baseline.Close();
             hostile.Close();
+        }
+    }
+
+    /// <summary>
+    /// A fast pointer move can jump from the parent item to outside the submenu without
+    /// ever entering the popup. Avalonia normally queues a delayed close on that exit,
+    /// so the DevExpress behavior must intercept the open parent's exit event.
+    /// </summary>
+    [AvaloniaFact]
+    public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
+    {
+        var parent = new MenuItem
+        {
+            Header = "Parent",
+            Items = { new MenuItem { Header = "Child" } },
+        };
+        var sibling = new MenuItem { Header = "Sibling" };
+        var presenter = new MenuFlyoutPresenter { Items = { parent, sibling } };
+        Window window = ShowWithFullTheme(ThemeVariant.Light);
+        TimeSpan originalMenuShowDelay = DefaultMenuInteractionHandler.MenuShowDelay;
+
+        try
+        {
+            window.Content = presenter;
+            Dispatcher.UIThread.RunJobs();
+
+            presenter.SelectedIndex = 0;
+            parent.IsSubMenuOpen = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(parent.IsSubMenuOpen);
+
+            DefaultMenuInteractionHandler.MenuShowDelay = TimeSpan.Zero;
+            var exit = new RoutedEventArgs(MenuItem.PointerExitedItemEvent, parent);
+            parent.RaiseEvent(exit);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(exit.Handled);
+            Assert.True(parent.IsSubMenuOpen);
+
+            sibling.RaiseEvent(new RoutedEventArgs(MenuItem.PointerEnteredItemEvent, sibling));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(parent.IsSubMenuOpen);
+        }
+        finally
+        {
+            DefaultMenuInteractionHandler.MenuShowDelay = originalMenuShowDelay;
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
         }
     }
 


### PR DESCRIPTION
## What changed

- Add a DevExpress-specific `MenuItem` behavior that handles pointer exit events for already-open submenu parents.
- Enable the behavior from the DevExpress `MenuItem` style.
- Add regression coverage for fast pointer movement while preserving normal sibling-menu switching.

## Why

Avalonia schedules a delayed submenu close when the pointer exits the parent item and has not entered the submenu. A fast pointer movement can skip the submenu hit area entirely, causing the newly opened submenu to dismiss. Handling the open parent's exit event prevents that close timer from being queued while leaving sibling selection, click dismissal, and keyboard behavior unchanged.

## User impact

DevExpress submenus remain open when the pointer quickly leaves their bounds, matching the behavior already observed after the submenu had remained open longer.

## Validation

- `dotnet test tests/Devolutions.AvaloniaControls.VisualTests/Devolutions.AvaloniaControls.VisualTests.csproj --no-restore --filter "FullyQualifiedName~MenuPackContractTests"`
- Passed: 26/26
- Manually confirmed by the reporter using fast pointer movement.