### PR TITLE
Separate visual and functional test runs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -130,6 +130,9 @@ to the OS-default theme (MacOS on macOS, DevExpress on Windows, etc.). This is w
 ### Testing
 Automated tests are available and should be used:
 - `dotnet test` runs the repository test suite, including visual regression tests.
+- `dotnet test --filter "DisplayName~VisualRegressionTests"` runs only visual regression tests.
+- `dotnet test --filter "DisplayName!~VisualRegressionTests"` runs only non-visual tests.
+- `./devtest visual` / `./devtest nonvisual` provide the same split with concise output.
 - Catalog and discovery behavior is covered in `tests/Devolutions.AvaloniaControls.VisualTests/` (for example `PageCatalogTests`, `VisualRegressionTests`, and `MainWindowNavigationTests`).
 
 Manual validation via SampleApp is still important for exploratory UI checks and theme behavior.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -132,7 +132,7 @@ Automated tests are available and should be used:
 - `dotnet test` runs the repository test suite, including visual regression tests.
 - `dotnet test --filter "DisplayName~VisualRegressionTests"` runs only visual regression tests.
 - `dotnet test --filter "DisplayName!~VisualRegressionTests"` runs only non-visual tests.
-- `./devtest visual` / `./devtest nonvisual` provide the same split with concise output.
+- `./devtest visual` / `./devtest nonvisual` / `./devtest functional` provide the same split with concise output; these are wrapper shorthands, not native `dotnet test` arguments.
 - Catalog and discovery behavior is covered in `tests/Devolutions.AvaloniaControls.VisualTests/` (for example `PageCatalogTests`, `VisualRegressionTests`, and `MainWindowNavigationTests`).
 
 Manual validation via SampleApp is still important for exploratory UI checks and theme behavior.

--- a/README.md
+++ b/README.md
@@ -53,13 +53,27 @@ Screenshots are captured at a fixed width (`1200`) with auto-calculated content 
 Baselines are maintained separately for each platform (`macOS`, `Windows`, `Linux`) due to rendering differences. When updating baselines, they only update for your current platform.
 
 ### Usage
-- `dotnet test --filter "DisplayName~VisualRegressionTests"` - runs all tests
-- `dotnet test` - runs all tests, plus some little unit tests (worth it for the time saved typing!)
+- `dotnet test` - runs all tests
+- `dotnet test --filter "DisplayName~VisualRegressionTests"` - runs only visual regression tests
+- `dotnet test --filter "DisplayName!~VisualRegressionTests"` - runs only non-visual tests
 - `dotnet test --filter "DisplayName~DevExpress"` - runs tests for all controls implemented in DevExpress
 - `dotnet test --filter "DisplayName~Button"` - runs tests for Button under each of the themes it's implemented in
 - `dotnet test --list-tests` - lists all test cases
-🆕 **Shor hand command & cleaner output:**
-- `./devtest` (macOS/Linux/Git Bash) or `.\devtest` (Windows PowerShell/CMD) - runs a script that calls the tests and prints a succinct visual-regression summary at the end. You can also use it with shorthand filter values (for example `--filter EditableCombo` instead of `--filter "DisplayName~EditableCombo"`).
+
+#### Combining `DisplayName` filters
+The xUnit/VSTest filter syntax uses `&` for AND, `|` for OR and `!` for NOT. 
+
+- `dotnet test --filter "DisplayName~Button&DisplayName~DevExpress"` - runs only tests whose display name contains both `Button` and `DevExpress`
+- `dotnet test --filter "DisplayName~ContextMenu|DisplayName~MenuFlyout"` - runs tests containing either `ContextMenu` or `MenuFlyout`
+- `dotnet test --filter "DisplayName~Button&DisplayName!~HyperlinkButton"` - runs tests containing `Button` but excluding `HyperlinkButton`
+
+
+🆕 **Shorthand command & cleaner output:**
+- `./devtest` (macOS/Linux/Git Bash) or `.\devtest` (Windows PowerShell/CMD) - runs all tests with a succinct summary.
+- `./devtest visual` - runs only visual regression tests.
+- `./devtest nonvisual` - runs only non-visual tests.
+- `./devtest functional` - alias for `nonvisual`.
+- `./devtest --filter EditableCombo` - shorthand for (`DisplayName~EditableCombo`).
 
 **Updating baseline screenshots** when changes are intentional:
 - **macOS/Linux:** `UPDATE_BASELINES=true dotnet test [filters]`

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -179,13 +179,17 @@ $inErrorMessageBlock = $false
         }
         $lastProgressTest = $testName
         $lastProgressStatus = $status
-        return
-    }
 
-    if ($normalized -match '^Failed\s+(.+)\[[^\]]+\]$') {
-        $currentFailedTest = $Matches[1].TrimEnd()
-        $currentFailureMessage = ""
-        $inErrorMessageBlock = $false
+        if ($status -eq "Failed") {
+            if ($testName -match 'VisualRegressionTests') {
+                $currentFailedTest = $null
+            }
+            else {
+                $currentFailedTest = $testName
+            }
+            $currentFailureMessage = ""
+            $inErrorMessageBlock = $false
+        }
         return
     }
 

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -15,12 +15,47 @@ function Normalize-FilterExpression {
     return "DisplayName~$Expression"
 }
 
+function Resolve-PresetFilter {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Preset
+    )
+
+    switch ($Preset.ToLowerInvariant()) {
+        "visual" { return "DisplayName~VisualRegressionTests" }
+        "nonvisual" { return "DisplayName!~VisualRegressionTests" }
+        "non-visual" { return "DisplayName!~VisualRegressionTests" }
+        "functional" { return "DisplayName!~VisualRegressionTests" }
+        "all" { return "" }
+        default { return $null }
+    }
+}
+
 $dotnetArgs = [System.Collections.Generic.List[string]]::new()
 $hasLoggerArg = $false
+$hasFilterArg = $false
+
+$presetFilter = $null
+$presetToken = $null
+if ($args.Count -gt 0) {
+    $resolvedPresetFilter = Resolve-PresetFilter -Preset $args[0]
+    if ($null -ne $resolvedPresetFilter) {
+        $presetFilter = $resolvedPresetFilter
+        $presetToken = $args[0]
+        if ($args.Count -gt 1) {
+            $args = $args[1..($args.Count - 1)]
+        }
+        else {
+            $args = @()
+        }
+    }
+}
+
 for ($index = 0; $index -lt $args.Count; ) {
     $current = $args[$index]
 
     if ($current -eq "--filter") {
+        $hasFilterArg = $true
         if ($index + 1 -ge $args.Count) {
             $dotnetArgs.Add($current)
             $index += 1
@@ -34,6 +69,7 @@ for ($index = 0; $index -lt $args.Count; ) {
     }
 
     if ($current.StartsWith("--filter=")) {
+        $hasFilterArg = $true
         $dotnetArgs.Add("--filter=$(Normalize-FilterExpression -Expression $current.Substring(9))")
         $index += 1
         continue
@@ -65,6 +101,15 @@ for ($index = 0; $index -lt $args.Count; ) {
     $index += 1
 }
 
+if (-not [string]::IsNullOrEmpty($presetFilter)) {
+    if ($hasFilterArg) {
+        throw "Cannot combine preset '$presetToken' with an explicit --filter. Use one or the other."
+    }
+
+    $dotnetArgs.Add("--filter")
+    $dotnetArgs.Add($presetFilter)
+}
+
 if (-not $hasLoggerArg) {
     $dotnetArgs.Add("--logger")
     $dotnetArgs.Add("console;verbosity=normal")
@@ -72,8 +117,11 @@ if (-not $hasLoggerArg) {
 
 $summaryRows = [System.Collections.Generic.HashSet[string]]::new()
 $fallbackLines = [System.Collections.Generic.List[string]]::new()
+$functionalFailureRows = [System.Collections.Generic.List[string]]::new()
 $resultLine = ""
 $progressSeen = $false
+$lastProgressTest = $null
+$lastProgressStatus = $null
 $testRunTarget = ""
 $testRunStatus = ""
 $totalTests = 0
@@ -81,6 +129,9 @@ $passedTests = 0
 $failedTests = 0
 $skippedTests = 0
 $totalDuration = ""
+$currentFailedTest = $null
+$currentFailureMessage = ""
+$inErrorMessageBlock = $false
 
 & dotnet test @dotnetArgs 2>&1 | ForEach-Object {
     $line = "$_"
@@ -106,30 +157,62 @@ $totalDuration = ""
         return
     }
 
-    if ($normalized -match '^(Passed|Failed|Skipped)\s+.*\[[^\]]+\]$') {
+    if ($normalized -match '^(Passed|Failed|Skipped)\s+(.+)\[[^\]]+\]$') {
+        $status = $Matches[1]
+        $testName = $Matches[2].TrimEnd()
+
+        if ($null -ne $lastProgressTest -and $lastProgressTest -eq $testName -and $lastProgressStatus -eq $status) {
+            $lastProgressTest = $null
+            $lastProgressStatus = $null
+            return
+        }
+
         if (-not $progressSeen) {
             Write-Host -NoNewline "Progress: "
             $progressSeen = $true
         }
 
-        switch ($Matches[1]) {
+        switch ($status) {
             "Passed" { Write-Host -NoNewline "✅" }
             "Failed" { Write-Host -NoNewline "❌" }
             "Skipped" { Write-Host -NoNewline "s" }
         }
+        $lastProgressTest = $testName
+        $lastProgressStatus = $status
         return
     }
 
-    if ($normalized -match '\[(FAIL|PASS|SKIP)\]$') {
-        if (-not $progressSeen) {
-            Write-Host -NoNewline "Progress: "
-            $progressSeen = $true
+    if ($normalized -match '^Failed\s+(.+)\[[^\]]+\]$') {
+        $currentFailedTest = $Matches[1].TrimEnd()
+        $currentFailureMessage = ""
+        $inErrorMessageBlock = $false
+        return
+    }
+
+    if ($normalized -match '^Error Message:$') {
+        $inErrorMessageBlock = $true
+        return
+    }
+
+    if ($inErrorMessageBlock) {
+        if ($normalized -match '^Stack Trace:$') {
+            if (-not [string]::IsNullOrWhiteSpace($currentFailedTest) -and -not [string]::IsNullOrWhiteSpace($currentFailureMessage)) {
+                $functionalFailureRows.Add("$currentFailedTest`t$currentFailureMessage")
+            }
+            $currentFailedTest = $null
+            $currentFailureMessage = ""
+            $inErrorMessageBlock = $false
+            return
         }
 
-        switch ($Matches[1]) {
-            "PASS" { Write-Host -NoNewline "✅" }
-            "FAIL" { Write-Host -NoNewline "❌" }
-            "SKIP" { Write-Host -NoNewline "s" }
+        $trimmed = $normalized.Trim()
+        if (-not [string]::IsNullOrWhiteSpace($trimmed) -and -not $trimmed.StartsWith('at ')) {
+            if ([string]::IsNullOrWhiteSpace($currentFailureMessage)) {
+                $currentFailureMessage = $trimmed
+            }
+            else {
+                $currentFailureMessage = "$currentFailureMessage | $trimmed"
+            }
         }
         return
     }
@@ -232,6 +315,21 @@ if ($summaryRows.Count -gt 0) {
     foreach ($row in $summaryRows) {
         $parts = $row -split "`t", 6
         Write-Host ("{0,-18} {1,-14} {2,-34} {3,-10} {4,-8} {5}" -f $parts[0], "[$($parts[1])]", $parts[2], $parts[3], $parts[5], $parts[4]) -ForegroundColor Yellow
+    }
+
+    Write-Host "________________________________________________________________________________"
+    Write-Host ""
+}
+
+if ($functionalFailureRows.Count -gt 0) {
+    Write-Host ""
+    Write-Host "________________________________________________________________________________"
+    Write-Host "Functional test failures" -ForegroundColor White
+
+    foreach ($row in $functionalFailureRows) {
+        $parts = $row -split "`t", 2
+        Write-Host ("• {0}" -f $parts[0]) -ForegroundColor White
+        Write-Host ("  {0}" -f $parts[1])
     }
 
     Write-Host "________________________________________________________________________________"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -271,7 +271,7 @@ dotnet_exit_code=${PIPESTATUS[0]}
 if [[ -s "$raw_output_file" ]]; then
   awk '
     BEGIN { current=""; message=""; in_error=0 }
-    /^[[:space:]]*Failed[[:space:]]+/ {
+    /^[[:space:]]*Failed[[:space:]]+[^[]+\[[^]]+\][[:space:]]*$/ {
       current = $0
       sub(/^[[:space:]]*Failed[[:space:]]+/, "", current)
       sub(/[[:space:]]+\[[^]]+\][[:space:]]*$/, "", current)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,11 +20,42 @@ normalize_filter_expression() {
   printf 'DisplayName~%s' "$expression"
 }
 
+resolve_preset_filter() {
+  local preset="$1"
+  case "$preset" in
+    visual)
+      printf 'DisplayName~VisualRegressionTests'
+      ;;
+    nonvisual|non-visual|functional)
+      printf 'DisplayName!~VisualRegressionTests'
+      ;;
+    all)
+      printf ''
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 dotnet_args=()
 has_logger_arg=0
+has_filter_arg=0
+preset_filter=""
+preset_token=""
+
+if [[ $# -gt 0 ]]; then
+  if resolved_preset_filter="$(resolve_preset_filter "$1")"; then
+    preset_filter="$resolved_preset_filter"
+    preset_token="$1"
+    shift
+  fi
+fi
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --filter)
+      has_filter_arg=1
       if [[ $# -lt 2 ]]; then
         dotnet_args+=("$1")
         shift
@@ -34,6 +65,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --filter=*)
+      has_filter_arg=1
       dotnet_args+=("--filter=$(normalize_filter_expression "${1#--filter=}")")
       shift
       ;;
@@ -59,6 +91,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -n "$preset_filter" ]]; then
+  if [[ "$has_filter_arg" -eq 1 ]]; then
+    printf '%s\n' "Cannot combine preset '$preset_token' with an explicit --filter. Use one or the other." >&2
+    exit 1
+  fi
+  dotnet_args+=("--filter" "$preset_filter")
+fi
+
 if [[ "$has_logger_arg" -eq 0 ]]; then
   dotnet_args+=("--logger" "console;verbosity=normal")
 fi
@@ -68,17 +108,23 @@ result_line_file="$(mktemp -t visual-regression-result.XXXXXX)"
 progress_seen_file="$(mktemp -t visual-regression-progress.XXXXXX)"
 fallback_file="$(mktemp -t visual-regression-fallback.XXXXXX)"
 totals_file="$(mktemp -t visual-regression-totals.XXXXXX)"
+raw_output_file="$(mktemp -t visual-regression-output.XXXXXX)"
+functional_failures_file="$(mktemp -t functional-test-failures.XXXXXX)"
+last_progress_test=""
+last_progress_status=""
 cleanup() {
   rm -f "$summary_file"
   rm -f "$result_line_file"
   rm -f "$progress_seen_file"
   rm -f "$fallback_file"
   rm -f "$totals_file"
+  rm -f "$raw_output_file"
+  rm -f "$functional_failures_file"
 }
 trap cleanup EXIT
 
 test_run_target=""
-dotnet test ${dotnet_args[@]+"${dotnet_args[@]}"} 2>&1 | while IFS= read -r line; do
+dotnet test ${dotnet_args[@]+"${dotnet_args[@]}"} 2>&1 | tee "$raw_output_file" | while IFS= read -r line; do
   normalized="$line"
 
   if [[ "$normalized" =~ ^\[xUnit\.net[[:space:]][^]]+\][[:space:]]*(.*)$ ]]; then
@@ -101,29 +147,28 @@ dotnet test ${dotnet_args[@]+"${dotnet_args[@]}"} 2>&1 | while IFS= read -r line
     continue
   fi
 
-  if [[ "$normalized" =~ ^(Passed|Failed|Skipped)[[:space:]]+.*\[[^]]+\]$ ]]; then
+  if [[ "$normalized" =~ ^(Passed|Failed|Skipped)[[:space:]]+(.+)\[[^]]+\]$ ]]; then
+    status_key="${BASH_REMATCH[1]}"
+    test_name="${BASH_REMATCH[2]}"
+    test_name="${test_name%[[:space:]]}"
+
+    if [[ "$last_progress_test" == "$test_name" && "$last_progress_status" == "$status_key" ]]; then
+      last_progress_test=""
+      last_progress_status=""
+      continue
+    fi
+
     if [[ ! -s "$progress_seen_file" ]]; then
       printf 'Progress: '
       printf '1' > "$progress_seen_file"
     fi
-    case "${BASH_REMATCH[1]}" in
+    case "$status_key" in
       Passed) printf '✅' ;;
       Failed) printf '❌' ;;
       Skipped) printf 's' ;;
     esac
-    continue
-  fi
-
-  if [[ "$normalized" =~ \[(FAIL|PASS|SKIP)\]$ ]]; then
-    if [[ ! -s "$progress_seen_file" ]]; then
-      printf 'Progress: '
-      printf '1' > "$progress_seen_file"
-    fi
-    case "${BASH_REMATCH[1]}" in
-      PASS) printf '✅' ;;
-      FAIL) printf '❌' ;;
-      SKIP) printf 's' ;;
-    esac
+    last_progress_test="$test_name"
+    last_progress_status="$status_key"
     continue
   fi
 
@@ -201,6 +246,54 @@ done
 
 dotnet_exit_code=${PIPESTATUS[0]}
 
+# Parse the raw output after the run so we can print a readable functional failure list regardless of xUnit formatting details.
+if [[ -s "$raw_output_file" ]]; then
+  awk '
+    BEGIN { current=""; message=""; in_error=0 }
+    /^[[:space:]]*Failed[[:space:]]+/ {
+      if (current != "" && message != "") {
+        print current "\t" message
+      }
+      current = $0
+      sub(/^[[:space:]]*Failed[[:space:]]+/, "", current)
+      sub(/[[:space:]]+\[[^]]+\][[:space:]]*$/, "", current)
+      message = ""
+      in_error = 0
+      next
+    }
+    /^[[:space:]]*Error Message:[[:space:]]*$/ {
+      in_error = 1
+      next
+    }
+    in_error {
+      if ($0 ~ /^[[:space:]]*Stack Trace:[[:space:]]*$/) {
+        if (current != "" && message != "") {
+          print current "\t" message
+        }
+        current = ""
+        message = ""
+        in_error = 0
+        next
+      }
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line == "" || line ~ /^at /) {
+        next
+      }
+      if (message != "") {
+        message = message " | "
+      }
+      message = message line
+      next
+    }
+    END {
+      if (current != "" && message != "") {
+        print current "\t" message
+      }
+    }
+  ' "$raw_output_file" > "$functional_failures_file"
+fi
+
 if [[ -s "$progress_seen_file" ]]; then
   printf '\n'
 fi
@@ -240,6 +333,16 @@ if [[ -s "$summary_file" ]]; then
   while IFS=$'\t' read -r status theme page variant path capped_desired_height; do
     printf '\033[33;1m%-18s %-14s %-34s %-10s %-8s %s\033[0m\n' "$status" "[$theme]" "$page" "$variant" "${capped_desired_height:-}" "$path"
   done < "$summary_file"
+  printf '%s\n\n' "________________________________________________________________________________"
+fi
+
+if [[ -s "$functional_failures_file" ]]; then
+  printf '\n%s\n' "________________________________________________________________________________"
+  printf '\033[1m%s\033[0m\n' "Functional test failures"
+  while IFS=$'\t' read -r test_name failure_message; do
+    printf '\033[1m• %s\033[0m\n' "$test_name"
+    printf '  %s\n' "$failure_message"
+  done < "$functional_failures_file"
   printf '%s\n\n' "________________________________________________________________________________"
 fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -169,11 +169,32 @@ dotnet test ${dotnet_args[@]+"${dotnet_args[@]}"} 2>&1 | tee "$raw_output_file" 
     esac
     last_progress_test="$test_name"
     last_progress_status="$status_key"
+
+    if [[ "$status_key" == "Failed" ]]; then
+      if [[ "$test_name" == *"VisualRegressionTests"* ]]; then
+        current_failed_test=""
+      else
+        current_failed_test="$test_name"
+      fi
+      current_failed_message=""
+      in_error_message_block=0
+    fi
     continue
   fi
 
   if [[ "$normalized" =~ ^(Failed!|Passed!)[[:space:]]+-[[:space:]]+Failed:[[:space:]]+[0-9]+,[[:space:]]+Passed:[[:space:]]+[0-9]+,[[:space:]]+Skipped:[[:space:]]+[0-9]+,[[:space:]]+Total:[[:space:]]+[0-9]+, ]]; then
     printf '%s\n' "$normalized" > "$result_line_file"
+    continue
+  fi
+
+  if [[ "$normalized" =~ ^Failed[[:space:]]+(.+)\[[^]]+\]$ ]]; then
+    if [[ "${BASH_REMATCH[1]}" == *"VisualRegressionTests"* ]]; then
+      continue
+    fi
+    current_failed_test="${BASH_REMATCH[1]}"
+    current_failed_test="${current_failed_test%[[:space:]]}"
+    current_failed_message=""
+    in_error_message_block=0
     continue
   fi
 
@@ -251,17 +272,32 @@ if [[ -s "$raw_output_file" ]]; then
   awk '
     BEGIN { current=""; message=""; in_error=0 }
     /^[[:space:]]*Failed[[:space:]]+/ {
-      if (current != "" && message != "") {
-        print current "\t" message
-      }
       current = $0
       sub(/^[[:space:]]*Failed[[:space:]]+/, "", current)
       sub(/[[:space:]]+\[[^]]+\][[:space:]]*$/, "", current)
+      if (current ~ /VisualRegressionTests/) {
+        current = ""
+        message = ""
+        in_error = 0
+        next
+      }
+      if (message != "") {
+        print current "\t" message
+      }
+      message = ""
+      in_error = 0
+      next
+    }
+    /^[[:space:]]*No baseline found for / || /^[[:space:]]*Visual regression detected for / {
+      current = ""
       message = ""
       in_error = 0
       next
     }
     /^[[:space:]]*Error Message:[[:space:]]*$/ {
+      if (current == "") {
+        next
+      }
       in_error = 1
       next
     }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -271,10 +271,10 @@ dotnet_exit_code=${PIPESTATUS[0]}
 if [[ -s "$raw_output_file" ]]; then
   awk '
     BEGIN { current=""; message=""; in_error=0 }
-    /^[[:space:]]*Failed[[:space:]]+[^[]+\[[^]]+\][[:space:]]*$/ {
+    /^[[:space:]]*Failed[[:space:]]+.*\[[^][]+\][[:space:]]*$/ {
       current = $0
       sub(/^[[:space:]]*Failed[[:space:]]+/, "", current)
-      sub(/[[:space:]]+\[[^]]+\][[:space:]]*$/, "", current)
+      sub(/[[:space:]]+\[[^][]+\][[:space:]]*$/, "", current)
       if (current ~ /VisualRegressionTests/) {
         current = ""
         message = ""


### PR DESCRIPTION
## Summary

This PR allows developers to run the visual regression suite and the rest of the tests separately using xUnit/VSTest `DisplayName` filters and the repository's `devtest` wrapper

The new developer experience using the `./devtest` convenience command is:

- `./devtest` = all tests
- `./devtest visual`  = visual regression tests only
- `./devtest functional`  = non-visual tests only

The same split was already supported with `dotnet test`, but not as convenient:

- `dotnet test` = all tests
- `dotnet test --filter "DisplayName~VisualRegressionTests"` = visual regression tests only
- `dotnet test --filter "DisplayName!~VisualRegressionTests"` = non-visual tests only

## Why the project name still says `VisualTests`

There is a slight mismatch in the repo layout: the non-visual tests still live in the `tests/Devolutions.AvaloniaControls.VisualTests` project/folder for now. We intentionally left that alone for this change because the project currently contains the shared Avalonia test harness, screenshot-baseline setup, and page/test app infrastructure. The test split is enforced at runtime via filters, which is the part we wanted to improve without taking on a broader project refactor.

## Notes

- The visual summary output is kept concise and targeted to screenshot regressions.
- Functional failures now print a more readable list of failing test names with their assertion messages.
- This change is intentionally limited to the wrapper/test-selection behavior and output formatting; it does not attempt a broader project reorganization.
