### PR TITLE
Enable automatic squash merge (instead of all commits)

### DIFF
--- a/.github/randy.yml
+++ b/.github/randy.yml
@@ -5,3 +5,11 @@ ai-review-approval:
   authorized-authors: ["apman", "Samuel-B-D", "xfortin-devolutions"]
   human-review-paths:
     - ".github/"
+
+pull-request-rules:
+  - name: autoSquashMerge
+    action: merge
+    authorized-actors: ["devolutions/architecture-maintainers"]
+    tags: ["auto-squash"]
+    options:
+      merge-strategy: squash


### PR DESCRIPTION
I just noticed that each time I merge our baseline updates with `[auto]`, it merges the 3 individual commits (from Mac, Windows and Linux). 

I think this new rule would allow us to use `[auto-squash]` for cleaner merge commits. 

(Similar rule is in https://github.com/Devolutions/forum/blob/master/.github/randy.yml)