### PR TITLE
[MacOS] Unify every LiquidGlass popup surface with the menus

### DIFF
--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -28,10 +28,15 @@
       <!--
         Pinned rather than derived from SystemAccentColor: the full theme runs the accent through
         OklchAdjustmentConverter, which the pack cannot reuse without importing the theme
-        dictionaries. Per variant because the two adjustments differ. With a custom macOS accent the
-        pack's hover tint stays at the default.
+        dictionaries. Per variant because the two adjustments differ.
+
+        The values are the converter's output for macOS's default accent (#007aff), so a stock Mac
+        renders the pack and the full theme identically. MacOsMenuPackContractTests pins
+        SystemAccentColor to that same accent, so the parity check measures what ships rather than
+        the headless fallback accent. With a custom macOS accent the pack's tint stays at default.
       -->
-      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005eca" Opacity="0.64" />
+      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005df1" Opacity="0.64" />
+      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#005df1" Opacity="0.64" />
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -39,7 +44,8 @@
       <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#22272a" />
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#ffffff" Opacity="0.26" />
       <SolidColorBrush x:Key="MacOsMenuAccentForegroundBrush" Color="#ffffff" />
-      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#1063d8" Opacity="0.69" />
+      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#2960ff" Opacity="0.69" />
+      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#2960ff" Opacity="0.69" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -36,7 +36,7 @@
         the headless fallback accent. With a custom macOS accent the pack's tint stays at default.
       -->
       <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005df1" Opacity="0.64" />
-      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#005df1" Opacity="0.64" />
+      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#d7d9d9" />
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -45,7 +45,7 @@
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#ffffff" Opacity="0.26" />
       <SolidColorBrush x:Key="MacOsMenuAccentForegroundBrush" Color="#ffffff" />
       <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#2960ff" Opacity="0.69" />
-      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#2960ff" Opacity="0.69" />
+      <SolidColorBrush x:Key="MacOsMenuSelectedBackgroundBrush" Color="#3d4243" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -25,6 +25,13 @@
       <SolidColorBrush x:Key="MacOsMenuPopupBackgroundBrush" Color="#f8f9f9" />
       <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#ffffff" />
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#000000" Opacity="0.2" />
+      <!--
+        Pinned rather than derived from SystemAccentColor: the full theme runs the accent through
+        OklchAdjustmentConverter, which the pack cannot reuse without importing the theme
+        dictionaries. Per variant because the two adjustments differ. With a custom macOS accent the
+        pack's hover tint stays at the default.
+      -->
+      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005eca" Opacity="0.64" />
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
@@ -32,16 +39,10 @@
       <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#22272a" />
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#ffffff" Opacity="0.26" />
       <SolidColorBrush x:Key="MacOsMenuAccentForegroundBrush" Color="#ffffff" />
+      <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#1063d8" Opacity="0.69" />
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 
-  <!--
-    Pinned rather than derived from SystemAccentColor: the full theme runs the accent through
-    OklchAdjustmentConverter here, which the pack cannot reuse without importing the theme
-    dictionaries. The value matches the default accent; with a custom macOS accent colour the
-    LiquidGlass hover tint stays at the default (the classic value above does follow the accent).
-  -->
-  <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005eca" Opacity="0.64" />
 
   <!-- Selection inset/radius: matches native macOS 26 (4pt inset, 5pt radius inside a 12pt menu). -->
   <Thickness x:Key="MacOsMenuPopupPadding">3 0 4 0</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -43,6 +43,11 @@
   -->
   <SolidColorBrush x:Key="MacOsMenuItemPointerOverBackgroundBrush" Color="#005eca" Opacity="0.64" />
 
+  <!-- Selection inset/radius: matches native macOS 26 (4pt inset, 5pt radius inside a 12pt menu). -->
+  <Thickness x:Key="MacOsMenuPopupPadding">3 0 4 0</Thickness>
+  <Thickness x:Key="MacOsMenuFlyoutScrollerMargin">0 3 0 4</Thickness>
+  <CornerRadius x:Key="MacOsMenuSelectionCornerRadius">6</CornerRadius>
+
   <Thickness x:Key="MacOsMenuPopupMargin">12 4 12 29</Thickness>
   <Thickness x:Key="MacOsMenuItemPadding">9 4 7 4</Thickness>
   <x:Double x:Key="MacOsMenuItemMinHeight">24</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -6,6 +6,10 @@
   full theme without pulling in the MacOS theme dictionaries (which would restyle
   non-menu controls in the consuming app).
 
+  The menu surface is deliberately opaque: Avalonia can only blur a popup's backdrop through the
+  window compositor, and that blur cannot be shaped to the menu's rounded corners, so translucent
+  menus show sharp content straight through. These values are sampled from native macOS menus.
+
   Only keys that actually differ from the classic values are listed. Values are pinned
   literals mirroring Accents/ThemeResources_LiquidGlass.axaml; MacOsMenuPackContractTests
   asserts pack/full-theme parity so the two cannot drift apart.
@@ -18,14 +22,14 @@
 
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Default">
-      <SolidColorBrush x:Key="MacOsMenuPopupBackgroundBrush" Color="#f8f9f9" Opacity="0.93" />
+      <SolidColorBrush x:Key="MacOsMenuPopupBackgroundBrush" Color="#f8f9f9" />
       <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#ffffff" />
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#000000" Opacity="0.2" />
     </ResourceDictionary>
 
     <ResourceDictionary x:Key="Dark">
-      <SolidColorBrush x:Key="MacOsMenuPopupBackgroundBrush" Color="#171717" Opacity="0.89" />
-      <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#171717" Opacity="0.89" />
+      <SolidColorBrush x:Key="MacOsMenuPopupBackgroundBrush" Color="#22272a" />
+      <SolidColorBrush x:Key="MacOsMenuPopupInnerBorderHighlightBrush" Color="#22272a" />
       <SolidColorBrush x:Key="MacOsMenuPopupBorderBrush" Color="#ffffff" Opacity="0.26" />
       <SolidColorBrush x:Key="MacOsMenuAccentForegroundBrush" Color="#ffffff" />
     </ResourceDictionary>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/MenuResources_LiquidGlass.axaml
@@ -44,10 +44,16 @@
   </ResourceDictionary.ThemeDictionaries>
 
 
-  <!-- Selection inset/radius: matches native macOS 26 (4pt inset, 5pt radius inside a 12pt menu). -->
+  <!--
+    Selection inset and radius, mirroring Accents/ThemeResources_LiquidGlass.axaml. The 4pt inset is
+    measured from a native macOS 26 menu; the 7pt radius is a judgement call that reads better than
+    the ~6pt a native menu measures, against our 12pt menu corner. The padding and scroller margin
+    are asymmetric on purpose - they absorb the top/left-only bevel from
+    MacOsMenuPopupInnerBorderThickness so the visible gap comes out even at 4pt.
+  -->
   <Thickness x:Key="MacOsMenuPopupPadding">3 0 4 0</Thickness>
   <Thickness x:Key="MacOsMenuFlyoutScrollerMargin">0 3 0 4</Thickness>
-  <CornerRadius x:Key="MacOsMenuSelectionCornerRadius">6</CornerRadius>
+  <CornerRadius x:Key="MacOsMenuSelectionCornerRadius">7</CornerRadius>
 
   <Thickness x:Key="MacOsMenuPopupMargin">12 4 12 29</Thickness>
   <Thickness x:Key="MacOsMenuItemPadding">9 4 7 4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -680,7 +680,13 @@
   <!-- TODO: Use Bindings to named item properties & AddBinding to encode these dependencies more securely -->
   <!-- InitialFirstItemDistance must match ComboBoxShadowMargin.bottom + PopupPadding.top -->
   <x:Int32 x:Key="InitialFirstItemDistance">9</x:Int32>
-  <x:Int32 x:Key="PopupTrimHeight">30</x:Int32> <!-- includes Margin, Padding, Shadow -->
+  <!--
+    Subtracted from a ComboBox's MaxDropDownHeight to get the usable list height, because
+    MaxDropDownHeight is applied to the Popup itself and so covers the chrome as well. In practice
+    that chrome is PopupMargin's vertical total - the allowance the shadow is drawn into - which is
+    why this is 30 against a "12 1 12 29" margin. Keep the two in step; MacOsPopupInsetTests checks it.
+  -->
+  <x:Int32 x:Key="PopupTrimHeight">30</x:Int32>
   <x:Int32 x:Key="PopupSideMarginWidth">12</x:Int32> <!-- must match PopupMargin l/r values -->
   <Thickness x:Key="PopupMargin">12 1 12 29</Thickness> <!-- to accommodate shadow -->
   <x:Double x:Key="PopupMarginCompensationOffset">-10</x:Double> <!-- to correct positioning -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -679,6 +679,14 @@
   <Thickness x:Key="PopupMargin">12 1 12 29</Thickness> <!-- to accommodate shadow -->
   <x:Double x:Key="PopupMarginCompensationOffset">-10</x:Double> <!-- to correct positioning -->
   <Thickness x:Key="PopupPadding">3 5</Thickness>
+  <!--
+    PopupPadding is the drop-down list inset and is composed with PopupInnerBorderThickness and
+    ComboBoxItemMargin (see MacOsPopupInsetTests). These two consumers compose it differently - the
+    calendar has no rows and no bevel, a plain ListBox is not a popup at all - so they carry their
+    own copies and are not dragged along when the list inset is tuned.
+  -->
+  <Thickness x:Key="CalendarPopupPadding">3 5</Thickness>
+  <Thickness x:Key="ListBoxPadding">3 5</Thickness>
   <Thickness x:Key="PopupInnerBorderThickness">1 1 0 0</Thickness>
   <SolidColorBrush x:Key="PopupBackgroundBrush" Color="{DynamicResource PopupBackgroundColor}" />
   <SolidColorBrush x:Key="PopupInnerBorderHighlightBrush" Color="{DynamicResource PopupBackgroundColor}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -779,9 +779,29 @@
   <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
   <!--
     Classic menus hover flat here while drop-down rows use the ControlBackgroundAccentRaisedBrush
-    gradient - a long-standing inconsistency, not something LiquidGlass introduced. Unifying them
-    needs the standalone menu pack to pin a gradient literal too (it currently pins a solid), so it
-    is left alone rather than half-done here.
+    gradient - a long-standing inconsistency, not something LiquidGlass introduced.
+
+    They also differ in a way that is not stylistic: this brush follows the system accent and the
+    gradient does not. Verified by forcing the accent to red - menus went red, the gradient stayed
+    on #269fff -> #0078d7, Avalonia's fallback accent.
+
+    The gradient's stops read AccentButtonTopColor/BottomColor, which are declared as
+    <StaticResource ResourceKey="SystemAccentColorLight1" /> aliases. A StaticResource alias resolves
+    once at load, so it captures the fallback accent before the platform value arrives and can never
+    update - the same scope-and-timing trap as the variant bugs elsewhere in this theme, but freezing
+    a live platform value rather than a variant.
+
+    Observed to affect the LIGHT variant only; dark follows a changed accent correctly. Both variants
+    declare the stops the same way, so the reason for the difference is not yet established - the
+    light stops go through SystemAccentColorLight1 while dark's top stop is SystemAccentColor
+    itself, which may be why one survives and the other does not. Worth confirming before fixing.
+
+    Fixing it properly means declaring ControlBackgroundAccentRaisedBrush per variant with stops
+    bound through DynamicResource, since the light and dark variants use different stops and a
+    root-level brush cannot vary by theme. That reaches every accent-raised surface in the classic
+    theme, not just these rows, so it wants its own change. Unifying the two hover styles would
+    additionally need the standalone menu pack to pin a gradient literal (it pins a solid), and the
+    pack parity check compares gradients only by type, so it would not really verify them.
   -->
   <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="ControlBackgroundAccentMidBrush" />
   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -55,10 +55,6 @@
       <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.12" />
       <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
       <!--
-        Per variant, not at the dictionary root: a root-level StaticResource cannot see into
-        ThemeDictionaries and would bind the Default (light) brush for dark menus too.
-      -->
-      <!--
         The neutral a popup row takes when it is selected or keyboard-focused but not under the
         pointer - menus and drop-down rows share it so the two read the same. Per variant, not at the
         dictionary root: a root-level StaticResource cannot see into ThemeDictionaries and would bind
@@ -781,6 +777,12 @@
   <Thickness x:Key="MenuItemActiveBackgroundMargin">-6,-2,-7,-2</Thickness>
   <Thickness x:Key="MenuItemIconPadding">0</Thickness>
   <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
+  <!--
+    Classic menus hover flat here while drop-down rows use the ControlBackgroundAccentRaisedBrush
+    gradient - a long-standing inconsistency, not something LiquidGlass introduced. Unifying them
+    needs the standalone menu pack to pin a gradient literal too (it currently pins a solid), so it
+    is left alone rather than half-done here.
+  -->
   <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="ControlBackgroundAccentMidBrush" />
   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
   <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -54,6 +54,11 @@
 
       <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.12" />
       <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.07" />
+      <!--
+        Per variant, not at the dictionary root: a root-level StaticResource cannot see into
+        ThemeDictionaries and would bind the Default (light) brush for dark menus too.
+      -->
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
       <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.03" />
 
       <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
@@ -289,6 +294,7 @@
 
       <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
       <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
       <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.05" />
 
       <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
@@ -762,7 +768,6 @@
   <Thickness x:Key="MenuToolBarItemActiveBackgroundMargin">-10 -3 -8 -3</Thickness>
   <Thickness x:Key="MenuItemActiveBackgroundMargin">-6,-2,-7,-2</Thickness>
   <Thickness x:Key="MenuItemIconPadding">0</Thickness>
-  <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
   <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="ControlBackgroundAccentMidBrush" />
   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
   <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources.axaml
@@ -58,7 +58,13 @@
         Per variant, not at the dictionary root: a root-level StaticResource cannot see into
         ThemeDictionaries and would bind the Default (light) brush for dark menus too.
       -->
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
+      <!--
+        The neutral a popup row takes when it is selected or keyboard-focused but not under the
+        pointer - menus and drop-down rows share it so the two read the same. Per variant, not at the
+        dictionary root: a root-level StaticResource cannot see into ThemeDictionaries and would bind
+        the Default (light) brush for dark popups too.
+      -->
+      <StaticResource x:Key="PopupRowSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
       <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.03" />
 
       <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
@@ -294,7 +300,7 @@
 
       <SolidColorBrush x:Key="LayoutBackgroundHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.24" />
       <SolidColorBrush x:Key="LayoutBackgroundMidBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.17" />
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
+      <StaticResource x:Key="PopupRowSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
       <SolidColorBrush x:Key="LayoutBackgroundLowBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.05" />
 
       <SolidColorBrush x:Key="LayoutBorderHighBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
@@ -774,6 +780,7 @@
   <Thickness x:Key="MenuToolBarItemActiveBackgroundMargin">-10 -3 -8 -3</Thickness>
   <Thickness x:Key="MenuItemActiveBackgroundMargin">-6,-2,-7,-2</Thickness>
   <Thickness x:Key="MenuItemIconPadding">0</Thickness>
+  <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="LayoutBackgroundMidBrush" />
   <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="ControlBackgroundAccentMidBrush" />
   <SolidColorBrush x:Key="SeparatorBrush" Color="{DynamicResource ForegroundColor}" Opacity="0.2" />
   <Thickness x:Key="MenuFlyoutScrollerMargin">0,4,0,4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -412,6 +412,18 @@
   <!-- Popup -->
   <Thickness x:Key="PopupMargin">12 4 12 29</Thickness> <!-- to accommodate shadow -->
   <Thickness x:Key="PopupInnerBorderThickness">1 1 0 0</Thickness>
+  <!--
+    Matches the 4pt inset the menus use, so a ComboBox drop-down and a menu look like the same
+    surface. Classic keeps "3 5".
+
+    Three things stack up to that 4pt, which is why the numbers look arbitrary:
+      PopupInnerBorderThickness  1 1 0 0   top/left-only bevel
+      PopupPadding               1 3 2 4   this key
+      ComboBoxItemMargin         2 0       carried by the row itself
+    left 1+1+2, top 1+3+0, right 0+2+2, bottom 0+4+0 - an even 4 on every side.
+    MacOsPopupInsetTests pins the sum, so change any one of the three and it will tell you.
+  -->
+  <Thickness x:Key="PopupPadding">1 3 2 4</Thickness>
   <x:Double x:Key="SubMenuPopupVerticalOffset">-11</x:Double>
 
   <!--

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -392,6 +392,25 @@
   <Thickness x:Key="PopupInnerBorderThickness">1 1 0 0</Thickness>
   <x:Double x:Key="SubMenuPopupVerticalOffset">-11</x:Double>
 
+  <!--
+    Menu surface insets. Native macOS 26 menus inset the selected row by 4pt from the menu
+    background on every side, and round it at 6pt inside the menu's own 12pt corner. Ours sat at 6pt
+    with a 4pt radius, which reads as too much air around a corner that is too tight.
+
+    The inset is not a single value. Horizontally it is PopupInnerBorderThickness + MenuFlyoutPadding;
+    vertically it is PopupInnerBorderThickness + MenuFlyoutScrollerMargin. PopupInnerBorderThickness
+    is "1 1 0 0" - a top/left-only bevel - so the padding and margin have to give that pixel back on
+    those two sides for the visible gap to come out even at 4pt. Hence the asymmetric values below;
+    they are not arbitrary, and a symmetric pair lands 1pt out on the top and left.
+
+    MenuSelectionCornerRadius exists because the generic SelectionCornerRadius is shared with
+    ComboBox, which should keep its own radius. Classic defines neither key and falls through to the
+    MacOsMenu* defaults in Accents/MenuResources.axaml, so it is unaffected.
+  -->
+  <Thickness x:Key="MenuFlyoutPadding">3 0 4 0</Thickness>
+  <Thickness x:Key="MenuFlyoutScrollerMargin">0 3 0 4</Thickness>
+  <CornerRadius x:Key="MenuSelectionCornerRadius">6</CornerRadius>
+
   <!-- MenuItem -->
   <Thickness x:Key="MenuItemPadding">9 4 7 4</Thickness>
   <x:Double x:Key="MenuItemMinHeight">24</x:Double>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -434,6 +434,8 @@
   -->
   <Thickness x:Key="PopupPadding">1 3 2 4</Thickness>
   <x:Int32 x:Key="InitialFirstItemDistance">7</x:Int32>
+  <!-- PopupMargin is "12 4 12 29" here, 3pt taller than classic's, so the trim follows it. -->
+  <x:Int32 x:Key="PopupTrimHeight">33</x:Int32>
   <x:Double x:Key="SubMenuPopupVerticalOffset">-11</x:Double>
 
   <!--

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -228,8 +228,13 @@
         Declared per variant, not once at the dictionary root: a root-level StaticResource cannot see
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
+
+        Both states are needed. A menu row is :selected while the keyboard is on it and :pointerover
+        under the mouse, and AppKit accents both; leaving the selected key undefined here drops
+        keyboard navigation back to the neutral LayoutBackgroundMidBrush from the base dictionary.
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -321,8 +326,13 @@
         Declared per variant, not once at the dictionary root: a root-level StaticResource cannot see
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
+
+        Both states are needed. A menu row is :selected while the keyboard is on it and :pointerover
+        under the mouse, and AppKit accents both; leaving the selected key undefined here drops
+        keyboard navigation back to the neutral LayoutBackgroundMidBrush from the base dictionary.
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -235,7 +235,7 @@
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Sampled from a native menu whose submenu is open with the pointer elsewhere. -->
-      <SolidColorBrush x:Key="MenuItemSelectedBackgroundBrush" Color="#d7d9d9" />
+      <SolidColorBrush x:Key="PopupRowSelectedBackgroundBrush" Color="#d7d9d9" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -333,7 +333,7 @@
         under the pointer - see MenuResourceAliasBuilder.
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
-      <SolidColorBrush x:Key="MenuItemSelectedBackgroundBrush" Color="#3d4243" />
+      <SolidColorBrush x:Key="PopupRowSelectedBackgroundBrush" Color="#3d4243" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -21,7 +21,13 @@
   <OklchAdjustmentConverter x:Key="DarkModeAccentBackgroundWashConverter" LightnessAdjustment="0" ChromaAdjustment="-0.01" HueAdjustment="5.1" />
 
   <OklchAdjustmentConverter x:Key="LightModeAccentHighlightConverter" LightnessAdjustment="-0.07" ChromaAdjustment="0.02" HueAdjustment="2" />
-  <OklchAdjustmentConverter x:Key="DarkModeAccentHighlightConverter" LightnessAdjustment="0.04" ChromaAdjustment="-0.02" HueAdjustment="-4.4" />
+  <!--
+    Fitted so the macOS default accent (#007aff) lands the menu/ComboBox selection on #274fbe, the
+    colour AppKit uses for a selected dark menu row. Applied as a relative Oklch delta, so a custom
+    system accent shifts with it. The previous values moved lightness and chroma the other way, which
+    read as a washed-out cyan next to Finder's.
+  -->
+  <OklchAdjustmentConverter x:Key="DarkModeAccentHighlightConverter" LightnessAdjustment="-0.0422" ChromaAdjustment="0.0238" HueAdjustment="7.12" />
 
   <!-- MARK: Brushes -->
 
@@ -217,6 +223,14 @@
 
       <StaticResource x:Key="PopupBorderBrush" ResourceKey="ForegroundT20" />
       <StaticResource x:Key="ComboBoxItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
+
+      <!--
+        Declared per variant, not once at the dictionary root: a root-level StaticResource cannot see
+        into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
+        menus end up wearing the light accent at the light opacity.
+      -->
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
+      <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -303,6 +317,14 @@
 
       <StaticResource x:Key="PopupBorderBrush" ResourceKey="ForegroundT26" />
       <StaticResource x:Key="ComboBoxItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
+
+      <!--
+        Declared per variant, not once at the dictionary root: a root-level StaticResource cannot see
+        into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
+        menus end up wearing the light accent at the light opacity.
+      -->
+      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
+      <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -414,8 +436,6 @@
   <!-- MenuItem -->
   <Thickness x:Key="MenuItemPadding">9 4 7 4</Thickness>
   <x:Double x:Key="MenuItemMinHeight">24</x:Double>
-  <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
-  <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
 
 
   <!-- TextBox -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -229,7 +229,6 @@
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
       -->
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
@@ -323,7 +322,6 @@
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
       -->
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
@@ -412,18 +410,6 @@
   <!-- Popup -->
   <Thickness x:Key="PopupMargin">12 4 12 29</Thickness> <!-- to accommodate shadow -->
   <Thickness x:Key="PopupInnerBorderThickness">1 1 0 0</Thickness>
-  <!--
-    Matches the 4pt inset the menus use, so a ComboBox drop-down and a menu look like the same
-    surface. Classic keeps "3 5".
-
-    Three things stack up to that 4pt, which is why the numbers look arbitrary:
-      PopupInnerBorderThickness  1 1 0 0   top/left-only bevel
-      PopupPadding               1 3 2 4   this key
-      ComboBoxItemMargin         2 0       carried by the row itself
-    left 1+1+2, top 1+3+0, right 0+2+2, bottom 0+4+0 - an even 4 on every side.
-    MacOsPopupInsetTests pins the sum, so change any one of the three and it will tell you.
-  -->
-  <Thickness x:Key="PopupPadding">1 3 2 4</Thickness>
   <x:Double x:Key="SubMenuPopupVerticalOffset">-11</x:Double>
 
   <!--

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -144,7 +144,15 @@
       <!-- OpaqueSurfaceTxx colours are used to fake the look of SurfaceTxx on standard backgrounds when true transparency doesn't work -->
       <SolidColorBrush x:Key="OpaqueSurfaceT07" Color="#ececec" />
 
-      <SolidColorBrush x:Key="TranslucentSurface" Color="#f8f9f9" Opacity="0.93" />
+      <!--
+        Opaque, even though LiquidGlass is translucent elsewhere. Avalonia can only blur a popup's
+        backdrop through the window compositor, and that blur cannot be shaped to the popup's
+        rounded corners - so a translucent popup shows sharp, legible content straight through it
+        instead of the frosted surface AppKit produces. This colour is sampled from a native macOS
+        menu sitting over a typical window background, so popups land where AppKit's do without
+        needing the blur. Renamed from TranslucentSurface, which no longer describes it.
+      -->
+      <SolidColorBrush x:Key="PopupSurface" Color="#f8f9f9" />
 
       <SolidColorBrush x:Key="AccentBackgroundWash" x:DataType="SolidColorBrush"
                        Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource LightModeAccentBackgroundWashConverter}}"
@@ -160,7 +168,7 @@
       <StaticResource x:Key="ControlLabelBrush" ResourceKey="ForegroundT85" />
       <StaticResource x:Key="ControlDisabledLabelBrush" ResourceKey="ForegroundT24" />
 
-      <StaticResource x:Key="PopupBackgroundBrush" ResourceKey="TranslucentSurface" />
+      <StaticResource x:Key="PopupBackgroundBrush" ResourceKey="PopupSurface" />
       <StaticResource x:Key="PopupInnerBorderHighlightBrush" ResourceKey="Highlight" />
 
       <!-- Control-specific resources -->
@@ -226,7 +234,12 @@
       <!-- OpaqueSurfaceTxx colours are used to fake the look of SurfaceTxx on standard backgrounds when true transparency doesn't work -->
       <SolidColorBrush x:Key="OpaqueSurfaceT08" Color="#323341" />
 
-      <SolidColorBrush x:Key="TranslucentSurface" Color="#171717" Opacity="0.89" />
+      <!--
+        Opaque popup surface - see the light variant above for the rationale. Sampled straight from
+        a native macOS dark menu, so it carries that material's slight cool cast rather than being a
+        neutral grey.
+      -->
+      <SolidColorBrush x:Key="PopupSurface" Color="#22272a" />
 
       <SolidColorBrush x:Key="AccentBackgroundWash"
                        Color="{ReflectionBinding Color, Source={StaticResource SystemAccent}, Converter={StaticResource DarkModeAccentBackgroundWashConverter}}"
@@ -242,7 +255,7 @@
       <StaticResource x:Key="ControlLabelBrush" ResourceKey="ForegroundT85" />
       <StaticResource x:Key="ControlDisabledLabelBrush" ResourceKey="ForegroundT24" />
 
-      <StaticResource x:Key="PopupBackgroundBrush" ResourceKey="TranslucentSurface" />
+      <StaticResource x:Key="PopupBackgroundBrush" ResourceKey="PopupSurface" />
       <StaticResource x:Key="PopupInnerBorderHighlightBrush" ResourceKey="PopupBackgroundBrush" />
 
       <!-- Control-specific resources -->

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -416,8 +416,12 @@
 
   <!--
     Menu surface insets. Native macOS 26 menus inset the selected row by 4pt from the menu
-    background on every side, and round it at 6pt inside the menu's own 12pt corner. Ours sat at 6pt
-    with a 4pt radius, which reads as too much air around a corner that is too tight.
+    background on every side, inside the menu's own 12pt corner. Ours sat at 6pt with a 4pt radius,
+    which reads as too much air around a corner that is too tight.
+
+    The 4pt inset is measured from Finder. The 7pt radius is not: measurement of a native menu puts
+    it nearer 6pt, but 7pt is what looks right against our 12pt menu corner, so it was chosen by eye
+    and should stay a judgement call rather than being "corrected" back to the measured value.
 
     The inset is not a single value. Horizontally it is PopupInnerBorderThickness + MenuFlyoutPadding;
     vertically it is PopupInnerBorderThickness + MenuFlyoutScrollerMargin. PopupInnerBorderThickness
@@ -431,7 +435,7 @@
   -->
   <Thickness x:Key="MenuFlyoutPadding">3 0 4 0</Thickness>
   <Thickness x:Key="MenuFlyoutScrollerMargin">0 3 0 4</Thickness>
-  <CornerRadius x:Key="MenuSelectionCornerRadius">6</CornerRadius>
+  <CornerRadius x:Key="MenuSelectionCornerRadius">7</CornerRadius>
 
   <!-- MenuItem -->
   <Thickness x:Key="MenuItemPadding">9 4 7 4</Thickness>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -410,6 +410,20 @@
   <!-- Popup -->
   <Thickness x:Key="PopupMargin">12 4 12 29</Thickness> <!-- to accommodate shadow -->
   <Thickness x:Key="PopupInnerBorderThickness">1 1 0 0</Thickness>
+  <!--
+    The drop-down list inset, matching the 4pt the menus use so every popup surface reads the same.
+    Three tokens stack up to it, which is why the numbers look arbitrary:
+      PopupInnerBorderThickness  1 1 0 0   top/left-only bevel
+      PopupPadding               1 3 2 4   this key
+      ComboBoxItemMargin         2 0       carried by the row itself
+    left 1+1+2, top 1+3+0, right 0+2+2, bottom 0+4+0 - an even 4 on every side.
+
+    InitialFirstItemDistance must track PopupPadding.Top (see ThemeResources.axaml): it positions a
+    ComboBox popup so the selected row lands over the closed control. ComboBox and MultiComboBox read
+    it through DynamicResource so this override actually reaches them.
+  -->
+  <Thickness x:Key="PopupPadding">1 3 2 4</Thickness>
+  <x:Int32 x:Key="InitialFirstItemDistance">7</x:Int32>
   <x:Double x:Key="SubMenuPopupVerticalOffset">-11</x:Double>
 
   <!--

--- a/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Accents/ThemeResources_LiquidGlass.axaml
@@ -229,12 +229,13 @@
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
 
-        Both states are needed. A menu row is :selected while the keyboard is on it and :pointerover
-        under the mouse, and AppKit accents both; leaving the selected key undefined here drops
-        keyboard navigation back to the neutral LayoutBackgroundMidBrush from the base dictionary.
+        Only the pointer-over state is accented. The :selected and :focus-visible states stay on the
+        neutral brush so a submenu-open or keyboard-focused row remains distinguishable from the one
+        under the pointer - see MenuResourceAliasBuilder.
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
+      <!-- Sampled from a native menu whose submenu is open with the pointer elsewhere. -->
+      <SolidColorBrush x:Key="MenuItemSelectedBackgroundBrush" Color="#d7d9d9" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 
@@ -327,12 +328,12 @@
         into ThemeDictionaries, so it silently binds the Default (light) AccentHighlight and dark
         menus end up wearing the light accent at the light opacity.
 
-        Both states are needed. A menu row is :selected while the keyboard is on it and :pointerover
-        under the mouse, and AppKit accents both; leaving the selected key undefined here drops
-        keyboard navigation back to the neutral LayoutBackgroundMidBrush from the base dictionary.
+        Only the pointer-over state is accented. The :selected and :focus-visible states stay on the
+        neutral brush so a submenu-open or keyboard-focused row remains distinguishable from the one
+        under the pointer - see MenuResourceAliasBuilder.
       -->
       <StaticResource x:Key="MenuItemPointerOverBackgroundBrush" ResourceKey="AccentHighlight" />
-      <StaticResource x:Key="MenuItemSelectedBackgroundBrush" ResourceKey="AccentHighlight" />
+      <SolidColorBrush x:Key="MenuItemSelectedBackgroundBrush" Color="#3d4243" />
       <!-- Note: Shadow used to render a border on the _outside_ -->
       <StaticResource x:Key="ComboBoxBoxShadow" ResourceKey="TextBoxBoxShadow" />
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
@@ -57,7 +57,7 @@
                     BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
                     BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
                     Background="{DynamicResource PopupBackgroundBrush}"
-                    CornerRadius="{DynamicResource LayoutCornerRadius}"
+                    CornerRadius="{DynamicResource PopupCornerRadius}"
                     Margin="{DynamicResource PopupMargin}"
                     Padding="{DynamicResource PopupPadding}"
                     BoxShadow="{DynamicResource PopupShadow}">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
@@ -55,18 +55,22 @@
             </Popup.MinWidth>
             <Border Name="PART_SuggestionsContainer"
                     BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                    BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                    Background="{DynamicResource PopupBackgroundBrush}"
+                    BorderBrush="{DynamicResource PopupBorderBrush}"
                     CornerRadius="{DynamicResource PopupCornerRadius}"
                     Margin="{DynamicResource PopupMargin}"
-                    Padding="{DynamicResource PopupPadding}"
                     BoxShadow="{DynamicResource PopupShadow}">
-              <ListBox Name="PART_SelectingItemsControl"
-                       Classes="selection_checkmark_off"
-                       BorderThickness="0"
-                       Background="Transparent"
-                       ItemTemplate="{TemplateBinding ItemTemplate}"
-                       Margin="{DynamicResource AutoCompleteListPadding}" />
+              <Border Name="InnerBorderHighlight"
+                      Background="{DynamicResource PopupBackgroundBrush}"
+                      BorderBrush="{DynamicResource PopupInnerBorderHighlightBrush}"
+                      BorderThickness="{DynamicResource PopupInnerBorderThickness}"
+                      CornerRadius="{DynamicResource PopupCornerRadius}"
+                      Padding="{DynamicResource PopupPadding}">
+                <ListBox Name="PART_SelectingItemsControl"
+                         Classes="selection_checkmark_off"
+                         BorderThickness="0"
+                         Background="Transparent"
+                         ItemTemplate="{TemplateBinding ItemTemplate}" />
+              </Border>
             </Border>
           </Popup>
         </Panel>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
@@ -69,7 +69,23 @@
                          Classes="selection_checkmark_off"
                          BorderThickness="0"
                          Background="Transparent"
-                         ItemTemplate="{TemplateBinding ItemTemplate}" />
+                         Padding="0"
+                         ItemTemplate="{TemplateBinding ItemTemplate}">
+                  <!--
+                    Rows here are ListBoxItems, shared with plain (non-popup) ListBoxes, so they
+                    carry the raised-accent hover and the generic control radius. Inside a drop-down
+                    they need to read like every other drop-down row. Padding is zeroed because the
+                    popup surface already supplies the inset - the ListBox's own would double it.
+                  -->
+                  <ListBox.Styles>
+                    <Style Selector="ListBoxItem">
+                      <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
+                    </Style>
+                    <Style Selector="ListBoxItem:pointerover /template/ Border#RootPanel">
+                      <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
+                    </Style>
+                  </ListBox.Styles>
+                </ListBox>
               </Border>
             </Border>
           </Popup>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/AutoCompleteBox.axaml
@@ -81,6 +81,24 @@
                     <Style Selector="ListBoxItem">
                       <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
                     </Style>
+
+                    <!--
+                      A ListBoxItem shows selection as a checkmark and keyboard focus as a ring.
+                      Neither survives here: selection_checkmark_off hides the checkmark, and the
+                      other drop-downs indicate both with the neutral fill instead. Without these a
+                      selected or keyboard-focused suggestion shows nothing at all.
+                    -->
+                    <Style Selector="ListBoxItem:selected /template/ Border#RootPanel">
+                      <Setter Property="Background" Value="{DynamicResource PopupRowSelectedBackgroundBrush}" />
+                    </Style>
+                    <Style Selector="ListBoxItem:focus-visible /template/ Border#RootPanel">
+                      <Setter Property="Background" Value="{DynamicResource PopupRowSelectedBackgroundBrush}" />
+                    </Style>
+                    <Style Selector="ListBoxItem:focus-visible /template/ Border#FocusRing">
+                      <Setter Property="IsVisible" Value="False" />
+                    </Style>
+
+                    <!-- Last, so the pointer's accent still wins over the neutral. -->
                     <Style Selector="ListBoxItem:pointerover /template/ Border#RootPanel">
                       <Setter Property="Background" Value="{DynamicResource ComboBoxItemPointerOverBackgroundBrush}" />
                     </Style>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -147,9 +147,16 @@
                      WindowManagerAddShadowHint="False"
                      IsLightDismissEnabled="True">
                 <!--
-                  Shares the popup surface with the drop-downs, but not their inner bevel or inset:
-                  it wraps a calendar rather than a list of rows, so it keeps its own
-                  CalendarPopupPadding and has no row margin to compose with.
+                  Shares the drop-downs' border and radius, but deliberately not their background,
+                  inner bevel or inset: it wraps a calendar rather than a list of rows, so it keeps
+                  its own CalendarPopupPadding and has no row margin to compose with.
+
+                  The background stays SystemRegionBrush. Sharing the popup surface was tried and
+                  does not work here: Calendar paints its own background, so the surface showed only
+                  through CalendarPopupPadding and read as a frame around the calendar; making the
+                  Calendar transparent instead exposed a per-element background behind every day
+                  cell. Keeping its own background is both simpler and correct - this popup is a
+                  panel of controls, not a list of rows on a surface.
 
                   The background is the one token on this surface that does not resolve identically
                   under the classic theme - SystemRegionBrush was White / #21222f there against
@@ -159,7 +166,7 @@
                 -->
                 <Border BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
                         BorderBrush="{DynamicResource PopupBorderBrush}"
-                        Background="{DynamicResource PopupBackgroundBrush}"
+                        Background="{DynamicResource SystemRegionBrush}"
                         CornerRadius="{DynamicResource PopupCornerRadius}"
                         Margin="{DynamicResource PopupMargin}"
                         Padding="{DynamicResource CalendarPopupPadding}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -146,12 +146,17 @@
                      HorizontalOffset="-10"
                      WindowManagerAddShadowHint="False"
                      IsLightDismissEnabled="True">
+                <!--
+                  Shares the popup surface with the drop-downs, but not their inner bevel or inset:
+                  it wraps a calendar rather than a list of rows, so it keeps its own
+                  CalendarPopupPadding and has no row margin to compose with.
+                -->
                 <Border BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                        BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
-                        Background="{DynamicResource SystemRegionBrush}"
-                        CornerRadius="{DynamicResource LayoutCornerRadius}"
+                        BorderBrush="{DynamicResource PopupBorderBrush}"
+                        Background="{DynamicResource PopupBackgroundBrush}"
+                        CornerRadius="{DynamicResource PopupCornerRadius}"
                         Margin="{DynamicResource PopupMargin}"
-                        Padding="{DynamicResource PopupPadding}"
+                        Padding="{DynamicResource CalendarPopupPadding}"
                         BoxShadow="{DynamicResource PopupShadow}">
                   <Calendar Name="PART_Calendar"
                             Focusable="True"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/CalendarDatePicker.axaml
@@ -150,6 +150,12 @@
                   Shares the popup surface with the drop-downs, but not their inner bevel or inset:
                   it wraps a calendar rather than a list of rows, so it keeps its own
                   CalendarPopupPadding and has no row margin to compose with.
+
+                  The background is the one token on this surface that does not resolve identically
+                  under the classic theme - SystemRegionBrush was White / #21222f there against
+                  PopupBackgroundBrush's #e7e7e7 / #262626 - so classic calendars change too. That is
+                  intentional: a calendar popping out of a control should read as the same surface as
+                  a menu or a drop-down in either theme.
                 -->
                 <Border BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
                         BorderBrush="{DynamicResource PopupBorderBrush}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -294,7 +294,7 @@
                 <MultiBinding Converter="{x:Static DevoMultiConverters.SelectedIndexToPopupOffsetConverter}">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedIndex" />
                   <Binding Source="{StaticResource ComboBoxItemHeight}" />
-                  <Binding Source="{StaticResource InitialFirstItemDistance}" />
+                  <DynamicResource ResourceKey="InitialFirstItemDistance" />
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
                   <Binding Source="{StaticResource PopupTrimHeight}" />
                 </MultiBinding>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBox.axaml
@@ -296,7 +296,7 @@
                   <Binding Source="{StaticResource ComboBoxItemHeight}" />
                   <DynamicResource ResourceKey="InitialFirstItemDistance" />
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
-                  <Binding Source="{StaticResource PopupTrimHeight}" />
+                  <DynamicResource ResourceKey="PopupTrimHeight" />
                 </MultiBinding>
               </Popup.VerticalOffset>
               <Border

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ComboBoxItem.axaml
@@ -67,7 +67,7 @@
 
     <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#RootPanel">
-        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+        <Setter Property="Background" Value="{DynamicResource PopupRowSelectedBackgroundBrush}" />
       </Style>
       <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -89,7 +89,7 @@
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="IsHitTestVisible" Value="True" />
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
     <Setter Property="Padding" Value="{DynamicResource ComboBoxItemPadding}" />
     <Setter Property="ContentTemplate">
       <DataTemplate>
@@ -130,7 +130,7 @@
       </ControlTemplate>
     </Setter>
     <Style Selector="^ /template/ Border#PART_Background">
-      <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+      <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
     </Style>
 
     <Style Selector="^[IsCommittedSelected=True]">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -312,15 +312,19 @@
                 ClipToBounds="False">
                 <Border
                   x:Name="PopupBorder"
-                  Background="{DynamicResource PopupBackgroundBrush}"
-                  BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+                  BorderBrush="{DynamicResource PopupBorderBrush}"
                   BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                  Padding="{DynamicResource PopupPadding}"
                   HorizontalAlignment="Stretch"
                   MaxWidth="{TemplateBinding MaxDropDownWidth}"
                   BoxShadow="{DynamicResource PopupShadow}"
                   Margin="{DynamicResource PopupMargin}"
                   CornerRadius="{DynamicResource PopupCornerRadius}">
+                  <Border Name="InnerBorderHighlight"
+                          Background="{DynamicResource PopupBackgroundBrush}"
+                          BorderBrush="{DynamicResource PopupInnerBorderHighlightBrush}"
+                          BorderThickness="{DynamicResource PopupInnerBorderThickness}"
+                          CornerRadius="{DynamicResource PopupCornerRadius}"
+                          Padding="{DynamicResource PopupPadding}">
                   <ScrollViewer
                     Name="PART_DropDownScrollViewer"
                     CornerRadius="{DynamicResource PopupCornerRadius}"
@@ -337,6 +341,7 @@
                       </ItemsPresenter.Styles>
                     </ItemsPresenter>
                   </ScrollViewer>
+                  </Border>
                 </Border>
               </Popup>
             </Grid>

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -141,13 +141,13 @@
 
     <Style Selector="^:focus-visible">
       <Style Selector="^ /template/ Border#PART_Background">
-        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+        <Setter Property="Background" Value="{DynamicResource PopupRowSelectedBackgroundBrush}" />
       </Style>
     </Style>
 
     <Style Selector="^[IsSelected=True]">
       <Style Selector="^ /template/ Border#PART_Background">
-        <Setter Property="Background" Value="{DynamicResource LayoutBackgroundMidBrush}" />
+        <Setter Property="Background" Value="{DynamicResource PopupRowSelectedBackgroundBrush}" />
       </Style>
     </Style>
 

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/EditableComboBox.axaml
@@ -320,10 +320,10 @@
                   MaxWidth="{TemplateBinding MaxDropDownWidth}"
                   BoxShadow="{DynamicResource PopupShadow}"
                   Margin="{DynamicResource PopupMargin}"
-                  CornerRadius="{DynamicResource LayoutCornerRadius}">
+                  CornerRadius="{DynamicResource PopupCornerRadius}">
                   <ScrollViewer
                     Name="PART_DropDownScrollViewer"
-                    CornerRadius="{DynamicResource LayoutCornerRadius}"
+                    CornerRadius="{DynamicResource PopupCornerRadius}"
                     HorizontalScrollBarVisibility="Disabled"
                     VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
                     IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/ListBox.axaml
@@ -45,7 +45,7 @@
   <ControlTheme x:Key="{x:Type ListBox}" TargetType="ListBox">
     <Setter Property="BorderBrush" Value="{DynamicResource ScrollControlBorder}" />
     <Setter Property="BorderThickness" Value="1" />
-    <Setter Property="Padding" Value="{DynamicResource PopupPadding}" />
+    <Setter Property="Padding" Value="{DynamicResource ListBoxPadding}" />
     <Setter Property="ScrollViewer.IsScrollChainingEnabled" Value="True" />
     <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="True" />
     <Setter Property="Template">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/Menu.axaml
@@ -119,7 +119,7 @@
           <Panel>
             <Border Name="MenuItemActiveBackground"
                     Background="Transparent"
-                    CornerRadius="{StaticResource MacOsMenuSelectionCornerRadius}"
+                    CornerRadius="{DynamicResource MacOsMenuSelectionCornerRadius}"
                     Margin="{DynamicResource MacOsMenuItemActiveBackgroundMargin}">
               <Border.IsVisible>
                 <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"
@@ -153,7 +153,7 @@
                 <Panel>
                   <Border Name="ToolBarItemActiveBackground"
                           Background="Transparent"
-                          CornerRadius="{StaticResource MacOsMenuSelectionCornerRadius}"
+                          CornerRadius="{DynamicResource MacOsMenuSelectionCornerRadius}"
                           Margin="{DynamicResource MacOsMenuToolBarItemActiveBackgroundMargin}">
                     <Border.IsVisible>
                       <MultiBinding Converter="{x:Static DevoMultiConverters.ClassToChoiceConverter}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MenuItem.axaml
@@ -92,7 +92,7 @@
                   Background="{TemplateBinding Background}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  CornerRadius="{StaticResource MacOsMenuSelectionCornerRadius}">
+                  CornerRadius="{DynamicResource MacOsMenuSelectionCornerRadius}">
             <Grid>
               <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -223,7 +223,7 @@
               <Border Background="{DynamicResource PopupBackgroundBrush}"
                       BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
                       BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
-                      CornerRadius="{DynamicResource LayoutCornerRadius}"
+                      CornerRadius="{DynamicResource PopupCornerRadius}"
                       Margin="{DynamicResource PopupMargin}"
                       Padding="{DynamicResource PopupPadding}"
                       BoxShadow="{DynamicResource PopupShadow}">

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -215,18 +215,22 @@
                 <MultiBinding Converter="{x:Static DevoMultiConverters.SelectedIndexToPopupOffsetConverter}">
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="SelectedIndex" />
                   <Binding Source="{StaticResource ComboBoxItemHeight}" />
-                  <Binding Source="{StaticResource InitialFirstItemDistance}" />
+                  <DynamicResource ResourceKey="InitialFirstItemDistance" />
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
                   <Binding Source="{StaticResource PopupTrimHeight}" />
                 </MultiBinding>
               </Popup.VerticalOffset>
-              <Border Background="{DynamicResource PopupBackgroundBrush}"
-                      BorderBrush="{DynamicResource MenuFlyoutPresenterBorderBrush}"
+              <Border BorderBrush="{DynamicResource PopupBorderBrush}"
                       BorderThickness="{DynamicResource MenuFlyoutPresenterBorderThickness}"
                       CornerRadius="{DynamicResource PopupCornerRadius}"
                       Margin="{DynamicResource PopupMargin}"
-                      Padding="{DynamicResource PopupPadding}"
                       BoxShadow="{DynamicResource PopupShadow}">
+                <Border Name="InnerBorderHighlight"
+                        Background="{DynamicResource PopupBackgroundBrush}"
+                        BorderBrush="{DynamicResource PopupInnerBorderHighlightBrush}"
+                        BorderThickness="{DynamicResource PopupInnerBorderThickness}"
+                        CornerRadius="{DynamicResource PopupCornerRadius}"
+                        Padding="{DynamicResource PopupPadding}">
                 <DockPanel LastChildFill="True">
                   <TextBox
                     Name="PART_FilterTextBox"
@@ -271,6 +275,7 @@
                       Foreground="{DynamicResource TextControlPlaceholderForeground}" />
                   </Panel>
                 </DockPanel>
+                </Border>
               </Border>
             </Popup>
             <!-- In-template focus ring (see TextBox.axaml). Lives in the normal visual tree so it is

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBox.axaml
@@ -217,7 +217,7 @@
                   <Binding Source="{StaticResource ComboBoxItemHeight}" />
                   <DynamicResource ResourceKey="InitialFirstItemDistance" />
                   <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="MaxDropDownHeight" />
-                  <Binding Source="{StaticResource PopupTrimHeight}" />
+                  <DynamicResource ResourceKey="PopupTrimHeight" />
                 </MultiBinding>
               </Popup.VerticalOffset>
               <Border BorderBrush="{DynamicResource PopupBorderBrush}"

--- a/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Controls/MultiComboBoxItem.axaml
@@ -19,7 +19,7 @@
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Template">
@@ -85,7 +85,7 @@
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="Foreground" Value="{DynamicResource ForegroundHighBrush}" />
     <Setter Property="Template">
@@ -155,7 +155,7 @@
     <Setter Property="Margin" Value="{DynamicResource ComboBoxItemMargin}" />
     <Setter Property="HorizontalAlignment" Value="Stretch" />
     <Setter Property="HorizontalContentAlignment" Value="Left" />
-    <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+    <Setter Property="CornerRadius" Value="{DynamicResource ComboBoxItemCornerRadius}" />
     <Setter Property="FontSize" Value="{DynamicResource ControlFontSize}" />
     <Setter Property="FontWeight" Value="SemiBold" />
     <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundAccentBrush}" />

--- a/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
@@ -19,7 +19,7 @@ internal static class MenuResourceAliasBuilder
     ("MacOsMenuSvgItemPointerOverCss", "SvgMenuItemPointerOverCss"),
     ("MacOsMenuSvgItemDisabledCss", "SvgMenuItemDisabledCss"),
     ("MacOsMenuAccentForegroundBrush", "ControlForegroundAccentHighBrush"),
-    ("MacOsMenuSelectedBackgroundBrush", "LayoutBackgroundMidBrush"),
+    ("MacOsMenuSelectedBackgroundBrush", "MenuItemSelectedBackgroundBrush"),
     ("MacOsMenuPressedBackgroundBrush", "LayoutBackgroundHighBrush"),
     ("MacOsMenuItemPointerOverBackgroundBrush", "MenuItemPointerOverBackgroundBrush"),
     ("MacOsMenuPopupBorderThickness", "MenuFlyoutPresenterBorderThickness"),

--- a/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
@@ -19,6 +19,10 @@ internal static class MenuResourceAliasBuilder
     ("MacOsMenuSvgItemPointerOverCss", "SvgMenuItemPointerOverCss"),
     ("MacOsMenuSvgItemDisabledCss", "SvgMenuItemDisabledCss"),
     ("MacOsMenuAccentForegroundBrush", "ControlForegroundAccentHighBrush"),
+    // Deliberately NOT the accent. A row is :selected when its submenu is open and the pointer has
+    // moved away, and :focus-visible under keyboard navigation. AppKit greys both so they stay
+    // distinguishable from the accent the pointer paints; accenting them makes a keyboard-focused
+    // row indistinguishable from a hovered one.
     ("MacOsMenuSelectedBackgroundBrush", "MenuItemSelectedBackgroundBrush"),
     ("MacOsMenuPressedBackgroundBrush", "LayoutBackgroundHighBrush"),
     ("MacOsMenuItemPointerOverBackgroundBrush", "MenuItemPointerOverBackgroundBrush"),

--- a/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
@@ -26,7 +26,7 @@ internal static class MenuResourceAliasBuilder
     ("MacOsMenuFontSize", "ControlFontSize"),
     ("MacOsMenuHeaderFontSizeSmall", "MenuHeaderFontSizeSmall"),
     ("MacOsMenuChevronSize", "TreeViewItemChevronSize"),
-    ("MacOsMenuSelectionCornerRadius", "SelectionCornerRadius"),
+    ("MacOsMenuSelectionCornerRadius", "MenuSelectionCornerRadius"),
     ("MacOsMenuPopupMargin", "PopupMargin"),
     ("MacOsMenuPopupInnerBorderThickness", "PopupInnerBorderThickness"),
     ("MacOsMenuPopupCornerRadius", "PopupCornerRadius"),

--- a/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
+++ b/src/Devolutions.AvaloniaTheme.MacOS/Internal/MenuResourceAliasBuilder.cs
@@ -23,7 +23,7 @@ internal static class MenuResourceAliasBuilder
     // moved away, and :focus-visible under keyboard navigation. AppKit greys both so they stay
     // distinguishable from the accent the pointer paints; accenting them makes a keyboard-focused
     // row indistinguishable from a hovered one.
-    ("MacOsMenuSelectedBackgroundBrush", "MenuItemSelectedBackgroundBrush"),
+    ("MacOsMenuSelectedBackgroundBrush", "PopupRowSelectedBackgroundBrush"),
     ("MacOsMenuPressedBackgroundBrush", "LayoutBackgroundHighBrush"),
     ("MacOsMenuItemPointerOverBackgroundBrush", "MenuItemPointerOverBackgroundBrush"),
     ("MacOsMenuPopupBorderThickness", "MenuFlyoutPresenterBorderThickness"),

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -340,7 +340,7 @@ public class MacOsMenuPackContractTests
     }
 
     [AvaloniaTheory]
-    [InlineData(true, "#FFF8F9F9", 0.93)]
+    [InlineData(true, "#FFF8F9F9", 1.0)]
     [InlineData(false, "#FFE7E7E7", 1.0)]
     public void Full_theme_menu_background_follows_active_macos_variant(
         bool liquidGlass,
@@ -452,7 +452,7 @@ public class MacOsMenuPackContractTests
     };
 
     [AvaloniaTheory]
-    [InlineData(true, "#FFF8F9F9", 0.93)]
+    [InlineData(true, "#FFF8F9F9", 1.0)]
     [InlineData(false, "#FFE7E7E7", 1.0)]
     public void Pack_menu_background_follows_active_macos_variant(
         bool liquidGlass,

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsMenuPackContractTests.cs
@@ -587,14 +587,25 @@ public class MacOsMenuPackContractTests
         ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
         MacOSVersionDetector.SetTestOverride(liquidGlass);
 
+        var fullWindow = new Window { RequestedThemeVariant = variant };
+
+        // The pack cannot run the accent through OklchAdjustmentConverter, so its accent-derived
+        // tokens are pinned literals - and they are pinned to what macOS's default accent produces,
+        // which is what ships. Headless otherwise supplies Avalonia's fallback accent (#0078d7), so
+        // without this the parity check would compare against a colour no user ever sees and would
+        // demand pins that are wrong on a real Mac.
+        fullWindow.Resources["SystemAccentColor"] = Color.Parse("#007aff");
+
         var fullTheme = new DevolutionsMacOsTheme();
         fullTheme.BeginInit();
         fullTheme.EndInit();
-        var fullWindow = new Window { RequestedThemeVariant = variant };
         fullWindow.Styles.Add(fullTheme);
 
         var packPage = new UserControl();
         var packWindow = new Window { Content = packPage, RequestedThemeVariant = variant };
+        // The classic pack pins follow SystemAccentColor rather than being literals, so both sides
+        // of the comparison have to sit on the same accent.
+        packWindow.Resources["SystemAccentColor"] = Color.Parse("#007aff");
         packWindow.Styles.Add(new AvaloniaFluentTheme());
         packPage.Styles.Add(new Devolutions.AvaloniaTheme.MacOS.Controls.MacOsMenuPack());
 

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -1,0 +1,99 @@
+namespace Devolutions.AvaloniaControls.VisualTests;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Devolutions.AvaloniaTheme.MacOS;
+using Devolutions.AvaloniaTheme.MacOS.Internal;
+using Xunit;
+
+/// <summary>
+///   Guards the visible gap between a popup's background edge and the first row inside it.
+/// </summary>
+/// <remarks>
+///   The gap is composed of two tokens, and the inner border is a top/left-only bevel
+///   ("1 1 0 0"), so the padding has to give that pixel back on those two sides for the gap to
+///   come out even. That makes the padding values look wrong in isolation and invites someone to
+///   "tidy" them into a symmetric pair, which silently puts the top and left 1pt out. These tests
+///   pin the composed result instead of the raw values, so the intent survives that edit.
+/// </remarks>
+[Collection("VisualTests")]
+public class MacOsPopupInsetTests
+{
+    private const double ExpectedInset = 4;
+
+    private static Window ShowLiquidGlass(ThemeVariant variant)
+    {
+        MacOSVersionDetector.SetTestOverride(true);
+        var theme = new DevolutionsMacOsTheme();
+        theme.BeginInit();
+        theme.EndInit();
+        var window = new Window { RequestedThemeVariant = variant };
+        window.Styles.Add(theme);
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        return window;
+    }
+
+    private static Thickness Get(Window w, string key, ThemeVariant variant)
+    {
+        Assert.True(w.TryFindResource(key, variant, out object? value), $"'{key}' should resolve.");
+        return Assert.IsType<Thickness>(value);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Generic_popup_inset_is_even_on_all_sides(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            // The row carries a margin of its own, so the gap is a sum of three tokens - checking
+            // only the bevel and the padding reports 4 while the rendered gap is 6.
+            Thickness bevel = Get(w, "PopupInnerBorderThickness", variant);
+            Thickness padding = Get(w, "PopupPadding", variant);
+            Thickness item = Get(w, "ComboBoxItemMargin", variant);
+
+            Assert.Equal(ExpectedInset, bevel.Left + padding.Left + item.Left);
+            Assert.Equal(ExpectedInset, bevel.Top + padding.Top + item.Top);
+            Assert.Equal(ExpectedInset, bevel.Right + padding.Right + item.Right);
+            Assert.Equal(ExpectedInset, bevel.Bottom + padding.Bottom + item.Bottom);
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Menu_inset_matches_the_generic_popup_inset(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            // Menus split the inset differently: the padding supplies the horizontal gap and the
+            // items-presenter margin the vertical one.
+            Thickness bevel = Get(w, "MacOsMenuPopupInnerBorderThickness", variant);
+            Thickness padding = Get(w, "MacOsMenuPopupPadding", variant);
+            Thickness scroller = Get(w, "MacOsMenuFlyoutScrollerMargin", variant);
+
+            Assert.Equal(ExpectedInset, bevel.Left + padding.Left);
+            Assert.Equal(ExpectedInset, padding.Right);
+            Assert.Equal(ExpectedInset, bevel.Top + scroller.Top);
+            Assert.Equal(ExpectedInset, scroller.Bottom);
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+}

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -3,6 +3,7 @@ namespace Devolutions.AvaloniaControls.VisualTests;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Devolutions.AvaloniaTheme.MacOS;
@@ -112,6 +113,36 @@ public class MacOsPopupInsetTests
             Assert.True(w.TryFindResource("ListBoxPadding", ThemeVariant.Dark, out object? list));
             Assert.NotEqual(Get(w, "PopupPadding", ThemeVariant.Dark), Assert.IsType<Thickness>(cal));
             Assert.NotEqual(Get(w, "PopupPadding", ThemeVariant.Dark), Assert.IsType<Thickness>(list));
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    /// <summary>
+    ///   A row that is selected or keyboard-focused but not hovered takes a neutral, and a menu row
+    ///   and a drop-down row must take the same one. They reach it by different routes - the menu
+    ///   through the MacOsMenu* alias, drop-down rows straight from the shared key - so nothing else
+    ///   keeps them together.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Menu_and_drop_down_rows_share_the_selected_neutral(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            Assert.True(w.TryFindResource("MacOsMenuSelectedBackgroundBrush", variant, out object? menu));
+            Assert.True(w.TryFindResource("PopupRowSelectedBackgroundBrush", variant, out object? row));
+
+            var m = Assert.IsAssignableFrom<ISolidColorBrush>(menu);
+            var r = Assert.IsAssignableFrom<ISolidColorBrush>(row);
+            Assert.Equal(r.Color, m.Color);
+            Assert.Equal(r.Opacity, m.Opacity, 3);
         }
         finally
         {

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -121,6 +121,32 @@ public class MacOsPopupInsetTests
     }
 
     /// <summary>
+    ///   MaxDropDownHeight is applied to the Popup, so it covers the chrome as well as the list.
+    ///   PopupTrimHeight is subtracted to get back to the usable list height, and the chrome that
+    ///   makes the difference is PopupMargin's vertical total. Nothing recomputes it, so a change to
+    ///   the margin silently mis-clamps how far a popup may shift.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Popup_trim_height_tracks_the_popup_margin(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            Thickness margin = Get(w, "PopupMargin", variant);
+            Assert.True(w.TryFindResource("PopupTrimHeight", variant, out object? trim));
+            Assert.Equal(margin.Top + margin.Bottom, System.Convert.ToDouble(trim));
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    /// <summary>
     ///   A selected row should look the same whether it is in a menu or a drop-down. The two carry
     ///   separate tokens - menus cannot share ComboBox's, which ComboBox itself needs - so nothing
     ///   but this keeps them at the same radius.

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -46,6 +46,83 @@ public class MacOsPopupInsetTests
     [AvaloniaTheory]
     [InlineData("Light")]
     [InlineData("Dark")]
+    public void Drop_down_inset_is_even_on_all_sides(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            // ComboBox, EditableComboBox, MultiComboBox and AutoCompleteBox all share this
+            // composition: the popup surface supplies the bevel and padding, the row its margin.
+            Thickness bevel = Get(w, "PopupInnerBorderThickness", variant);
+            Thickness padding = Get(w, "PopupPadding", variant);
+            Thickness row = Get(w, "ComboBoxItemMargin", variant);
+
+            Assert.Equal(ExpectedInset, bevel.Left + padding.Left + row.Left);
+            Assert.Equal(ExpectedInset, bevel.Top + padding.Top + row.Top);
+            Assert.Equal(ExpectedInset, bevel.Right + padding.Right + row.Right);
+            Assert.Equal(ExpectedInset, bevel.Bottom + padding.Bottom + row.Bottom);
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    /// <summary>
+    ///   A ComboBox popup is positioned so the selected row lands over the closed control, and that
+    ///   offset is a constant that has to track the padding above the first row. Nothing recomputes
+    ///   it, so this is the only thing stopping the two drifting apart.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Popup_offset_constant_tracks_the_padding_above_the_first_row(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            Thickness shadow = Get(w, "ComboBoxShadowMargin", variant);
+            Thickness padding = Get(w, "PopupPadding", variant);
+            Assert.True(w.TryFindResource("InitialFirstItemDistance", variant, out object? distance));
+
+            Assert.Equal(shadow.Bottom + padding.Top, System.Convert.ToDouble(distance));
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    /// <summary>
+    ///   The calendar popup and a plain ListBox compose the inset differently, so they carry their
+    ///   own padding keys. If either is pointed back at the shared one, tuning the drop-down inset
+    ///   silently distorts them.
+    /// </summary>
+    [AvaloniaFact]
+    public void Calendar_and_list_box_do_not_share_the_drop_down_padding()
+    {
+        Window w = ShowLiquidGlass(ThemeVariant.Dark);
+        try
+        {
+            Assert.True(w.TryFindResource("CalendarPopupPadding", ThemeVariant.Dark, out object? cal));
+            Assert.True(w.TryFindResource("ListBoxPadding", ThemeVariant.Dark, out object? list));
+            Assert.NotEqual(Get(w, "PopupPadding", ThemeVariant.Dark), Assert.IsType<Thickness>(cal));
+            Assert.NotEqual(Get(w, "PopupPadding", ThemeVariant.Dark), Assert.IsType<Thickness>(list));
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
     public void Menu_inset_is_even_on_all_sides(string variantName)
     {
         ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -10,7 +10,7 @@ using Devolutions.AvaloniaTheme.MacOS.Internal;
 using Xunit;
 
 /// <summary>
-///   Guards the visible gap between a popup's background edge and the first row inside it.
+///   Guards the visible gap between a menu's background edge and the first row inside it.
 /// </summary>
 /// <remarks>
 ///   The gap is composed of two tokens, and the inner border is a top/left-only bevel
@@ -46,41 +46,14 @@ public class MacOsPopupInsetTests
     [AvaloniaTheory]
     [InlineData("Light")]
     [InlineData("Dark")]
-    public void Generic_popup_inset_is_even_on_all_sides(string variantName)
+    public void Menu_inset_is_even_on_all_sides(string variantName)
     {
         ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
         Window w = ShowLiquidGlass(variant);
         try
         {
-            // The row carries a margin of its own, so the gap is a sum of three tokens - checking
-            // only the bevel and the padding reports 4 while the rendered gap is 6.
-            Thickness bevel = Get(w, "PopupInnerBorderThickness", variant);
-            Thickness padding = Get(w, "PopupPadding", variant);
-            Thickness item = Get(w, "ComboBoxItemMargin", variant);
-
-            Assert.Equal(ExpectedInset, bevel.Left + padding.Left + item.Left);
-            Assert.Equal(ExpectedInset, bevel.Top + padding.Top + item.Top);
-            Assert.Equal(ExpectedInset, bevel.Right + padding.Right + item.Right);
-            Assert.Equal(ExpectedInset, bevel.Bottom + padding.Bottom + item.Bottom);
-        }
-        finally
-        {
-            w.Close();
-            MacOSVersionDetector.SetTestOverride(null);
-        }
-    }
-
-    [AvaloniaTheory]
-    [InlineData("Light")]
-    [InlineData("Dark")]
-    public void Menu_inset_matches_the_generic_popup_inset(string variantName)
-    {
-        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
-        Window w = ShowLiquidGlass(variant);
-        try
-        {
-            // Menus split the inset differently: the padding supplies the horizontal gap and the
-            // items-presenter margin the vertical one.
+            // Menus split the inset across two tokens: the padding supplies the horizontal gap and
+            // the items-presenter margin the vertical one.
             Thickness bevel = Get(w, "MacOsMenuPopupInnerBorderThickness", variant);
             Thickness padding = Get(w, "MacOsMenuPopupPadding", variant);
             Thickness scroller = Get(w, "MacOsMenuFlyoutScrollerMargin", variant);

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupInsetTests.cs
@@ -120,6 +120,31 @@ public class MacOsPopupInsetTests
         }
     }
 
+    /// <summary>
+    ///   A selected row should look the same whether it is in a menu or a drop-down. The two carry
+    ///   separate tokens - menus cannot share ComboBox's, which ComboBox itself needs - so nothing
+    ///   but this keeps them at the same radius.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Menu_and_drop_down_rows_share_a_corner_radius(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window w = ShowLiquidGlass(variant);
+        try
+        {
+            Assert.True(w.TryFindResource("MenuSelectionCornerRadius", variant, out object? menu));
+            Assert.True(w.TryFindResource("ComboBoxItemCornerRadius", variant, out object? row));
+            Assert.Equal(Assert.IsType<CornerRadius>(menu), Assert.IsType<CornerRadius>(row));
+        }
+        finally
+        {
+            w.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
     [AvaloniaTheory]
     [InlineData("Light")]
     [InlineData("Dark")]

--- a/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupOffsetTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/MacOsPopupOffsetTests.cs
@@ -1,0 +1,150 @@
+namespace Devolutions.AvaloniaControls.VisualTests;
+
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Devolutions.AvaloniaTheme.MacOS;
+using Devolutions.AvaloniaTheme.MacOS.Internal;
+using Xunit;
+
+/// <summary>
+///   Checks the popup offset a control actually computes, not just the resources it is built from.
+/// </summary>
+/// <remarks>
+///   <para>
+///     <c>InitialFirstItemDistance</c> and <c>PopupTrimHeight</c> are constants that duplicate
+///     geometry defined elsewhere - the first must equal <c>ComboBoxShadowMargin.Bottom +
+///     PopupPadding.Top</c>, the second <c>PopupMargin</c>'s vertical total. Nothing recomputes
+///     them, so changing the geometry silently mis-positions every ComboBox popup.
+///   </para>
+///   <para>
+///     These tests therefore derive what the offset should be from the *source* geometry, open a
+///     real popup, and compare. That covers the whole chain - geometry, constant, and the control
+///     that consumes it - rather than asserting a constant against itself.
+///   </para>
+///   <para>
+///     Note both constants live in merged dictionaries where the LiquidGlass copy is merged last,
+///     so <c>StaticResource</c> resolves them correctly; the <c>DynamicResource</c> the templates
+///     now use is belt-and-braces. That is unlike
+///     <c>MacOsMenuSelectionCornerRadius</c>, whose classic default is an own entry and whose
+///     LiquidGlass value arrives through the runtime alias dictionary - there
+///     <c>StaticResource</c> did resolve the wrong one.
+///   </para>
+/// </remarks>
+[Collection("VisualTests")]
+public class MacOsPopupOffsetTests
+{
+    private const int SelectedIndex = 3;
+
+    private static Window ShowLiquidGlass(ThemeVariant variant)
+    {
+        MacOSVersionDetector.SetTestOverride(true);
+        var theme = new DevolutionsMacOsTheme();
+        theme.BeginInit();
+        theme.EndInit();
+        var window = new Window { RequestedThemeVariant = variant, Width = 400, Height = 300 };
+        window.Styles.Add(theme);
+        return window;
+    }
+
+    private static Avalonia.Thickness Thickness(Window w, string key, ThemeVariant variant)
+    {
+        Assert.True(w.TryFindResource(key, variant, out object? value), $"'{key}' should resolve.");
+        return Assert.IsType<Avalonia.Thickness>(value);
+    }
+
+    private static int Int(Window w, string key, ThemeVariant variant)
+    {
+        Assert.True(w.TryFindResource(key, variant, out object? value), $"'{key}' should resolve.");
+        return Convert.ToInt32(value);
+    }
+
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Combo_box_popup_offset_follows_the_resolved_constants(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window window = ShowLiquidGlass(variant);
+        var combo = new ComboBox
+        {
+            ItemsSource = Enumerable.Range(1, 10).Select(i => $"Item {i}").ToList(),
+            SelectedIndex = SelectedIndex,
+            // Large enough that the offset is not clamped, so this measures the offset itself.
+            MaxDropDownHeight = 400,
+        };
+        window.Content = combo;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            combo.IsDropDownOpen = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            // Derived from the geometry the constant is supposed to track, not from the constant.
+            Avalonia.Thickness shadow = Thickness(window, "ComboBoxShadowMargin", variant);
+            Avalonia.Thickness padding = Thickness(window, "PopupPadding", variant);
+            int rowHeight = Int(window, "ComboBoxItemHeight", variant);
+            double expected = ((SelectedIndex + 1) * -rowHeight) - (shadow.Bottom + padding.Top);
+
+            Assert.Equal(expected, popup.VerticalOffset);
+        }
+        finally
+        {
+            window.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+
+    /// <summary>
+    ///   The clamp path, which is what <c>PopupTrimHeight</c> drives: with a short
+    ///   MaxDropDownHeight the offset must stop at the popup's usable height instead of shifting
+    ///   the selected row all the way up.
+    /// </summary>
+    [AvaloniaTheory]
+    [InlineData("Light")]
+    [InlineData("Dark")]
+    public void Combo_box_popup_offset_clamps_using_the_resolved_trim(string variantName)
+    {
+        ThemeVariant variant = variantName == "Dark" ? ThemeVariant.Dark : ThemeVariant.Light;
+        Window window = ShowLiquidGlass(variant);
+        const double maxDropDownHeight = 60;
+        var combo = new ComboBox
+        {
+            ItemsSource = Enumerable.Range(1, 40).Select(i => $"Item {i}").ToList(),
+            SelectedIndex = 30,
+            MaxDropDownHeight = maxDropDownHeight,
+        };
+        window.Content = combo;
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            combo.IsDropDownOpen = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            // PopupTrimHeight is meant to be PopupMargin's vertical total; derive it from there.
+            Avalonia.Thickness margin = Thickness(window, "PopupMargin", variant);
+            Assert.Equal(-(maxDropDownHeight - (margin.Top + margin.Bottom)), popup.VerticalOffset);
+        }
+        finally
+        {
+            window.Close();
+            MacOSVersionDetector.SetTestOverride(null);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #643. Started as "our LiquidGlass menus don't look like AppKit's" and grew into unifying every popup surface, because the menus turned out to be the only ones that were nearly right. Every value here is measured from a native macOS 26 popup, then checked against the rendered result — not derived from the tokens, which was wrong twice (see *Insets are a sum*).

## Why the surfaces are opaque rather than blurred

The obvious fix for "sharp content shows through a translucent menu" is a blurred backdrop. It doesn't work, and it's worth recording so nobody re-treads it:

- macOS **does** grant `AcrylicBlur` to popup windows — `ActualTransparencyLevel` really comes back `AcrylicBlur` on a menu's `PopupRoot`. Plain `Blur` resolves to `None`.
- It must be applied imperatively: `Popup` assigns `TransparencyLevelHint` as a *local value*, so `Style Selector="PopupRoot"` is silently ignored.
- The blocker is shape. `NSVisualEffectView` fills the whole window rect and can't be masked, so the transparent shadow margin renders as a pale rectangle with square corners around the rounded menu. Dropping the margin removes the halo but squares the corners instead.
- Avalonia has no backdrop filter — `BlurEffect` blurs an element's own content, not what's behind it (AvaloniaUI/Avalonia#7518, discussion #13993; the Mica backdrop brush issue #10719 is still open).

Rounded *and* blurred needs an upstream Avalonia change. So the surface is opaque, in colours sampled from a native popup over a typical window background — which is what the translucency was approximating.

## What changed

| | before | after | native |
|---|---|---|---|
| surface, light | `#f8f9f9` @0.93 | `#f8f9f9` opaque | `#f7f7f8` |
| surface, dark | `#171717` @0.89 | `#22272a` opaque | `#22272a` |
| menu inset | 6pt, uneven | 4pt all sides | 4pt |
| drop-down inset | 6/6/5/5 (worse elsewhere) | 4pt all sides | — |
| row radius | 4–5pt, three different tokens | 7pt everywhere | ~6pt (see below) |
| hover, dark | `#0c49a9` | `#274fbd` | `#274fbe` |
| selected / keyboard | translucent, two different values | `#d7d9d9` / `#3d4243` | same |

`ComboBox`, `EditableComboBox`, `MultiComboBox` and `AutoCompleteBox` now share the two-layer surface the menus use: an outer border carrying radius, shadow and margin, wrapping an inner bevelled border carrying background and padding. Only `ComboBox` had it before; the rest had a single flat border, so no bevel, a different border brush, and an inset 1pt short on top and left.

`CalendarDatePicker` takes the shared **border and radius only**. Sharing the background was tried and reverted: `Calendar` paints its own, so the surface showed only through the padding and read as a frame around the calendar; making the `Calendar` transparent instead exposed a background behind every day cell. It is a panel of controls, not a list of rows on a surface.

The 7pt row radius is the one value **not** measured: native measures nearer 6pt, but 7pt reads correctly inside our 12pt corner, so it was chosen by eye. The comments mark it as a judgement call with the measured value alongside.

`:selected` and `:focus-visible` are deliberately **not** accented. AppKit greys both so they stay distinguishable from the row under the pointer; accenting them was tried and reverted, because it made a keyboard-focused row indistinguishable from a hovered one. The reasoning sits next to the mapping, since "selected should use the accent" is a reasonable-sounding change to propose.

## One bug, several times

Most substantive bugs here are the same shape — **a variant-dependent value resolved in a scope that cannot see variants**. #643 was the first; this branch found more:

1. **Menu tokens** (#643) — `MergeResourceInclude` made the classic defaults *own entries*, which outrank every merged dictionary, so `GlobalStyles="False"` consumers never saw the LiquidGlass values.
2. **Selection radius** — three `CornerRadius` bindings read `MacOsMenuSelectionCornerRadius` through `StaticResource`. Its classic default is an own entry while the LiquidGlass value arrives through the runtime alias dictionary, so `StaticResource` resolved the wrong one and the radius change was inert until they became `DynamicResource` (measured: a ~3px arc instead of 7).
3. **Dark hover colour** — `MenuItemSelectedBackgroundBrush`/`MenuItemPointerOverBackgroundBrush` sat at the dictionary *root* as `StaticResource`. A root-level `StaticResource` can't see into `ThemeDictionaries`, so both bound the Default (light) `AccentHighlight`: dark menus wore the light accent at the light opacity. `ComboBoxItemPointerOverBackgroundBrush` already declared per-variant, which is why nobody caught it.
4. **The classic selected neutral** — same root-level `StaticResource`; harmless while the key was unused, real once the menu consumed it.

`InitialFirstItemDistance` and `PopupTrimHeight` are a *different* problem and were initially mis-diagnosed as the same one: they were stale, not unreachable. Both live in merged dictionaries where the LiquidGlass copy is merged last, so `StaticResource` resolves them correctly — the missing LiquidGlass override was the whole fix, and the `DynamicResource` they now use is belt-and-braces.

**Still outstanding, deliberately:** several menu tokens are consumed as `<Binding Source="{StaticResource MacOsMenu…}"/>` inside MultiBindings in `Menu.axaml`, including `MacOsMenuItemPadding` and the popup vertical offsets. `Binding.Source` can't take a `DynamicResource`, so it needs restructuring. Toolbar-style menus therefore still use classic padding and offsets.

## Insets are a sum, not a value

The gap between a popup's edge and its first row is composed of two or three tokens, and `PopupInnerBorderThickness` is `1 1 0 0` — a **top/left-only bevel**. So symmetric values cannot produce a symmetric gap:

```
menus       bevel 1 1 0 0 + MenuFlyoutPadding 3 0 4 0 + MenuFlyoutScrollerMargin 0 3 0 4
drop-downs  bevel 1 1 0 0 + PopupPadding      1 3 2 4 + ComboBoxItemMargin       2 0
```

I got this wrong twice — once by missing the bevel asymmetry, once by missing the row margin — and **a test passed through the second one**, because it summed only the tokens I knew about. `MacOsPopupInsetTests` now pins the *composed* gap for both paths.

`PopupPadding` also had two consumers that compose it differently and were being distorted by list-specific tuning — `CalendarDatePicker` wraps a calendar in it raw, and `ListBox` isn't a popup at all. Both now carry their own key, guarded by a test.

## Classic

Almost every token swap resolves to the same value in classic and is a no-op there — `PopupBorderBrush`/`MenuFlyoutPresenterBorderBrush`, `PopupCornerRadius`/`LayoutCornerRadius`, `ComboBoxItemCornerRadius`/`ControlCornerRadius`, the padding key splits, and the hover brush. Three things do change, all reviewed on-device:

1. **AutoCompleteBox is tighter** — its nested `ListBox` no longer adds its own padding on top of the popup's. It was the outlier in classic too.
2. **1px content shift, top and left**, in `EditableComboBox`/`MultiComboBox`/`AutoCompleteBox` from the bevel they gained. `ComboBox` already had it, so this is alignment.
3. **AutoCompleteBox suggestions gain a visible selected/focused state** — the neutral fill, with the generic focus ring suppressed, matching the other drop-downs. Previously the rows had *no* visible selected state in that popup, in either theme, because the checkmark they rely on is hidden there. Pre-existing bug, fixed here.

Not changed in classic: the flat-vs-gradient hover difference between menus and drop-down rows, and the fact that classic's accent-raised gradient is frozen to Avalonia's fallback accent in the light variant (`AccentButtonTopColor` is a `StaticResource` alias, resolved once at load). Both are pre-existing, both reach far beyond these popups, and both are recorded in the theme for the accent-harmonization work.

## Testing

- 219 non-visual tests pass.
- `MacOsPopupInsetTests` (new) pins the composed insets, the `InitialFirstItemDistance` and `PopupTrimHeight` dependencies, that the calendar and plain `ListBox` keep their own padding keys, and that menu and drop-down rows share both the row radius and the selected neutral.
- `MacOsPopupOffsetTests` (new) opens a real ComboBox popup and checks `Popup.VerticalOffset` against expectations derived from the source geometry, so geometry, constant and consumer are covered together rather than a constant being asserted against itself. Teeth-checked at −103/−105 and −27/−30.
- Geometry was verified by **measuring the rendered popup** against its outer border, not by token arithmetic — that is how both the bevel asymmetry and the row-margin term were found.
- The dark hover colour is confirmed two ways: the same Oklch model reproduces the measured *light* value (`#5996f5` computed vs `#5a95f4` measured, within 2/255), and the pack parity test independently demanded the computed pin.
- `MacOsMenuPackContractTests` now pins `SystemAccentColor` to macOS's `#007aff`, so parity measures what ships rather than Avalonia's headless fallback accent — the pack's literals were previously tuned to a colour no user ever sees.
- Menus, all five popups and both selection states confirmed on-device in light and dark, and classic re-checked.

## Not verified

**Visual regression was not run locally** — the baselines fail wholesale on my machine, so it yields no signal. Expect LiquidGlass baseline movement, and note it would be **correct** here: this changes every popup surface and the menu geometry. If CI flags those pages they need regenerating, not investigating.
