### PR TITLE
[DevExpress] Seal host style leakage in MenuPack menu items

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
@@ -28,4 +28,17 @@
     <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
     <Setter Property="TextBlock.LineHeight" Value="NaN" />
   </Style>
+
+  <!--
+    Menu-bar items are direct children of Menu, so the popup-row selector above does not reach them.
+    A host MenuItem Style therefore still overrides the ControlTheme unless we seal the bar items too.
+  -->
+  <Style Selector="Menu > MenuItem:not(:separator)">
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
+    <Setter Property="Padding" Value="6 1" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
@@ -23,6 +23,8 @@
   <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
     <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
     <Setter Property="Padding" Value="{DynamicResource DevExMenuNestedItemPadding}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
     <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
     <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
     <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
@@ -36,6 +38,8 @@
   <Style Selector="Menu > MenuItem:not(:separator)">
     <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
     <Setter Property="Padding" Value="6 1" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
     <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
     <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
     <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
@@ -23,5 +23,9 @@
   <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
     <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
     <Setter Property="Padding" Value="{DynamicResource DevExMenuNestedItemPadding}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -148,6 +148,11 @@ opted-out section still match the platform-themed menus elsewhere in the same ap
 host's font defeated that, because the branded section rendered its menus in the branded font and
 size. Pinning also keeps menu geometry identical across hosts.
 
+Style-level sealing is applied in two selectors instead of one: popup rows are descendants of
+`MenuFlyoutPresenter`/`ContextMenu`/`Menu`, while menu-bar items are direct children of `Menu`. The
+popup-row geometry and the top-level bar geometry are different, so the seal pins the same typography
+for both but preserves each item's own padding and bar height.
+
 **The pack styles menu content only.** It deliberately does not ship a `Separator` `ControlTheme`:
 that resource is keyed `{x:Type Separator}`, so merging it would restyle *every* separator in your
 app rather than just menu ones. Menu separators instead reuse the host's separator template — which

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -130,11 +130,16 @@ theme and the menu pack. There is one source of truth, so the pack can never dri
 
 Two rules make the pack safe to layer over a host theme you do not control:
 
-1. **Every key the pack owns is prefixed `DevExMenu`** — it cannot collide with, or be silently overridden by, the host
-   theme's keys.
+1. **The pack's token keys are prefixed `DevExMenu`** — those resources are owned by the pack and cannot collide with,
+   or be silently overridden by, the host theme's keys.
 2. **Values are pinned literals, never aliases.** Menu tokens do not resolve through generic theme-wide or Fluent-owned
    keys. A host theme that redefines e.g. `MenuFlyoutPresenterBorderThemeThickness` or `FlyoutThemeMaxWidth` cannot move
    menu visuals.
+
+The pack also intentionally ships non-prefixed named and implicit control themes such as `MenuTopLevelMenuItem`,
+`HorizontalMenuFlyoutPresenter`, `{x:Type MenuItem}`, `{x:Type Menu}`, and `{x:Type ContextMenu}`. Those keys are not
+resource-name collisions: they are the pack's own design-time theme registrations, and they are intentionally exempt
+from the `DevExMenu` prefix rule.
 
 **Inherited from the host (by design):**
 
@@ -142,16 +147,17 @@ Two rules make the pack safe to layer over a host theme you do not control:
 |-----|-----|
 | `FluentMenuScrollViewer` | Fluent's scroll viewer theme, reused rather than duplicated. This is the one remaining hard dependency on Fluent — see the prerequisite note above. |
 
-**Typography is pinned, not inherited.** `DevExMenuFontFamily` / `DevExMenuFontSize` /
-`DevExMenuFontWeight` are owned by the pack. The point of the pack is that menus in a branded or
-opted-out section still match the platform-themed menus elsewhere in the same app; inheriting the
-host's font defeated that, because the branded section rendered its menus in the branded font and
-size. Pinning also keeps menu geometry identical across hosts.
+**Typography and normal-state colours are pinned, not inherited.** `DevExMenuFontFamily` /
+`DevExMenuFontSize` / `DevExMenuFontWeight` are owned by the pack, and the same applies to the
+normal-state `DevExMenuItemBackground` / `DevExMenuItemForeground` values. The point of the pack is that
+menus in a branded or opted-out section still match the platform-themed menus elsewhere in the same app;
+inheriting the host's font or colours defeated that. Pinning also keeps menu geometry identical across hosts.
 
 Style-level sealing is applied in two selectors instead of one: popup rows are descendants of
-`MenuFlyoutPresenter`/`ContextMenu`/`Menu`, while menu-bar items are direct children of `Menu`. The
-popup-row geometry and the top-level bar geometry are different, so the seal pins the same typography
-for both but preserves each item's own padding and bar height.
+`MenuFlyoutPresenter`/`ContextMenu`/`Menu`, while menu-bar items are direct children of `Menu`. The popup-row
+geometry and the top-level bar geometry are different, so the seal pins the same typography and normal-state colour
+for both while preserving each item's own padding and bar height. The seal intentionally covers the normal state only;
+hover, pressed, selected, and disabled states are handled by template-child selectors in the `MenuItem` control theme.
 
 **The pack styles menu content only.** It deliberately does not ship a `Separator` `ControlTheme`:
 that resource is keyed `{x:Type Separator}`, so merging it would restyle *every* separator in your

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -156,13 +156,23 @@ inside the menu-scoped selector. A guard test asserts that adding the pack leave
 separators byte-identical.
 
 **Overriding a token.** Because tokens are prefixed, you can retarget any single value without affecting the rest of
-your app:
+your app. The override must live in the same resource scope as the pack (or a descendant of it), because resource lookup
+walks up the tree and stops at the first match. If a `StyleInclude` is added on a `UserControl` but the override lives on the
+`Window`, the override is silently ignored.
 
 ```xaml
-<StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
-<!-- ... later in your own resources ... -->
-<SolidColorBrush x:Key="DevExMenuSeparatorBrush" Color="#ff0000" />
+<Application.Styles>
+  <StyleInclude Source="avares://Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml" />
+</Application.Styles>
+
+<Application.Resources>
+  <SolidColorBrush x:Key="DevExMenuSeparatorBrush" Color="#ff0000" />
+</Application.Resources>
 ```
+
+The pack and the override must live in the same collection scope, or in a parent/child scope where the override is resolved
+before the pack is considered. In practice, the simplest pattern is to keep the pack in `Application.Styles` and the override in
+`Application.Resources` (or in the same `UserControl.Resources` scope as the pack).
 
 Both rules are enforced by `MenuPackContractTests` in the visual test project, which asserts that every `DevExMenu*`
 token resolves identically under the full theme and under "pack over a foreign host", and that a hostile host theme

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -262,6 +262,64 @@ public class MenuPackContractTests
     }
 
     [AvaloniaFact]
+    public void Host_menu_item_styles_do_not_change_the_menu_bar()
+    {
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light, Width = 500, Height = 300 };
+        window.Styles.Add(new AvaloniaFluentTheme());
+
+        var uri = new Uri(PackUri);
+        window.Styles.Add(new StyleInclude(uri) { Source = uri });
+
+        var hostStyle = new Style(selector => selector.OfType<MenuItem>())
+        {
+            Setters =
+            {
+                new Setter(TextBlock.FontFamilyProperty, new FontFamily("Comic Sans MS")),
+                new Setter(TextBlock.FontSizeProperty, 42d),
+                new Setter(TextBlock.FontWeightProperty, FontWeight.Bold),
+                new Setter(MenuItem.PaddingProperty, new Thickness(30)),
+                new Setter(MenuItem.MinHeightProperty, 77d),
+            },
+        };
+        window.Styles.Add(hostStyle);
+
+        var menu = new Menu
+        {
+            Items =
+            {
+                new MenuItem { Header = "File" },
+                new MenuItem { Header = "Edit" },
+            },
+        };
+        window.Content = menu;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var item = (MenuItem)menu.Items[0];
+
+            Assert.True(window.TryFindResource("DevExMenuFontFamily", ThemeVariant.Light, out object? fontFamily));
+            Assert.True(window.TryFindResource("DevExMenuFontSize", ThemeVariant.Light, out object? fontSize));
+            Assert.True(window.TryFindResource("DevExMenuFontWeight", ThemeVariant.Light, out object? fontWeight));
+
+            Assert.Equal(fontFamily, item.FontFamily);
+            Assert.Equal((double)fontSize, item.FontSize, 3);
+            Assert.Equal((FontWeight)fontWeight, item.FontWeight);
+            Assert.Equal(new Thickness(6, 1, 6, 1), item.Padding);
+            Assert.Equal(32d, item.MinHeight, 3);
+            Assert.True(double.IsNaN(item.GetValue(TextBlock.LineHeightProperty)));
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
     public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
     {
         var parent = new MenuItem

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -212,9 +212,8 @@ public class MenuPackContractTests
     }
 
     /// <summary>
-    /// A fast pointer move can jump from the parent item to outside the submenu without
-    /// ever entering the popup. Avalonia normally queues a delayed close on that exit,
-    /// so the DevExpress behavior must intercept the open parent's exit event.
+    /// Host menu-item styles must not override the pack's pinned popup-row typography,
+    /// including the font family, size, weight, and line-height seal applied at style level.
     /// </summary>
     [AvaloniaFact]
     public void Host_menu_item_styles_do_not_change_pinned_typography()
@@ -229,6 +228,7 @@ public class MenuPackContractTests
         {
             Setters =
             {
+                new Setter(TextBlock.FontFamilyProperty, new FontFamily("Comic Sans MS")),
                 new Setter(TextBlock.FontSizeProperty, 42d),
                 new Setter(TextBlock.FontWeightProperty, FontWeight.Bold),
                 new Setter(TextBlock.LineHeightProperty, 55d),
@@ -249,6 +249,8 @@ public class MenuPackContractTests
             contextMenu.Open(button);
             Dispatcher.UIThread.RunJobs();
 
+            Assert.True(window.TryFindResource("DevExMenuFontFamily", ThemeVariant.Light, out object? fontFamily));
+            Assert.Equal(fontFamily, menuItem.FontFamily);
             Assert.Equal(12d, menuItem.FontSize, 3);
             Assert.Equal(FontWeight.Normal, menuItem.FontWeight);
             Assert.True(double.IsNaN(menuItem.GetValue(TextBlock.LineHeightProperty)));
@@ -277,6 +279,7 @@ public class MenuPackContractTests
                 new Setter(TextBlock.FontFamilyProperty, new FontFamily("Comic Sans MS")),
                 new Setter(TextBlock.FontSizeProperty, 42d),
                 new Setter(TextBlock.FontWeightProperty, FontWeight.Bold),
+                new Setter(TextBlock.LineHeightProperty, 55d),
                 new Setter(MenuItem.PaddingProperty, new Thickness(30)),
                 new Setter(MenuItem.MinHeightProperty, 77d),
             },
@@ -377,6 +380,11 @@ public class MenuPackContractTests
         }
     }
 
+    /// <summary>
+    /// A fast pointer move can jump from the parent item to outside the submenu without
+    /// ever entering the popup. Avalonia normally queues a delayed close on that exit,
+    /// so the DevExpress behavior must intercept the open parent's exit event.
+    /// </summary>
     [AvaloniaFact]
     public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
     {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Platform;
 using Avalonia.Headless.XUnit;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Media;
 using Avalonia.Styling;
 using AvaloniaFluentTheme = Avalonia.Themes.Fluent.FluentTheme;
 using Avalonia.Threading;
@@ -215,6 +216,51 @@ public class MenuPackContractTests
     /// ever entering the popup. Avalonia normally queues a delayed close on that exit,
     /// so the DevExpress behavior must intercept the open parent's exit event.
     /// </summary>
+    [AvaloniaFact]
+    public void Host_menu_item_styles_do_not_change_pinned_typography()
+    {
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light, Width = 500, Height = 300 };
+        window.Styles.Add(new AvaloniaFluentTheme());
+
+        var uri = new Uri(PackUri);
+        window.Styles.Add(new StyleInclude(uri) { Source = uri });
+
+        var hostStyle = new Style(selector => selector.OfType<MenuItem>())
+        {
+            Setters =
+            {
+                new Setter(TextBlock.FontSizeProperty, 42d),
+                new Setter(TextBlock.FontWeightProperty, FontWeight.Bold),
+                new Setter(TextBlock.LineHeightProperty, 55d),
+            },
+        };
+        window.Styles.Add(hostStyle);
+
+        var menuItem = new MenuItem { Header = "Pinned" };
+        var contextMenu = new ContextMenu { Items = { menuItem } };
+        var button = new Button { Content = "Open", ContextMenu = contextMenu };
+        window.Content = button;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            contextMenu.Open(button);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(12d, menuItem.FontSize, 3);
+            Assert.Equal(FontWeight.Normal, menuItem.FontWeight);
+            Assert.True(double.IsNaN(menuItem.GetValue(TextBlock.LineHeightProperty)));
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
     [AvaloniaFact]
     public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
     {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -320,6 +320,64 @@ public class MenuPackContractTests
     }
 
     [AvaloniaFact]
+    public void Host_menu_item_styles_do_not_change_normal_state_colours()
+    {
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light, Width = 500, Height = 300 };
+        window.Styles.Add(new AvaloniaFluentTheme());
+        window.Styles.Add(new StyleInclude(new Uri(PackUri)) { Source = new Uri(PackUri) });
+
+        var hostStyle = new Style(selector => selector.OfType<MenuItem>())
+        {
+            Setters =
+            {
+                new Setter(MenuItem.BackgroundProperty, Brushes.Purple),
+                new Setter(MenuItem.ForegroundProperty, Brushes.Green),
+            },
+        };
+        window.Styles.Add(hostStyle);
+
+        var popupItem = new MenuItem { Header = "Popup" };
+        var contextMenu = new ContextMenu { Items = { popupItem } };
+        var button = new Button { ContextMenu = contextMenu };
+        button.Content = "Open";
+
+        var menu = new Menu
+        {
+            Items =
+            {
+                new MenuItem { Header = "File" },
+                new MenuItem { Header = "Edit" },
+            },
+        };
+        var barItem = (MenuItem)menu.Items[0];
+        window.Content = new StackPanel { Children = { button, menu } };
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            contextMenu.Open(button);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(window.TryFindResource("DevExMenuItemBackground", ThemeVariant.Light, out object? popupBackground));
+            Assert.True(window.TryFindResource("DevExMenuItemForeground", ThemeVariant.Light, out object? popupForeground));
+
+            Assert.Equal(((SolidColorBrush)popupBackground!).Color, ((SolidColorBrush)popupItem.Background!).Color);
+            Assert.Equal(((SolidColorBrush)popupForeground!).Color, ((SolidColorBrush)popupItem.Foreground!).Color);
+
+            Assert.Equal(((SolidColorBrush)popupBackground!).Color, ((SolidColorBrush)barItem.Background!).Color);
+            Assert.Equal(((SolidColorBrush)popupForeground!).Color, ((SolidColorBrush)barItem.Foreground!).Color);
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
     public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
     {
         var parent = new MenuItem


### PR DESCRIPTION
This deals with a couple of issues in the DevExpress MenuPack discovered during work on the Linux MenuPack (#630)

## Summary
- Fix the DevExpress menu-pack typography leak when a host `MenuItem` style overrides `FontSize`, `FontWeight`, or `LineHeight`.
- Add a regression test that renders a real `ContextMenu` under a hostile host style and asserts the menu remains pinned.
- Clarify the README guidance for overriding menu tokens and the resource-scope rule.

## Validation
- `dotnet build --nologo`
- `dotnet test tests/Devolutions.AvaloniaControls.VisualTests/Devolutions.AvaloniaControls.VisualTests.csproj --filter "MenuPackContractTests" -v minimal`
- `dotnet test tests/Devolutions.AvaloniaControls.VisualTests/Devolutions.AvaloniaControls.VisualTests.csproj --filter "VisualRegressionTests" -v minimal`