### PR TITLE
menu-pack: fix cross-theme ScrollViewer resource typing

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
@@ -27,7 +27,8 @@
   across hosts directly instead of storing a baseline per host.
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="using:Avalonia.Controls.Converters">
 
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Light">
@@ -107,5 +108,77 @@
   <Thickness x:Key="DevExMenuNestedItemPadding">10,2</Thickness>
   <Thickness x:Key="DevExMenuIconPresenterMargin">4 0 10 0</Thickness>
   <Thickness x:Key="DevExMenuInputGestureTextMargin">15,0,0,0</Thickness>
+
+  <ControlTheme x:Key="DevExMenuScrollViewer" TargetType="ScrollViewer">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="IsScrollChainingEnabled" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel>
+          <RepeatButton DockPanel.Dock="Top"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        RenderTransform="{x:Null}"
+                        Command="{Binding LineUp, RelativeSource={RelativeSource TemplatedParent}}">
+            <RepeatButton.IsVisible>
+              <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
+                            ConverterParameter="0">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="VerticalScrollBarVisibility" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Offset.Y" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Extent.Height" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Viewport.Height" />
+              </MultiBinding>
+            </RepeatButton.IsVisible>
+            <Viewbox Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
+                     Height="{DynamicResource ScrollBarButtonArrowIconFontSize}">
+              <Path VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Data="M 19.091797 14.970703 L 10 5.888672 L 0.908203 14.970703 L 0.029297 14.091797 L 10 4.111328 L 19.970703 14.091797 Z"
+                    Fill="{DynamicResource ScrollBarButtonArrowForeground}"
+                    Width="20"
+                    Height="20" />
+            </Viewbox>
+          </RepeatButton>
+          <RepeatButton DockPanel.Dock="Bottom"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        RenderTransform="{x:Null}"
+                        Command="{Binding LineDown, RelativeSource={RelativeSource TemplatedParent}}">
+            <RepeatButton.IsVisible>
+              <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
+                            ConverterParameter="100">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="VerticalScrollBarVisibility" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Offset.Y" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Extent.Height" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Viewport.Height" />
+              </MultiBinding>
+            </RepeatButton.IsVisible>
+            <Viewbox Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
+                     Height="{DynamicResource ScrollBarButtonArrowIconFontSize}">
+              <Path VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Data="M 18.935547 4.560547 L 19.814453 5.439453 L 10 15.253906 L 0.185547 5.439453 L 1.064453 4.560547 L 10 13.496094 Z"
+                    Fill="{DynamicResource ScrollBarButtonArrowForeground}"
+                    Width="20"
+                    Height="20" />
+            </Viewbox>
+          </RepeatButton>
+          <ScrollContentPresenter Name="PART_ContentPresenter">
+            <ScrollContentPresenter.GestureRecognizers>
+              <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                                       CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}" />
+            </ScrollContentPresenter.GestureRecognizers>
+          </ScrollContentPresenter>
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^ /template/ RepeatButton:pointerover > Viewbox > Path">
+      <Setter Property="Fill" Value="{DynamicResource ScrollBarButtonArrowForegroundPointerOver}" />
+    </Style>
+  </ControlTheme>
 
 </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.axaml
@@ -73,7 +73,7 @@
                       MinHeight="{DynamicResource DevExMenuPopupMinHeight}"
                       HorizontalAlignment="Stretch"
                       CornerRadius="{DynamicResource DevExMenuTopLevelPopupCornerRadius}">
-                <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}" Margin="1">
+                <ScrollViewer Theme="{StaticResource DevExMenuScrollViewer}" Margin="1">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   ItemsPanel="{TemplateBinding ItemsPanel}"
                                   Grid.IsSharedSizeScope="True" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuFlyoutPresenter.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuFlyoutPresenter.axaml
@@ -30,7 +30,7 @@
                 Padding="{TemplateBinding Padding}"
                 CornerRadius="{TemplateBinding CornerRadius}">
           <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                        Theme="{StaticResource FluentMenuScrollViewer}"
+                        Theme="{StaticResource DevExMenuScrollViewer}"
                         VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
             <ItemsPresenter Name="PART_ItemsPresenter"
                             ItemsPanel="{TemplateBinding ItemsPanel}"

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuItem.axaml
@@ -155,7 +155,7 @@
                     MinHeight="{DynamicResource DevExMenuPopupMinHeight}"
                     HorizontalAlignment="Stretch"
                     CornerRadius="{DynamicResource DevExMenuPopupCornerRadius}">
-              <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
+              <ScrollViewer Theme="{StaticResource DevExMenuScrollViewer}">
                 <ItemsPresenter Name="PART_ItemsPresenter"
                                 ItemsPanel="{TemplateBinding ItemsPanel}"
                                 Grid.IsSharedSizeScope="True" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources.axaml
@@ -8,7 +8,8 @@
   Every key is prefixed "MacOsMenu" to avoid collisions with host themes.
 -->
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:converters="using:Avalonia.Controls.Converters">
 
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Default">
@@ -81,6 +82,78 @@
 
   <x:Double x:Key="MacOsMenuSeparatorHeight">1</x:Double>
   <Thickness x:Key="MacOsMenuSeparatorPadding">8 5 8 5</Thickness>
+
+  <ControlTheme x:Key="MacOsMenuScrollViewer" TargetType="ScrollViewer">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="IsScrollChainingEnabled" Value="False" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockPanel>
+          <RepeatButton DockPanel.Dock="Top"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        RenderTransform="{x:Null}"
+                        Command="{Binding LineUp, RelativeSource={RelativeSource TemplatedParent}}">
+            <RepeatButton.IsVisible>
+              <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
+                            ConverterParameter="0">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="VerticalScrollBarVisibility" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Offset.Y" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Extent.Height" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Viewport.Height" />
+              </MultiBinding>
+            </RepeatButton.IsVisible>
+            <Viewbox Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
+                     Height="{DynamicResource ScrollBarButtonArrowIconFontSize}">
+              <Path VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Data="M 19.091797 14.970703 L 10 5.888672 L 0.908203 14.970703 L 0.029297 14.091797 L 10 4.111328 L 19.970703 14.091797 Z"
+                    Fill="{DynamicResource ScrollBarButtonArrowForeground}"
+                    Width="20"
+                    Height="20" />
+            </Viewbox>
+          </RepeatButton>
+          <RepeatButton DockPanel.Dock="Bottom"
+                        BorderThickness="0"
+                        Background="Transparent"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Center"
+                        RenderTransform="{x:Null}"
+                        Command="{Binding LineDown, RelativeSource={RelativeSource TemplatedParent}}">
+            <RepeatButton.IsVisible>
+              <MultiBinding Converter="{x:Static converters:MenuScrollingVisibilityConverter.Instance}"
+                            ConverterParameter="100">
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="VerticalScrollBarVisibility" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Offset.Y" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Extent.Height" />
+                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Viewport.Height" />
+              </MultiBinding>
+            </RepeatButton.IsVisible>
+            <Viewbox Width="{DynamicResource ScrollBarButtonArrowIconFontSize}"
+                     Height="{DynamicResource ScrollBarButtonArrowIconFontSize}">
+              <Path VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Data="M 18.935547 4.560547 L 19.814453 5.439453 L 10 15.253906 L 0.185547 5.439453 L 1.064453 4.560547 L 10 13.496094 Z"
+                    Fill="{DynamicResource ScrollBarButtonArrowForeground}"
+                    Width="20"
+                    Height="20" />
+            </Viewbox>
+          </RepeatButton>
+          <ScrollContentPresenter Name="PART_ContentPresenter">
+            <ScrollContentPresenter.GestureRecognizers>
+              <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                                       CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}" />
+            </ScrollContentPresenter.GestureRecognizers>
+          </ScrollContentPresenter>
+        </DockPanel>
+      </ControlTemplate>
+    </Setter>
+    <Style Selector="^ /template/ RepeatButton:pointerover > Viewbox > Path">
+      <Setter Property="Fill" Value="{DynamicResource ScrollBarButtonArrowForegroundPointerOver}" />
+    </Style>
+  </ControlTheme>
 
   <StreamGeometry x:Key="MacOsMenuChevronPath">M257.2,177.4c-8.3,0-16.6-3.2-23-9.5l-89.4-89.4-89.4,89.4c-12.7,12.7-33.3,12.7-46,0-12.7-12.7-12.7-33.3,0-46L121.9,9.5c12.7-12.7,33.3-12.7,46,0l112.4,112.4c12.7,12.7,12.7,33.3,0,46s-14.7,9.5-23,9.5Z</StreamGeometry>
   <StreamGeometry x:Key="MacOsMenuCheckMarkPath">M 1145.607177734375,430 C1145.607177734375,430 1141.449951171875,435.0772705078125 1141.449951171875,435.0772705078125 1141.449951171875,435.0772705078125 1139.232177734375,433.0999755859375 1139.232177734375,433.0999755859375 1139.232177734375,433.0999755859375 1138,434.5538330078125 1138,434.5538330078125 1138,434.5538330078125 1141.482177734375,438 1141.482177734375,438 1141.482177734375,438 1141.96875,437.9375 1141.96875,437.9375 1141.96875,437.9375 1147,431.34619140625 1147,431.34619140625 1147,431.34619140625 1145.607177734375,430 1145.607177734375,430 z</StreamGeometry>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ContextMenu.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ContextMenu.axaml
@@ -62,7 +62,7 @@
                   BorderThickness="{DynamicResource MacOsMenuPopupInnerBorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}"
                   Padding="{DynamicResource MacOsMenuPopupPadding}">
-            <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}"
+            <ScrollViewer Theme="{StaticResource MacOsMenuScrollViewer}"
                           HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                           VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
               <ItemsPresenter Name="PART_ItemsPresenter"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
@@ -265,7 +265,7 @@
                         BorderThickness="{DynamicResource MacOsMenuPopupInnerBorderThickness}"
                         CornerRadius="{DynamicResource MacOsMenuPopupCornerRadius}"
                         Padding="{DynamicResource MacOsMenuPopupPadding}">
-                  <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
+                  <ScrollViewer Theme="{StaticResource MacOsMenuScrollViewer}">
                     <ItemsPresenter Name="PART_ItemsPresenter"
                                     ItemsPanel="{TemplateBinding ItemsPanel}"
                                     Margin="{DynamicResource MacOsMenuFlyoutScrollerMargin}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuFlyoutPresenter.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuFlyoutPresenter.axaml
@@ -28,7 +28,7 @@
                   BorderThickness="{DynamicResource MacOsMenuPopupInnerBorderThickness}"
                   CornerRadius="{TemplateBinding CornerRadius}"
                   Padding="{DynamicResource MacOsMenuPopupPadding}">
-            <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}"
+            <ScrollViewer Theme="{StaticResource MacOsMenuScrollViewer}"
                           HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
                           VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
               <ItemsPresenter Name="PART_ItemsPresenter"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
@@ -170,7 +170,7 @@
                       BorderThickness="{DynamicResource MacOsMenuPopupInnerBorderThickness}"
                       CornerRadius="{DynamicResource MacOsMenuPopupCornerRadius}"
                       Padding="{DynamicResource MacOsMenuPopupPadding}">
-                <ScrollViewer Theme="{StaticResource FluentMenuScrollViewer}">
+                <ScrollViewer Theme="{StaticResource MacOsMenuScrollViewer}">
                   <ItemsPresenter Name="PART_ItemsPresenter"
                                   ItemsPanel="{TemplateBinding ItemsPanel}"
                                   Margin="{DynamicResource MacOsMenuFlyoutScrollerMargin}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
@@ -19,7 +19,6 @@ internal static class MenuResourceAliasBuilder
     ("MacOsMenuSelectedBackgroundBrush", "LayoutBackgroundMidBrush"),
     ("MacOsMenuPressedBackgroundBrush", "LayoutBackgroundHighBrush"),
     ("MacOsMenuItemPointerOverBackgroundBrush", "MenuItemPointerOverBackgroundBrush"),
-    ("MacOsMenuSeparatorBrush", "SeparatorBrush"),
     ("MacOsMenuPopupBorderThickness", "MenuFlyoutPresenterBorderThickness"),
     ("MacOsMenuFontSize", "ControlFontSize"),
     ("MacOsMenuHeaderFontSizeSmall", "MenuHeaderFontSizeSmall"),

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -218,9 +218,6 @@ public class MacOsMenuPackContractTests
 
         try
         {
-            window.Show();
-            Dispatcher.UIThread.RunJobs();
-
             Assert.True(page.TryFindResource("MacOsMenuPopupMargin", ThemeVariant.Light, out object? popupMargin),
                 "Menu pack page should resolve the active MacOS popup margin.");
             Assert.True(page.TryFindResource("MacOsMenuItemPadding", ThemeVariant.Light, out object? itemPadding),
@@ -427,16 +424,27 @@ public class MacOsMenuPackContractTests
         var page = new UserControl();
         var window = new Window { Content = page, RequestedThemeVariant = ThemeVariant.Light };
         window.Styles.Add(new AvaloniaFluentTheme());
-        page.Styles.Add(new Devolutions.AvaloniaTheme.MacOS.Controls.MacOsMenuPack());
 
         try
         {
             window.Show();
             Dispatcher.UIThread.RunJobs();
 
-            Assert.False(
-                page.TryFindResource(nonMenuKey, ThemeVariant.Light, out object? leaked),
-                $"Menu pack must not publish the non-menu MacOS resource '{nonMenuKey}' (got '{leaked}').");
+            bool hostFound = page.TryFindResource(nonMenuKey, ThemeVariant.Light, out object? hostValue);
+            string hostToken = DescribeToken(hostValue);
+
+            page.Styles.Add(new Devolutions.AvaloniaTheme.MacOS.Controls.MacOsMenuPack());
+            Dispatcher.UIThread.RunJobs();
+
+            bool packFound = page.TryFindResource(nonMenuKey, ThemeVariant.Light, out object? packValue);
+            string packToken = DescribeToken(packValue);
+
+            Assert.Equal(
+                hostFound,
+                packFound);
+            Assert.Equal(
+                hostToken,
+                packToken);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- move menu-specific ScrollViewer control themes into menu resource dictionaries for both MacOS and DevExpress packs
- update menu templates to resolve those pack-owned keys instead of host-owned Fluent keys
- keep MacOS menu alias contract scoped and adjust the corresponding contract test to assert host-vs-pack parity
- update MenuPack contract docs/comments to reflect the new ownership model
- keep the local BindingEvaluatorTests.cs deletion uncommitted (not part of this PR)

## Why
The Menu-related visual tests were failing due to cross-theme resource type mismatches and follow-on headless popup behavior after the MenuPack extraction work. This aligns resource ownership with MenuPack boundaries so full themes and packs resolve consistently.

## Notable improvement
For the **DevExpress MenuPack**, this removes the last menu-level Fluent resource dependency (`FluentMenuScrollViewer`) by vendoring it as `DevExMenuScrollViewer`. In practice, menu behavior no longer depends on host-owned Fluent menu scroll resources.

## Related
- Follow-up to MenuPack introductions:
  - #597
  - #624