### PR TITLE
Fix macos submenu disappearing

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Behaviors/MenuItemSubmenuPointerExitBehavior.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Behaviors/MenuItemSubmenuPointerExitBehavior.cs
@@ -1,0 +1,44 @@
+namespace Devolutions.AvaloniaTheme.MacOS.Behaviors;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+/// <summary>
+/// Prevents Avalonia from scheduling its one-shot submenu close when the pointer exits
+/// a menu item whose submenu is already open.
+/// </summary>
+internal static class MenuItemSubmenuPointerExitBehavior
+{
+    public static readonly AttachedProperty<bool> EnableProperty =
+        AvaloniaProperty.RegisterAttached<MenuItem, bool>("Enable", typeof(MenuItemSubmenuPointerExitBehavior));
+
+    static MenuItemSubmenuPointerExitBehavior()
+    {
+        EnableProperty.Changed.AddClassHandler<MenuItem>(OnEnableChanged);
+    }
+
+    public static bool GetEnable(MenuItem element) => element.GetValue(EnableProperty);
+
+    public static void SetEnable(MenuItem element, bool value) => element.SetValue(EnableProperty, value);
+
+    private static void OnEnableChanged(MenuItem menuItem, AvaloniaPropertyChangedEventArgs args)
+    {
+        menuItem.RemoveHandler(MenuItem.PointerExitedItemEvent, OnPointerExitedItem);
+
+        if (args.NewValue is true)
+        {
+            menuItem.AddHandler(MenuItem.PointerExitedItemEvent, OnPointerExitedItem, RoutingStrategies.Bubble);
+        }
+    }
+
+    private static void OnPointerExitedItem(object? sender, RoutedEventArgs args)
+    {
+        if (sender is MenuItem menuItem &&
+            ReferenceEquals(args.Source, menuItem) &&
+            menuItem.IsSubMenuOpen)
+        {
+            args.Handled = true;
+        }
+    }
+}

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
@@ -1,7 +1,8 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:conv="using:Avalonia.Controls.Converters"
-                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design">
+                    xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.MacOS.Design"
+                    xmlns:behaviors="using:Devolutions.AvaloniaTheme.MacOS.Behaviors">
 
   <Design.PreviewWith>
     <design:ThemePreviewer Width="280" MinHeight="540">
@@ -81,6 +82,7 @@
     <!--  Narrow padding should be used for mouse input, when non-narrow one should be used for touch input in future.  -->
     <Setter Property="Padding" Value="{DynamicResource MacOsMenuItemPadding}" />
     <Setter Property="FocusAdorner" Value="{x:Null}" />
+    <Setter Property="behaviors:MenuItemSubmenuPointerExitBehavior.Enable" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <Panel>

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -4,10 +4,12 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
+using Avalonia.Controls.Platform;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Shapes;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
 using Avalonia.Styling;
@@ -744,6 +746,56 @@ public class MacOsMenuPackContractTests
         {
             packWindow.Close();
             packWindow.Content = null;
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>
+    /// A submenu overlaps its parent item near the chevron. Avalonia normally queues a delayed
+    /// close when that overlap moves the pointer out of the parent, so the MacOS behavior must
+    /// intercept the open parent's exit event without breaking normal sibling navigation.
+    /// </summary>
+    [AvaloniaFact]
+    public void Open_submenu_does_not_queue_close_when_pointer_exits_parent()
+    {
+        var parent = new MenuItem
+        {
+            Header = "Parent",
+            Items = { new MenuItem { Header = "Child" } },
+        };
+        var sibling = new MenuItem { Header = "Sibling" };
+        var presenter = new MenuFlyoutPresenter { Items = { parent, sibling } };
+        Window window = ShowWithFullTheme(ThemeVariant.Light);
+        TimeSpan originalMenuShowDelay = DefaultMenuInteractionHandler.MenuShowDelay;
+
+        try
+        {
+            window.Content = presenter;
+            Dispatcher.UIThread.RunJobs();
+
+            presenter.SelectedIndex = 0;
+            parent.IsSubMenuOpen = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(parent.IsSubMenuOpen);
+
+            DefaultMenuInteractionHandler.MenuShowDelay = TimeSpan.Zero;
+            var exit = new RoutedEventArgs(MenuItem.PointerExitedItemEvent, parent);
+            parent.RaiseEvent(exit);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(exit.Handled);
+            Assert.True(parent.IsSubMenuOpen);
+
+            sibling.RaiseEvent(new RoutedEventArgs(MenuItem.PointerEnteredItemEvent, sibling));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(parent.IsSubMenuOpen);
+        }
+        finally
+        {
+            DefaultMenuInteractionHandler.MenuShowDelay = originalMenuShowDelay;
+            window.Close();
+            window.Content = null;
             Dispatcher.UIThread.RunJobs();
         }
     }


### PR DESCRIPTION
This pull request introduces a new behavior to improve submenu interaction in MacOS-themed Avalonia menus. The main change is the addition of a behavior that prevents submenus from being closed prematurely when the pointer exits a parent menu item, aligning the interaction more closely with native MacOS expectations. The update also includes a new visual test to verify this behavior and integrates the behavior into the menu item style.

**Menu Interaction Improvements:**
* Added `MenuItemSubmenuPointerExitBehavior` in `MenuItemSubmenuPointerExitBehavior.cs` to prevent Avalonia from closing an open submenu when the pointer exits the parent menu item, unless navigating to a sibling.
* Updated `MenuItem.axaml` to attach the new behavior by default to all menu items, ensuring consistent submenu behavior across the theme. [[1]](diffhunk://#diff-e340843fda5d6d078a9afee9311dd4c10ae207ab59f5fbb76a2b6698f826d32fL4-R5) [[2]](diffhunk://#diff-e340843fda5d6d078a9afee9311dd4c10ae207ab59f5fbb76a2b6698f826d32fR85)

**Testing Enhancements:**
* Added a visual test `Open_submenu_does_not_queue_close_when_pointer_exits_parent` to `MacOsMenuPackContractTests.cs` to verify that open submenus are not closed when the pointer exits the parent menu item, unless moving to a sibling.
* Updated test file imports to include necessary namespaces for the new behavior and event handling.