### PR TITLE
[MacOS] Fix menu tokens ignoring the active variant

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/ThemeRoot.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/ThemeRoot.axaml
@@ -11,8 +11,13 @@
   <Styles.Resources>
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
+        <!-- ResourceInclude, not MergeResourceInclude: a merged-in dictionary becomes part of this
+             dictionary's own entries, and own entries outrank every merged dictionary - including
+             the menu alias dictionary that MacOsTheme/MacOsThemeWithGlobalStyles append. These
+             classic defaults would then shadow the active variant's values and menus would stay
+             classic under LiquidGlass. Kept first: MergeResourceInclude must come last. -->
+        <ResourceInclude Source="/Accents/MenuResources.axaml" />
         <MergeResourceInclude Source="/Accents/Icons.axaml" />
-        <MergeResourceInclude Source="/Accents/MenuResources.axaml" />
         <!-- Theme-variant (Classic OR LiquidGlass) loaded conditionally in MacOsTheme.axaml.cs -->
         <MergeResourceInclude Source="/Controls/_index.axaml" />
       </ResourceDictionary.MergedDictionaries>

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -375,6 +375,82 @@ public class MacOsMenuPackContractTests
         }
     }
 
+    /// <summary>
+    ///   The full theme ships in two shapes: <c>GlobalStyles="True"</c> wraps ThemeRoot.axaml in an
+    ///   outer Styles element, while <c>GlobalStyles="False"</c> *is* ThemeRoot.axaml. Only the
+    ///   second one carries the classic MenuResources defaults in its own resource dictionary, and
+    ///   own entries outrank every merged dictionary - including the menu alias dictionary that
+    ///   carries the active variant's values. Consumers using GlobalStyles="False" (RDM) therefore
+    ///   used to get classic menus while every other control followed LiquidGlass.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void Full_theme_menu_tokens_follow_the_active_variant_with_and_without_global_styles(
+        bool globalStyles,
+        bool liquidGlass)
+    {
+        MacOSVersionDetector.SetTestOverride(liquidGlass);
+
+        var window = new Window { RequestedThemeVariant = ThemeVariant.Light };
+        var macOsTheme = new DevolutionsMacOsTheme { GlobalStyles = globalStyles };
+        macOsTheme.BeginInit();
+        macOsTheme.EndInit();
+        window.Styles.Add(macOsTheme);
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            // Every menu token must agree with the legacy theme key it aliases, whichever variant
+            // the theme loaded. This is what breaks when the alias dictionary loses the lookup.
+            (string MenuToken, string LegacyToken)[] pairs =
+            {
+                ("MacOsMenuPopupBackgroundBrush", "PopupBackgroundBrush"),
+                ("MacOsMenuPopupCornerRadius", "PopupCornerRadius"),
+                ("MacOsMenuPopupMargin", "PopupMargin"),
+                ("MacOsMenuItemPadding", "MenuItemPadding"),
+                ("MacOsMenuItemMinHeight", "MenuItemMinHeight"),
+                ("MacOsMenuSubMenuPopupVerticalOffset", "SubMenuPopupVerticalOffset"),
+            };
+
+            foreach ((string menuToken, string legacyToken) in pairs)
+            {
+                Assert.True(
+                    window.TryFindResource(menuToken, ThemeVariant.Light, out object? menuValue),
+                    $"Menu token '{menuToken}' should resolve (GlobalStyles={globalStyles}).");
+                Assert.True(
+                    window.TryFindResource(legacyToken, ThemeVariant.Light, out object? legacyValue),
+                    $"Legacy token '{legacyToken}' should resolve (GlobalStyles={globalStyles}).");
+
+                Assert.Equal(
+                    Describe(legacyValue),
+                    Describe(menuValue));
+            }
+
+            // Absolute check, so a regression that makes both sides classic still fails.
+            Assert.True(window.TryFindResource("MacOsMenuPopupCornerRadius", ThemeVariant.Light, out object? radius));
+            Assert.Equal(
+                liquidGlass ? new CornerRadius(12) : new CornerRadius(5),
+                Assert.IsType<CornerRadius>(radius));
+        }
+        finally
+        {
+            window.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    private static string Describe(object? value) => value switch
+    {
+        ISolidColorBrush brush => $"{brush.Color} @{brush.Opacity.ToString(CultureInfo.InvariantCulture)}",
+        null => "<null>",
+        _ => value.ToString() ?? "<null>",
+    };
+
     [AvaloniaTheory]
     [InlineData(true, "#FFF8F9F9", 0.93)]
     [InlineData(false, "#FFE7E7E7", 1.0)]


### PR DESCRIPTION
## Problem

`<DevolutionsMacOsTheme GlobalStyles="False" />` resolved every `MacOsMenu*` token to the **classic** literal, even under LiquidGlass. Reported from RDM: menus stayed classic while every other control followed the variant. Rolling the package back to 2026.8.10 fixed it, because the menu templates read the legacy theme keys directly there.

## Root cause

`ThemeRoot.axaml` pulled `Accents/MenuResources.axaml` in with `MergeResourceInclude`, which folds the merged keys into the owning dictionary's **own entries**. Own entries outrank every merged dictionary, so the classic defaults shadowed the menu alias dictionary that `MacOsTheme`/`MacOsThemeWithGlobalStyles` append — the one carrying the active variant's values. The alias dictionary itself was always correct; it simply never got consulted.

This only bites in one of the two theme shapes:

| | inner class | XAML it loads |
|---|---|---|
| `GlobalStyles="True"` | `MacOsThemeWithGlobalStyles` | a wrapper that `StyleInclude`s `ThemeRoot.axaml` |
| `GlobalStyles="False"` (**RDM**, and the SampleApp) | `MacOsTheme` | **is** `ThemeRoot.axaml` |

With `True`, `ThemeRoot` is a nested child style, so the parent's alias dictionary wins and the tokens were already right.

Measured on `master` before the fix, forced LiquidGlass:

```
--- GlobalStyles=True ---            --- GlobalStyles=False ---
MacOsMenuPopupCornerRadius = 12       MacOsMenuPopupCornerRadius = 5     <- classic
MacOsMenuItemPadding  = 9,4,7,4       MacOsMenuItemPadding  = 9,4,7,2    <- classic
MacOsMenuItemMinHeight = 24           MacOsMenuItemMinHeight = 22        <- classic
PopupCornerRadius = 12  (LG)          PopupCornerRadius = 12  (LG)       <- non-menu controls fine
```

Introduced by the macOS menu-pack work (#624/#630/#632), first shipped in 2026.8.25. Not related to the sealing PRs (#633/#639).

### Why the existing tests missed it

`MacOsMenuPackContractTests` is the only place that asserts LiquidGlass menu values, and its LiquidGlass cases construct `new DevolutionsMacOsTheme()` — the default `GlobalStyles = true`, i.e. the shape that was never broken. Everything that goes through `App.SetTheme` uses the SampleApp's `MacOsStyles` resource, which *is* `GlobalStyles="False"`, but the contract tests reach it only via `MacOsClassicTheme`, where classic and LiquidGlass cannot diverge by definition.

## Fix

`ResourceInclude` instead of `MergeResourceInclude`, so the defaults nest as a merged dictionary and the later-appended aliases win. Avalonia enforces `AVLN2000` (`MergeResourceInclude` must come last inside `MergedDictionaries`), hence the reorder — precedence-neutral, since every key in `MenuResources.axaml` is `MacOsMenu*`-prefixed and so collides with nothing in `Icons.axaml`, `_index.axaml`, or `ThemeResources.axaml`.

## Testing

- New `Full_theme_menu_tokens_follow_the_active_variant_with_and_without_global_styles`: both theme shapes × both variants, asserting each menu token agrees with the legacy key it aliases, plus an absolute corner-radius check so a regression making *both* sides classic still fails.
- Verified the test has teeth: reverting the fix fails only `(globalStyles: False, liquidGlass: True)`, with `#ffe7e7e7 @1` vs the expected `#fff8f9f9 @0.93`.
- Full non-visual suite: 202 passed.
- Validated end to end in RDM with a locally built package: macOS menus now follow LiquidGlass.

### Visual regression — please watch this on CI

Visual regression was **not** run locally (the baselines fail wholesale on my machine, so it produces no usable signal). **Baseline movement is plausible here and would be correct, not a regression.** `VisualRegressionTests` captures a `LiquidGlass` theme through the SampleApp's `GlobalStyles="False"` path — the affected one — so the six existing LiquidGlass menu baselines (`MenuDemo`, `ContextMenuDemo`, `MenuFlyoutDemo`, light + dark) were captured *with this bug present*, showing classic menu metrics under LiquidGlass.

Whether they actually shift depends on whether the diverging tokens are visible with popups closed: the LiquidGlass overrides are mostly popup-surface values (`PopupCornerRadius`, `PopupMargin`, `MenuItemPadding`, `MenuItemMinHeight`, popup brushes), and top-level menu-bar items don't use them. So the pages may well be pixel-identical — but I can't assert that from here, and if CI does flag those six, they need regenerating rather than investigating.

## Follow-up (not in this PR)

In the `GlobalStyles="False"` path the `MacOsMenu*` tokens still come from a snapshot taken at theme construction, so app-level overrides of the legacy menu keys — and post-construction changes such as a macOS accent-colour switch feeding `MacOsMenuItemPointerOverBackgroundBrush` — do not reach menus.
