### PR TITLE
[MenuPacks] Only seal host-proofing styles in standalone packs, not full themes

### DIFF
--- a/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Accents/MenuResources.axaml
@@ -87,7 +87,13 @@
   <FontWeight x:Key="DevExMenuFontWeight">Normal</FontWeight>
 
   <!-- Menu bar -->
+  <!--
+    BarHeight sizes the bar itself (the Menu ControlTheme's Height). BarItemMinHeight sizes the
+    items inside it, which also carry Margin="3" - so it must stay small enough that
+    BarItemMinHeight + margins fits within BarHeight, or bar items overflow the menu's border.
+  -->
   <x:Double x:Key="DevExMenuBarHeight">32</x:Double>
+  <x:Double x:Key="DevExMenuBarItemMinHeight">26</x:Double>
 
   <!-- Popup surfaces -->
   <Thickness x:Key="DevExMenuPopupBorderThickness">1</Thickness>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/Menu.styles.axaml
@@ -20,29 +20,19 @@
     <Setter Property="behaviors:MenuSeparatorAlignmentBehavior.Enable" Value="False" />
   </Style>
 
+  <!--
+    Popup-row geometry. This predates the menu pack's host-proofing work and is part of the
+    theme's baseline look, so it stays here and ships with the full theme as well as the pack.
+
+    The host-proofing "sealing" styles that used to sit alongside this (re-asserting colors,
+    typography and the menu-bar geometry) have moved to MenuPack.Sealing.styles.axaml, which is
+    included only by the standalone menu pack (MenuPack.styles.axaml), not by the full theme's
+    GlobalStyles.axaml. Inside the full theme, app-level Style overrides on menu items must be
+    able to win, the same way they can for any other themed control - see
+    MenuPack.Sealing.styles.axaml for the full rationale.
+  -->
   <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
     <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
     <Setter Property="Padding" Value="{DynamicResource DevExMenuNestedItemPadding}" />
-    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
-    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
-  </Style>
-
-  <!--
-    Menu-bar items are direct children of Menu, so the popup-row selector above does not reach them.
-    A host MenuItem Style therefore still overrides the ControlTheme unless we seal the bar items too.
-  -->
-  <Style Selector="Menu > MenuItem:not(:separator)">
-    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
-    <Setter Property="Padding" Value="6 1" />
-    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
-    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
   </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
@@ -38,9 +38,15 @@
   <!--
     Menu-bar items are direct children of Menu, so the popup-row selector above does not reach them.
     A host MenuItem Style therefore still overrides the ControlTheme unless we seal the bar items too.
+
+    MinHeight must match what the full theme renders (the base MenuItem ControlTheme's nested-item
+    min height), NOT DevExMenuBarHeight: that token sizes the *bar* via the Menu ControlTheme's
+    Height. Because items also carry Margin="3", sealing the bar height here made each item claim
+    BarHeight + 3 + 3 inside a BarHeight-tall bar, so bar items rendered taller than under the full
+    theme and their pointer-over highlight spilled over the menu border.
   -->
   <Style Selector="Menu > MenuItem:not(:separator)">
-    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
     <Setter Property="Padding" Value="6 1" />
     <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
@@ -39,14 +39,13 @@
     Menu-bar items are direct children of Menu, so the popup-row selector above does not reach them.
     A host MenuItem Style therefore still overrides the ControlTheme unless we seal the bar items too.
 
-    MinHeight must match what the full theme renders (the base MenuItem ControlTheme's nested-item
-    min height), NOT DevExMenuBarHeight: that token sizes the *bar* via the Menu ControlTheme's
-    Height. Because items also carry Margin="3", sealing the bar height here made each item claim
-    BarHeight + 3 + 3 inside a BarHeight-tall bar, so bar items rendered taller than under the full
-    theme and their pointer-over highlight spilled over the menu border.
+    MinHeight uses the dedicated bar-item token, NOT DevExMenuBarHeight: that token sizes the *bar*
+    via the Menu ControlTheme's Height. Because items also carry Margin="3", sealing the bar height
+    here made each item claim BarHeight + 3 + 3 inside a BarHeight-tall bar, so bar items rendered
+    taller than under the full theme and their pointer-over highlight spilled over the menu border.
   -->
   <Style Selector="Menu > MenuItem:not(:separator)">
-    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarItemMinHeight}" />
     <Setter Property="Padding" Value="6 1" />
     <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
     <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.Sealing.styles.axaml
@@ -1,0 +1,52 @@
+<!--
+  Host-proofing for the standalone DevExpress menu pack.
+
+  When the pack is layered onto an unrelated host theme (rather than used as part of the full
+  DevolutionsDevExpressTheme), a host Style targeting MenuItem generically would otherwise win over
+  the pack's ControlTheme, because a Style setter outranks a ControlTheme setter. These selectors
+  re-assert the host-invariant menu-bar/menu-row properties at StyleTrigger priority
+  (via the `:not(:separator)` pseudo-class) so they beat ordinary host Styles regardless of
+  declaration order or scope.
+
+  This file is intentionally NOT included by GlobalStyles.axaml. Inside the full theme, menu items
+  are just theme-styled controls like any other, and app-level Style overrides must be able to win,
+  the same way they can override any other control's theme styling. Only MenuPack.styles.axaml
+  includes this file, since only the standalone pack needs to defend its look against a host theme
+  it doesn't control.
+
+  If you need to override these pack styles from an app that only consumes the standalone pack
+  (not the full theme), your override selector must also enter StyleTrigger priority (for example
+  by adding your own `:not(:separator)` or other pseudo-class predicate) and should live in a scope
+  nested inside the one that hosts the pack (e.g. a UserControl.Styles below the pack's
+  Application/Window-level Styles) - Avalonia resolves same-priority ties by scope (inner wins)
+  before declaration order.
+-->
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuNestedItemMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource DevExMenuNestedItemPadding}" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
+
+  <!--
+    Menu-bar items are direct children of Menu, so the popup-row selector above does not reach them.
+    A host MenuItem Style therefore still overrides the ControlTheme unless we seal the bar items too.
+  -->
+  <Style Selector="Menu > MenuItem:not(:separator)">
+    <Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
+    <Setter Property="Padding" Value="6 1" />
+    <Setter Property="Background" Value="{DynamicResource DevExMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource DevExMenuItemForeground}" />
+    <Setter Property="FontFamily" Value="{DynamicResource DevExMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource DevExMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource DevExMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
+</Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/Controls/MenuPack.styles.axaml
@@ -24,4 +24,5 @@
   <StyleInclude Source="/Controls/MenuSvg.styles.axaml" />
   <StyleInclude Source="/Controls/Separator.styles.axaml" />
   <StyleInclude Source="/Controls/Menu.styles.axaml" />
+  <StyleInclude Source="/Controls/MenuPack.Sealing.styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.DevExpress/README.md
+++ b/src/Devolutions.AvaloniaTheme.DevExpress/README.md
@@ -152,6 +152,13 @@ geometry and the top-level bar geometry are different, so the seal pins the same
 for both while preserving each item's own padding and bar height. The seal intentionally covers the normal state only;
 hover, pressed, selected, and disabled states are handled by template-child selectors in the `MenuItem` control theme.
 
+This sealing lives in `MenuPack.Sealing.styles.axaml` and is included only by the standalone pack, not by the full
+`DevolutionsDevExpressTheme`. Inside the full theme, app-level `Style` overrides on menu items are expected to win,
+the same as for any other themed control. To override a pack-sealed property from a consuming app, your override
+selector must also match a pseudo-class (e.g. `:not(:separator)`) to reach the same `StyleTrigger` priority tier, and
+should live in a scope nested inside the one hosting the pack (Avalonia resolves same-priority ties by scope — inner
+wins — before declaration order).
+
 **The pack styles menu content only.** It deliberately does not ship a `Separator` `ControlTheme`:
 that resource is keyed `{x:Type Separator}`, so merging it would restyle *every* separator in your
 app rather than just menu ones. Menu separators instead reuse the host's separator template — which

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/Menu.styles.axaml
@@ -24,38 +24,14 @@
   </Style>
 
   <!--
-    Row geometry and typography are (re)applied at Style level, not only through the MenuItem
-    ControlTheme. Host themes set these with Styles of their own (for example the DevExpress
-    theme's Menu.styles.axaml), and a Style setter outranks a ControlTheme setter, so a
-    ControlTheme alone lets the host resize menu rows when the pack is layered on top.
-  -->
-  <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
-    <Setter Property="Background" Value="{DynamicResource LinuxMenuItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource LinuxMenuItemForeground}" />
-    <Setter Property="MinHeight" Value="{DynamicResource LinuxMenuItemMinHeight}" />
-    <Setter Property="Padding" Value="{DynamicResource LinuxMenuItemPadding}" />
-    <Setter Property="FontFamily" Value="{DynamicResource LinuxMenuFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource LinuxMenuFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource LinuxMenuFontWeight}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
-  </Style>
+    Note: host-proofing "sealing" styles for menu-bar/menu-row geometry and typography used to
+    live here. They have moved to MenuPack.Sealing.styles.axaml, which is included only by the
+    standalone menu pack (MenuPack.styles.axaml), not by the full theme's GlobalStyles.axaml.
+    Inside the full theme, app-level Style overrides on menu items must be able to win, the same
+    way they can for any other themed control - see MenuPack.Sealing.styles.axaml for the full
+    rationale.
 
-  <!--
-    Same sealing for menu-bar items. They are direct children of Menu, so the selector above
-    (which only matches popup rows and submenu items) does not reach them, leaving the menu bar
-    exposed to a host MenuItem Style.
-
-    The geometry tokens differ from the popup rows: menu-bar items have their own padding, so
-    the popup row padding must NOT be applied here.
+    The separate `MenuItem:separator` MinHeight rule above remains here (StyleTrigger priority,
+    unaffected by this move) and continues to protect separator rows independently.
   -->
-  <Style Selector="Menu > MenuItem:not(:separator)">
-    <Setter Property="Background" Value="{DynamicResource LinuxMenuItemBackground}" />
-    <Setter Property="Foreground" Value="{DynamicResource LinuxMenuItemForeground}" />
-    <Setter Property="MinHeight" Value="{DynamicResource LinuxMenuItemMinHeight}" />
-    <Setter Property="Padding" Value="{DynamicResource LinuxMenuTopLevelItemPadding}" />
-    <Setter Property="FontFamily" Value="{DynamicResource LinuxMenuFontFamily}" />
-    <Setter Property="FontSize" Value="{DynamicResource LinuxMenuFontSize}" />
-    <Setter Property="FontWeight" Value="{DynamicResource LinuxMenuFontWeight}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
-  </Style>
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuPack.Sealing.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuPack.Sealing.styles.axaml
@@ -1,0 +1,56 @@
+<!--
+  Host-proofing for the standalone Linux (Yaru) menu pack.
+
+  When the pack is layered onto an unrelated host theme (rather than used as part of the full
+  DevolutionsLinuxYaruTheme), a host Style targeting MenuItem generically would otherwise win over
+  the pack's ControlTheme, because a Style setter outranks a ControlTheme setter. These selectors
+  re-assert the host-invariant menu-bar/menu-row properties at StyleTrigger priority
+  (via the `:not(:separator)` pseudo-class) so they beat ordinary host Styles regardless of
+  declaration order or scope.
+
+  This file is intentionally NOT included by GlobalStyles.axaml. Inside the full theme, menu items
+  are just theme-styled controls like any other, and app-level Style overrides must be able to win,
+  the same way they can override any other control's theme styling. Only MenuPack.styles.axaml
+  includes this file, since only the standalone pack needs to defend its look against a host theme
+  it doesn't control.
+
+  If you need to override these pack styles from an app that only consumes the standalone pack
+  (not the full theme), your override selector must also enter StyleTrigger priority (for example
+  by adding your own `:not(:separator)` or other pseudo-class predicate) and should live in a scope
+  nested inside the one that hosts the pack (e.g. a UserControl.Styles below the pack's
+  Application/Window-level Styles) - Avalonia resolves same-priority ties by scope (inner wins)
+  before declaration order.
+-->
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
+    <Setter Property="Background" Value="{DynamicResource LinuxMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource LinuxMenuItemForeground}" />
+    <Setter Property="MinHeight" Value="{DynamicResource LinuxMenuItemMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource LinuxMenuItemPadding}" />
+    <Setter Property="FontFamily" Value="{DynamicResource LinuxMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource LinuxMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource LinuxMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
+
+  <!--
+    Same sealing for menu-bar items. They are direct children of Menu, so the selector above
+    (which only matches popup rows and submenu items) does not reach them, leaving the menu bar
+    exposed to a host MenuItem Style.
+
+    The geometry tokens differ from the popup rows: menu-bar items have their own padding, so
+    the popup row padding must NOT be applied here.
+  -->
+  <Style Selector="Menu > MenuItem:not(:separator)">
+    <Setter Property="Background" Value="{DynamicResource LinuxMenuItemBackground}" />
+    <Setter Property="Foreground" Value="{DynamicResource LinuxMenuItemForeground}" />
+    <Setter Property="MinHeight" Value="{DynamicResource LinuxMenuItemMinHeight}" />
+    <Setter Property="Padding" Value="{DynamicResource LinuxMenuTopLevelItemPadding}" />
+    <Setter Property="FontFamily" Value="{DynamicResource LinuxMenuFontFamily}" />
+    <Setter Property="FontSize" Value="{DynamicResource LinuxMenuFontSize}" />
+    <Setter Property="FontWeight" Value="{DynamicResource LinuxMenuFontWeight}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
+</Styles>

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuPack.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/MenuPack.styles.axaml
@@ -37,4 +37,5 @@
   <StyleInclude Source="/Controls/MenuSvg.styles.axaml" />
   <StyleInclude Source="/Controls/Separator.styles.axaml" />
   <StyleInclude Source="/Controls/Menu.styles.axaml" />
+  <StyleInclude Source="/Controls/MenuPack.Sealing.styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.Linux/README.md
+++ b/src/Devolutions.AvaloniaTheme.Linux/README.md
@@ -136,6 +136,13 @@ of `Menu`** and would otherwise be left exposed. The two blocks pin the same typ
 since menu-bar items have their own padding. Only the *normal* state is sealed there; hover / selected /
 disabled colours are applied to template children, which a host `MenuItem` style cannot reach.
 
+This sealing lives in `MenuPack.Sealing.styles.axaml` and is included only by the standalone pack, not by the full
+`DevolutionsLinuxYaruTheme`. Inside the full theme, app-level `Style` overrides on menu items are expected to win,
+the same as for any other themed control. To override a pack-sealed property from a consuming app, your override
+selector must also match a pseudo-class (e.g. `:not(:separator)`) to reach the same `StyleTrigger` priority tier, and
+should live in a scope nested inside the one hosting the pack (Avalonia resolves same-priority ties by scope — inner
+wins — before declaration order).
+
 **SVG menu icons are recoloured by the pack.** Menu icons ship with an embedded fill, so
 `MenuSvg.styles.axaml` applies `LinuxMenuSvgItemDefaultCss` / `LinuxMenuSvgItemDisabledCss` per variant. The full
 theme includes the same file from `GlobalStyles.axaml`, so the two cannot drift.

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.styles.axaml
@@ -26,39 +26,20 @@
   </Style>
 
   <!--
-    Menu row geometry and typography are pinned at Style level, not only through the MenuItem
-    ControlTheme. Host themes set these with Styles of their own, and a Style setter outranks a
-    ControlTheme setter, so a ControlTheme alone lets the host resize menu rows when the menu pack
-    is layered on top.
+    Popup-row geometry. This predates the menu pack's host-proofing work and is part of the
+    theme's baseline look, so it stays here and ships with the full theme as well as the pack.
+    (The MenuItem ControlTheme sets the same values, so this is a belt-and-braces restatement.)
 
-    We deliberately do not pin FontSize/Padding here: MacOS top-level menu items compute those values
-    from the Menu's MacOS_Theme_MenuLabelBelowIcon class via DevolutionsMacOsTopLevelMenuItem in
-    Menu.axaml. A blanket fixed FontSize/Padding would break the class-based toolbar sizing.
+    The host-proofing "sealing" styles that used to sit alongside this (re-asserting colors,
+    typography and the menu-bar geometry) have moved to MenuPack.Sealing.styles.axaml, which is
+    included only by the standalone menu pack (MenuPack.styles.axaml), not by the full theme's
+    GlobalStyles.axaml. Inside the full theme, app-level Style overrides on menu items must be
+    able to win, the same way they can for any other themed control - see
+    MenuPack.Sealing.styles.axaml for the full rationale.
   -->
-  <Style Selector="Menu > MenuItem:not(:separator)">
-    <Setter Property="MinHeight" Value="0" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Foreground" Value="{DynamicResource MacOsMenuItemForegroundBrush}" />
-    <Setter Property="FontFamily" Value="{DynamicResource MacOsMenuFontFamily}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
-  </Style>
-
   <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
     <Setter Property="MinHeight" Value="{DynamicResource MacOsMenuItemMinHeight}" />
-    <Setter Property="FontSize" Value="{DynamicResource MacOsMenuFontSize}" />
     <Setter Property="Padding" Value="{DynamicResource MacOsMenuItemPadding}" />
-    <Setter Property="Background" Value="Transparent" />
-    <Setter Property="Foreground" Value="{DynamicResource MacOsMenuForegroundHighBrush}" />
-    <Setter Property="FontFamily" Value="{DynamicResource MacOsMenuFontFamily}" />
-    <Setter Property="TextBlock.LineHeight" Value="NaN" />
-
-    <Style Selector="^:pointerover">
-      <Setter Property="Foreground" Value="{DynamicResource MacOsMenuAccentForegroundBrush}" />
-    </Style>
-
-    <Style Selector="^:disabled">
-      <Setter Property="Foreground" Value="{DynamicResource MacOsMenuForegroundLowBrush}" />
-    </Style>
   </Style>
 
   <Style Selector="MenuFlyoutPresenter > MenuItem:separator, ContextMenu > MenuItem:separator">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuPack.Sealing.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuPack.Sealing.styles.axaml
@@ -1,0 +1,52 @@
+<!--
+  Host-proofing for the standalone MacOS menu pack.
+
+  When the pack is layered onto an unrelated host theme (rather than used as part of the full
+  DevolutionsMacOsTheme), a host Style targeting MenuItem generically would otherwise win over the
+  pack's ControlTheme, because a Style setter outranks a ControlTheme setter. These selectors
+  re-assert the host-invariant menu-bar/menu-row properties at StyleTrigger priority
+  (via the `:not(:separator)` pseudo-class) so they beat ordinary host Styles regardless of
+  declaration order or scope.
+
+  This file is intentionally NOT included by GlobalStyles.axaml. Inside the full theme, menu items
+  are just theme-styled controls like any other, and app-level Style overrides (e.g. a MenuDemo
+  page recoloring its own top-level MenuItems) must be able to win, the same way they can override
+  any other control's theme styling. Only MenuPack.styles.axaml includes this file, since only the
+  standalone pack needs to defend its look against a host theme it doesn't control.
+
+  If you need to override these pack styles from an app that only consumes the standalone pack
+  (not the full theme), your override selector must also enter StyleTrigger priority (for example
+  by adding your own `:not(:separator)` or other pseudo-class predicate) and should live in a scope
+  nested inside the one that hosts the pack (e.g. a UserControl.Styles below the pack's
+  Application/Window-level Styles) - Avalonia resolves same-priority ties by scope (inner wins)
+  before declaration order.
+-->
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Style Selector="Menu > MenuItem:not(:separator)">
+    <Setter Property="MinHeight" Value="0" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MacOsMenuItemForegroundBrush}" />
+    <Setter Property="FontFamily" Value="{DynamicResource MacOsMenuFontFamily}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+  </Style>
+
+  <Style Selector="MenuFlyoutPresenter MenuItem:not(:separator), ContextMenu MenuItem:not(:separator), MenuItem MenuItem:not(:separator)">
+    <Setter Property="MinHeight" Value="{DynamicResource MacOsMenuItemMinHeight}" />
+    <Setter Property="FontSize" Value="{DynamicResource MacOsMenuFontSize}" />
+    <Setter Property="Padding" Value="{DynamicResource MacOsMenuItemPadding}" />
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Foreground" Value="{DynamicResource MacOsMenuForegroundHighBrush}" />
+    <Setter Property="FontFamily" Value="{DynamicResource MacOsMenuFontFamily}" />
+    <Setter Property="TextBlock.LineHeight" Value="NaN" />
+
+    <Style Selector="^:pointerover">
+      <Setter Property="Foreground" Value="{DynamicResource MacOsMenuAccentForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^:disabled">
+      <Setter Property="Foreground" Value="{DynamicResource MacOsMenuForegroundLowBrush}" />
+    </Style>
+  </Style>
+</Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuPack.styles.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuPack.styles.axaml
@@ -15,5 +15,6 @@
 
   <StyleInclude Source="/Controls/MenuPack.Separator.styles.axaml" />
   <StyleInclude Source="/Controls/Menu.styles.axaml" />
+  <StyleInclude Source="/Controls/MenuPack.Sealing.styles.axaml" />
   <StyleInclude Source="/Controls/MenuSvg.styles.axaml" />
 </Styles>

--- a/src/Devolutions.AvaloniaTheme.MacOS/README.md
+++ b/src/Devolutions.AvaloniaTheme.MacOS/README.md
@@ -148,6 +148,13 @@ Prerequisites and caveats:
   hostile host cannot recolor, resize, or retype the menu chrome. `FontSize` and `Padding` remain
   class-driven by the menu's `MacOS_Theme_MenuLabelBelowIcon` variant, so the toolbar /
   label-below-icon sizing stays intact.
+- This sealing is specific to the standalone pack (`MenuPack.Sealing.styles.axaml`) and does not
+  apply when using `<DevolutionsMacOsTheme />` directly: inside the full theme, app-level `Style`
+  overrides on menu items are expected to win, the same as for any other themed control. To
+  override a pack-sealed property from a consuming app, your override selector must also match a
+  pseudo-class (e.g. `:not(:separator)`) to reach the same `StyleTrigger` priority tier, and should
+  live in a scope nested inside the one hosting the pack (Avalonia resolves same-priority ties by
+  scope, inner wins, before declaration order).
 
 ## Styled Controls
 

--- a/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
@@ -513,9 +513,15 @@ public class LinuxMenuPackContractTests
     /// <summary>
     /// Under the full theme (not the standalone pack), an app-level Style override on top-level
     /// MenuItems must be able to recolor them - the same way an app can override any other
-    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
-    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
-    /// escalate to StyleTrigger priority to defend against a foreign host theme.
+    /// theme-styled control.
+    ///
+    /// The mechanism is the deliberate *absence* of menu-bar sealing from the full theme, not a
+    /// priority difference: Menu.styles.axaml ships no `Menu &gt; MenuItem` selector at all, so the
+    /// app's Style competes only with the MenuItem ControlTheme, which any Style outranks. (The
+    /// `MenuItem:separator` rule that remains there is itself StyleTrigger priority - it just
+    /// matches separators, not menu-bar items.) Menu-bar sealing lives solely in
+    /// MenuPack.Sealing.styles.axaml, which only the standalone pack includes, because only the
+    /// pack has to defend its look against a foreign host theme.
     /// </summary>
     [AvaloniaFact]
     public void App_level_override_wins_over_full_theme_menu_bar_styling()

--- a/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
@@ -470,6 +470,42 @@ public class LinuxMenuPackContractTests
     }
 
     /// <summary>
+    /// Under the full theme (not the standalone pack), an app-level Style override on top-level
+    /// MenuItems must be able to recolor them - the same way an app can override any other
+    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
+    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
+    /// escalate to StyleTrigger priority to defend against a foreign host theme.
+    /// </summary>
+    [AvaloniaFact]
+    public void App_level_override_wins_over_full_theme_menu_bar_styling()
+    {
+        var window = ShowWithFullTheme(ThemeVariant.Light);
+
+        var menu = new Menu { Name = "MainMenu" };
+        var item = new MenuItem { Header = "File" };
+        menu.Items.Add(item);
+
+        var appPage = new UserControl { Content = menu };
+        appPage.Styles.Add(new Style(x => x.OfType<Menu>().Name("MainMenu").Child().OfType<MenuItem>())
+        {
+            Setters = { new Setter(MenuItem.ForegroundProperty, Brushes.HotPink) }
+        });
+
+        window.Content = appPage;
+
+        try
+        {
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(Brushes.HotPink, item.Foreground);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
     ///   Builds a host <c>Style</c> that tries to override one pinned menu property.
     /// </summary>
     private static Style HostileMenuItemStyle(string property)

--- a/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/LinuxMenuPackContractTests.cs
@@ -470,6 +470,47 @@ public class LinuxMenuPackContractTests
     }
 
     /// <summary>
+    /// A menu-bar item must have the same rendered height under the full theme and under the
+    /// standalone pack. Guards against sealing a bar-sized token (which sizes the Menu itself)
+    /// as an item's MinHeight - see the DevExpress pack for a regression of exactly that kind.
+    /// </summary>
+    [AvaloniaFact]
+    public void Pack_and_full_theme_render_the_same_menu_bar_item_height()
+    {
+        static double MeasureBarItemHeight(Window window)
+        {
+            var menu = new Menu();
+            var item = new MenuItem { Header = "File" };
+            menu.Items.Add(item);
+            window.Content = menu;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            return item.Bounds.Height;
+        }
+
+        Window fullWindow = ShowWithFullTheme(ThemeVariant.Light);
+        Window packWindow = ShowWithPackOverHostTheme(ThemeVariant.Light);
+
+        try
+        {
+            double fullHeight = MeasureBarItemHeight(fullWindow);
+            double packHeight = MeasureBarItemHeight(packWindow);
+
+            Assert.True(fullHeight > 0, "Full-theme menu bar item did not lay out.");
+            Assert.Equal(fullHeight, packHeight, 1);
+        }
+        finally
+        {
+            fullWindow.Close();
+            packWindow.Close();
+            fullWindow.Content = null;
+            packWindow.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
     /// Under the full theme (not the standalone pack), an app-level Style override on top-level
     /// MenuItems must be able to recolor them - the same way an app can override any other
     /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -706,6 +706,49 @@ public class MacOsMenuPackContractTests
     }
 
     /// <summary>
+    /// A menu-bar item must have the same rendered height under the full theme and under the
+    /// standalone pack. Guards against sealing a bar-sized token (which sizes the Menu itself)
+    /// as an item's MinHeight - see the DevExpress pack for a regression of exactly that kind.
+    /// </summary>
+    [AvaloniaFact]
+    public void Pack_and_full_theme_render_the_same_menu_bar_item_height()
+    {
+        static double MeasureBarItemHeight(Window window)
+        {
+            var menu = new Menu();
+            var item = new MenuItem { Header = "File" };
+            menu.Items.Add(item);
+            window.Content = menu;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            return item.Bounds.Height;
+        }
+
+        Window fullWindow = ShowWithFullTheme(ThemeVariant.Light);
+        double fullHeight = MeasureBarItemHeight(fullWindow);
+        fullWindow.Close();
+        fullWindow.Content = null;
+        Dispatcher.UIThread.RunJobs();
+
+        Window packWindow = ShowWithPackOverHostTheme(ThemeVariant.Light);
+
+        try
+        {
+            double packHeight = MeasureBarItemHeight(packWindow);
+
+            Assert.True(fullHeight > 0, "Full-theme menu bar item did not lay out.");
+            Assert.Equal(fullHeight, packHeight, 1);
+        }
+        finally
+        {
+            packWindow.Close();
+            packWindow.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
     /// Under the full theme (not the standalone pack), an app-level Style override on top-level
     /// MenuItems must be able to recolor them - the same way an app can override any other
     /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -751,11 +751,18 @@ public class MacOsMenuPackContractTests
     /// <summary>
     /// Under the full theme (not the standalone pack), an app-level Style override on top-level
     /// MenuItems must be able to recolor them - the same way an app can override any other
-    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
-    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
-    /// escalate to StyleTrigger priority to defend against a foreign host theme. This guards
-    /// against regressing to a state where the sealing styles unconditionally win over app
-    /// overrides even inside the full theme (see PRs #630/#631/#633 and the fix in this PR).
+    /// theme-styled control.
+    ///
+    /// The mechanism is the deliberate *absence* of menu-bar sealing from the full theme, not a
+    /// priority difference: Menu.styles.axaml ships no `Menu &gt; MenuItem` selector at all, so the
+    /// app's Style competes only with the MenuItem ControlTheme, which any Style outranks. (The
+    /// popup-row geometry selector that remains there still uses `:not(:separator)` and so is
+    /// still StyleTrigger priority - it just doesn't match menu-bar items.) Menu-bar sealing lives
+    /// solely in MenuPack.Sealing.styles.axaml, which only the standalone pack includes, because
+    /// only the pack has to defend its look against a foreign host theme.
+    ///
+    /// This guards against regressing to a state where the sealing styles unconditionally win over
+    /// app overrides even inside the full theme (see PRs #630/#631/#633 and the fix in this PR).
     /// </summary>
     [AvaloniaFact]
     public void App_level_override_wins_over_full_theme_menu_bar_styling()

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -705,6 +705,50 @@ public class MacOsMenuPackContractTests
         }
     }
 
+    /// <summary>
+    /// Under the full theme (not the standalone pack), an app-level Style override on top-level
+    /// MenuItems must be able to recolor them - the same way an app can override any other
+    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
+    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
+    /// escalate to StyleTrigger priority to defend against a foreign host theme. This guards
+    /// against regressing to a state where the sealing styles unconditionally win over app
+    /// overrides even inside the full theme (see PRs #630/#631/#633 and the fix in this PR).
+    /// </summary>
+    [AvaloniaFact]
+    public void App_level_override_wins_over_full_theme_menu_bar_styling()
+    {
+        var fullTheme = new DevolutionsMacOsTheme();
+        fullTheme.BeginInit();
+        fullTheme.EndInit();
+
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Dark };
+        window.Styles.Add(fullTheme);
+
+        var menu = new Menu { Name = "MainMenu" };
+        var item = new MenuItem { Header = "File" };
+        menu.Items.Add(item);
+
+        var appPage = new UserControl { Content = menu };
+        appPage.Styles.Add(new Style(x => x.OfType<Menu>().Name("MainMenu").Child().OfType<MenuItem>())
+        {
+            Setters = { new Setter(MenuItem.ForegroundProperty, Brushes.HotPink) }
+        });
+
+        window.Content = appPage;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(Brushes.HotPink, item.Foreground);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [AvaloniaFact]
     public void Host_theme_overrides_do_not_leak_into_popup_row_colors()
     {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -324,6 +324,50 @@ public class MenuPackContractTests
         }
     }
 
+    /// <summary>
+    /// Under the full theme (not the standalone pack), an app-level Style override on top-level
+    /// MenuItems must be able to recolor them - the same way an app can override any other
+    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
+    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
+    /// escalate to StyleTrigger priority to defend against a foreign host theme.
+    /// </summary>
+    [AvaloniaFact]
+    public void App_level_override_wins_over_full_theme_menu_bar_styling()
+    {
+        var theme = new DevolutionsDevExpressTheme();
+        theme.BeginInit();
+        theme.EndInit();
+
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light };
+        window.Styles.Add(theme);
+
+        var menu = new Menu { Name = "MainMenu" };
+        var item = new MenuItem { Header = "File" };
+        menu.Items.Add(item);
+
+        var appPage = new UserControl { Content = menu };
+        appPage.Styles.Add(new Style(selector => selector.OfType<Menu>().Name("MainMenu").Child().OfType<MenuItem>())
+        {
+            Setters = { new Setter(MenuItem.ForegroundProperty, Brushes.HotPink) }
+        });
+
+        window.Content = appPage;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(Brushes.HotPink, item.Foreground);
+        }
+        finally
+        {
+            window.Close();
+            window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
     [AvaloniaFact]
     public void Host_menu_item_styles_do_not_change_normal_state_colours()
     {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -69,6 +69,7 @@ public class MenuPackContractTests
         "DevExMenuSvgItemDefaultCss",
         "DevExMenuSvgItemDisabledCss",
         "DevExMenuBarHeight",
+        "DevExMenuBarItemMinHeight",
         "DevExMenuPopupBorderThickness",
         "DevExMenuPopupPadding",
         "DevExMenuFlyoutPresenterPadding",
@@ -314,10 +315,10 @@ public class MenuPackContractTests
             Assert.Equal((FontWeight)fontWeight, item.FontWeight);
             Assert.Equal(new Thickness(6, 1, 6, 1), item.Padding);
 
-            // The host's 77d must not leak. The sealed value is the nested-item min height, which
+            // The host's 77d must not leak. The sealed value is the dedicated bar-item token, which
             // is what the full theme renders for bar items too - NOT DevExMenuBarHeight, which
             // sizes the bar itself (see MenuPack.Sealing.styles.axaml).
-            Assert.True(window.TryFindResource("DevExMenuNestedItemMinHeight", ThemeVariant.Light, out object? minHeight));
+            Assert.True(window.TryFindResource("DevExMenuBarItemMinHeight", ThemeVariant.Light, out object? minHeight));
             Assert.Equal(Convert.ToDouble(minHeight), item.MinHeight, 3);
             Assert.True(double.IsNaN(item.GetValue(TextBlock.LineHeightProperty)));
         }
@@ -381,7 +382,8 @@ public class MenuPackContractTests
     /// height of the *bar* (consumed by the Menu ControlTheme's Height), not of an item. Since
     /// items also carry <c>Margin="3"</c>, that made each item claim BarHeight + 3 + 3 inside a
     /// BarHeight-tall bar, so bar items rendered taller than under the full theme and the
-    /// pointer-over highlight spilled over the menu's border.
+    /// pointer-over highlight spilled over the menu's border. It now seals the dedicated
+    /// <c>DevExMenuBarItemMinHeight</c> token instead.
     /// </summary>
     [AvaloniaFact]
     public void Pack_and_full_theme_render_the_same_menu_bar_item_height()

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -333,9 +333,15 @@ public class MenuPackContractTests
     /// <summary>
     /// Under the full theme (not the standalone pack), an app-level Style override on top-level
     /// MenuItems must be able to recolor them - the same way an app can override any other
-    /// theme-styled control. The full theme's sealing styles (in Menu.styles.axaml) apply at plain
-    /// Style priority; only the standalone MenuPack's styles (in MenuPack.Sealing.styles.axaml)
-    /// escalate to StyleTrigger priority to defend against a foreign host theme.
+    /// theme-styled control.
+    ///
+    /// The mechanism is the deliberate *absence* of menu-bar sealing from the full theme, not a
+    /// priority difference: Menu.styles.axaml ships no `Menu &gt; MenuItem` selector at all, so the
+    /// app's Style competes only with the MenuItem ControlTheme, which any Style outranks. (The
+    /// popup-row geometry selector that remains there still uses `:not(:separator)` and so is
+    /// still StyleTrigger priority - it just doesn't match menu-bar items.) Menu-bar sealing lives
+    /// solely in MenuPack.Sealing.styles.axaml, which only the standalone pack includes, because
+    /// only the pack has to defend its look against a foreign host theme.
     /// </summary>
     [AvaloniaFact]
     public void App_level_override_wins_over_full_theme_menu_bar_styling()
@@ -376,7 +382,7 @@ public class MenuPackContractTests
 
     /// <summary>
     /// A menu-bar item must have the same rendered height under the full theme and under the
-    /// standalone pack, and must fit inside the bar.
+    /// standalone pack, and must fit inside the bar together with its margins.
     ///
     /// The pack used to seal <c>MinHeight</c> to <c>DevExMenuBarHeight</c>, but that token is the
     /// height of the *bar* (consumed by the Menu ControlTheme's Height), not of an item. Since
@@ -388,7 +394,9 @@ public class MenuPackContractTests
     [AvaloniaFact]
     public void Pack_and_full_theme_render_the_same_menu_bar_item_height()
     {
-        static double MeasureBarItemHeight(Window window)
+        // Bounds excludes the item's margin, so the vertical space it actually occupies inside the
+        // bar - which is what can overflow the menu's border - is the bounds plus those margins.
+        static (double Rendered, double Occupied) MeasureBarItem(Window window)
         {
             var menu = new Menu();
             var item = new MenuItem { Header = "File" };
@@ -397,7 +405,8 @@ public class MenuPackContractTests
             Dispatcher.UIThread.RunJobs();
             window.UpdateLayout();
 
-            return item.Bounds.Height;
+            double rendered = item.Bounds.Height;
+            return (rendered, rendered + item.Margin.Top + item.Margin.Bottom);
         }
 
         Window fullWindow = ShowWithFullTheme(ThemeVariant.Light);
@@ -405,8 +414,8 @@ public class MenuPackContractTests
 
         try
         {
-            double fullHeight = MeasureBarItemHeight(fullWindow);
-            double packHeight = MeasureBarItemHeight(packWindow);
+            (double fullHeight, _) = MeasureBarItem(fullWindow);
+            (double packHeight, double packOccupied) = MeasureBarItem(packWindow);
 
             Assert.True(fullHeight > 0, "Full-theme menu bar item did not lay out.");
             Assert.Equal(fullHeight, packHeight, 1);
@@ -415,9 +424,10 @@ public class MenuPackContractTests
             double bar = Convert.ToDouble(barHeight);
 
             // The item plus its margins must fit within the bar it lives in.
-            Assert.True(packHeight <= bar,
-                $"Menu bar item is {packHeight}px tall inside a {bar}px bar, so its highlight " +
-                "overflows the menu border. DevExMenuBarHeight sizes the bar, not the item.");
+            Assert.True(packOccupied <= bar,
+                $"Menu bar item occupies {packOccupied}px (bounds {packHeight}px plus margins) " +
+                $"inside a {bar}px bar, so its highlight overflows the menu border. " +
+                "DevExMenuBarHeight sizes the bar, not the item.");
         }
         finally
         {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MenuPackContractTests.cs
@@ -313,7 +313,12 @@ public class MenuPackContractTests
             Assert.Equal((double)fontSize, item.FontSize, 3);
             Assert.Equal((FontWeight)fontWeight, item.FontWeight);
             Assert.Equal(new Thickness(6, 1, 6, 1), item.Padding);
-            Assert.Equal(32d, item.MinHeight, 3);
+
+            // The host's 77d must not leak. The sealed value is the nested-item min height, which
+            // is what the full theme renders for bar items too - NOT DevExMenuBarHeight, which
+            // sizes the bar itself (see MenuPack.Sealing.styles.axaml).
+            Assert.True(window.TryFindResource("DevExMenuNestedItemMinHeight", ThemeVariant.Light, out object? minHeight));
+            Assert.Equal(Convert.ToDouble(minHeight), item.MinHeight, 3);
             Assert.True(double.IsNaN(item.GetValue(TextBlock.LineHeightProperty)));
         }
         finally
@@ -364,6 +369,60 @@ public class MenuPackContractTests
         {
             window.Close();
             window.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// A menu-bar item must have the same rendered height under the full theme and under the
+    /// standalone pack, and must fit inside the bar.
+    ///
+    /// The pack used to seal <c>MinHeight</c> to <c>DevExMenuBarHeight</c>, but that token is the
+    /// height of the *bar* (consumed by the Menu ControlTheme's Height), not of an item. Since
+    /// items also carry <c>Margin="3"</c>, that made each item claim BarHeight + 3 + 3 inside a
+    /// BarHeight-tall bar, so bar items rendered taller than under the full theme and the
+    /// pointer-over highlight spilled over the menu's border.
+    /// </summary>
+    [AvaloniaFact]
+    public void Pack_and_full_theme_render_the_same_menu_bar_item_height()
+    {
+        static double MeasureBarItemHeight(Window window)
+        {
+            var menu = new Menu();
+            var item = new MenuItem { Header = "File" };
+            menu.Items.Add(item);
+            window.Content = menu;
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            return item.Bounds.Height;
+        }
+
+        Window fullWindow = ShowWithFullTheme(ThemeVariant.Light);
+        Window packWindow = ShowWithPackOverHostTheme(ThemeVariant.Light);
+
+        try
+        {
+            double fullHeight = MeasureBarItemHeight(fullWindow);
+            double packHeight = MeasureBarItemHeight(packWindow);
+
+            Assert.True(fullHeight > 0, "Full-theme menu bar item did not lay out.");
+            Assert.Equal(fullHeight, packHeight, 1);
+
+            Assert.True(packWindow.TryFindResource("DevExMenuBarHeight", ThemeVariant.Light, out object? barHeight));
+            double bar = Convert.ToDouble(barHeight);
+
+            // The item plus its margins must fit within the bar it lives in.
+            Assert.True(packHeight <= bar,
+                $"Menu bar item is {packHeight}px tall inside a {bar}px bar, so its highlight " +
+                "overflows the menu border. DevExMenuBarHeight sizes the bar, not the item.");
+        }
+        finally
+        {
+            fullWindow.Close();
+            packWindow.Close();
+            fullWindow.Content = null;
+            packWindow.Content = null;
             Dispatcher.UIThread.RunJobs();
         }
     }


### PR DESCRIPTION
## Problem

Top-level `MenuItem`s in the MacOS full theme's `MenuDemo` changed colour in Dark Mode as a side-effect of #633 (and the equivalent DevExpress #631 / Linux #630 work). The demo's own `Style` override (`Menu#MainMenu > MenuItem` → `Foreground`) had silently stopped taking effect.

Root cause: the MenuPack's host-proofing "sealing" styles use `:not(:separator)` selectors, which Avalonia promotes to **`StyleTrigger`** priority. Those styles lived in `Menu.styles.axaml`, which is included by **both** `MenuPack.styles.axaml` (the standalone pack) **and** `GlobalStyles.axaml` (the full theme). The escalation is exactly what the pack needs — it must repel a foreign host theme's styles at any scope and in any declaration order — but as a side-effect it also beat any app-level `Style`-tier override *inside the full theme*, where no foreign-style problem exists.

Verified empirically (with a throwaway Avalonia headless harness) that precedence resolves as: **priority tier** (Animation > LocalValue > StyleTrigger > Template/ControlTheme > Style > Inherited) first, then **style scope** (inner beats outer), then **declaration order**. Selector specificity plays no part once the tier is decided — so no specificity tweak could satisfy both goals.

## Design goal

Two requirements must hold, and they are genuinely different problems:

- **Host-proofing** — the *standalone* pack must resist an unrelated host app theme leaking into pack-styled menus, at any scope, in any order.
- **App-overridability** — inside the *full* theme, menu items are ordinary themed controls; an app's own `Style` overrides must win, exactly as they do for every other control the theme styles.

Shipping one set of sealing styles to both consumers of `Menu.styles.axaml` made these two goals fight each other in the full theme.

## Fix

Structural separation rather than selector-priority tricks:

- Extracted the `:not(:separator)` **host-proofing restatements** out of each theme's `Menu.styles.axaml` into a new pack-only `MenuPack.Sealing.styles.axaml` (MacOS, DevExpress, Linux).
- `MenuPack.styles.axaml` includes both files, so the standalone pack keeps its host-proofing.
- `GlobalStyles.axaml` is unchanged — it still includes only `Menu.styles.axaml`, now without the escalation, so app-level overrides behave normally under the full theme.

Importantly, the **pre-existing popup-row geometry** (`MinHeight`/`Padding`) stays in `Menu.styles.axaml`. It predates the sealing work and is part of each theme's baseline look; only the host-proofing restatements of colour, typography and menu-bar geometry moved out. (An earlier iteration of this PR moved that geometry too, which shrank every DevExpress menu — DevExpress, unlike MacOS and Linux, has no `MinHeight` in its `MenuItem` `ControlTheme`, so that style was its only source.)

Consumers who use *only* the standalone pack and need to override a sealed property still can: match the same pseudo-class-based selector shape (to reach `StyleTrigger` tier) and declare the override in a scope nested inside the pack's. This is documented in each theme's README.

## Testing

- Full visual regression suite: **300/301 pass**, and **no baseline screenshots are changed** by this PR.
- The single failure is the Linux `MenuDemo` baseline, which was captured a few days ago while a minor leak was still present; its diff is a colour-only shift of a few RGB units confined to the menu-bar text rows, with no geometry change — i.e. the fix working as intended. Left for a separate baseline refresh.
- All 82 MenuPack contract tests pass — host-leak protection is intact.
- Added a contract test per theme, `App_level_override_wins_over_full_theme_menu_bar_styling`, asserting an app-level `Style` on `Menu#MainMenu > MenuItem` now wins under the full theme.

## Notes for reviewers

- No changes to `GlobalStyles.axaml` in any theme — that's the crux of the fix.
- Worth a sanity check that the split between "baseline look" (stays shared) and "host-proofing restatement" (moves to the pack) is drawn in the right place for each theme, since the three themes distribute menu geometry differently between `ControlTheme` and `Style`.


---

## Follow-up: menu-bar items were taller under the pack than under the full theme

While reviewing, a second, longer-standing discrepancy surfaced: under the **standalone pack**, menu-bar items (`File`/`Edit`/`Tools`/`Help`, and the bottom icon menu) rendered noticeably taller than under the full theme. It was only obvious on hover or tab focus, where the bottom menu's highlight visibly overlapped the menu's outer border.

Cause: the pack sealed

```xml
<Setter Property="MinHeight" Value="{DynamicResource DevExMenuBarHeight}" />
```

but `DevExMenuBarHeight` (32) sizes the **bar** — it's what the `Menu` `ControlTheme` binds its `Height` to — not an item. Since menu items also carry `Margin="3"`, each bar item claimed 32 + 3 + 3 = **38px inside a 32px bar**, which is exactly why the highlight spilled over the border. Measured: **32px under the pack vs 26px under the full theme**.

The token was right for its own purpose and merely applied to the wrong property, so both the token-parity tests and the visual baselines were blind to it: the pack has no baseline screenshot of its own, and the contract tests compared token *values* only.

Fixed by introducing a dedicated `DevExMenuBarItemMinHeight` token (26 — what the full theme actually renders for bar items) and sealing that. It's declared right next to `DevExMenuBarHeight`, where the original confusion arose, with a comment spelling out that one sizes the bar and the other the items inside it, and that the latter plus the items' `Margin="3"` must fit within the former. It's also added to the token-parity list. MacOS (`0`) and Linux (`LinuxMenuItemMinHeight`) were checked and were already correct.

Since this is now the **third** time the full theme and the pack have silently drifted apart geometrically (the class-of-bug the contract tests were introduced for), this adds a **rendered-geometry** contract test per theme asserting a bar item lays out to the same height under both — closing the gap that token-only comparisons leave open.

Also removed a hard-coded `Assert.Equal(32d, item.MinHeight)` in `Host_menu_item_styles_do_not_change_the_menu_bar`, which had baked in the buggy value; it now resolves the token, still proving the host's override doesn't leak while tracking the theme's real geometry.

**Testing:** full visual suite **303/304**, no baseline changes; all **85** contract tests pass.

