### PR TITLE
[Linux] Fix ComboBox popup alignment for large scrolling option sets

### DIFF
--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -57,6 +57,16 @@ public static class ComboBoxPopupAlignmentBehavior
     /// </summary>
     private const double MaxCorrection = 2000;
 
+    /// <summary>
+    /// How many consecutive passes must measure the same misalignment before the popup is treated
+    /// as clamped rather than merely not yet repositioned. Wayland's popup placement is
+    /// asynchronous: the compositor slides the popup to fit the screen after a <c>configure</c>
+    /// round-trip, so the first pass or two after opening can measure the pre-slide position, which
+    /// looks identical to being genuinely stuck against the edge. Requiring more than one repeat
+    /// before concluding "stuck" gives that round-trip a chance to land first.
+    /// </summary>
+    private const int StuckStreakThreshold = 3;
+
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
 
@@ -119,6 +129,11 @@ public static class ComboBoxPopupAlignmentBehavior
         private int pass;
 
         private double previousMisalignment;
+
+        /// <summary>
+        /// Consecutive passes in a row that measured the same misalignment as the one before them.
+        /// </summary>
+        private int stuckStreak;
 
         private bool passScheduled;
 
@@ -213,6 +228,7 @@ public static class ComboBoxPopupAlignmentBehavior
 
             this.pass = 0;
             this.previousMisalignment = double.NaN;
+            this.stuckStreak = 0;
             this.popupRoot = root;
             root.LayoutUpdated += this.OnLayoutUpdated;
             this.SchedulePass();
@@ -245,6 +261,7 @@ public static class ComboBoxPopupAlignmentBehavior
 
             this.pass = 0;
             this.previousMisalignment = double.NaN;
+            this.stuckStreak = 0;
 
             // The popup is not positioned yet at Opened time - measuring here would compare against
             // a stale location. The first layout pass after opening is the earliest useful moment.
@@ -337,15 +354,22 @@ public static class ComboBoxPopupAlignmentBehavior
                 // must not reach the popupIsStuck comparison either, or two identical bad readings
                 // in a row would look like a clamped popup and send TryScroll off to an endpoint.
                 this.previousMisalignment = double.NaN;
+                this.stuckStreak = 0;
                 this.SchedulePass();
                 return;
             }
 
-            // If the previous correction did not move the row, the popup is clamped - by the screen
-            // edge, or because the list is already scrolled to an end. Scrolling is the only lever
-            // left, and if that cannot help either we are as close as this ComboBox can get.
-            bool popupIsStuck = !double.IsNaN(this.previousMisalignment)
-                                && Math.Abs(misalignment - this.previousMisalignment) <= Tolerance;
+            // If several passes in a row measure the same misalignment, the popup is clamped - by
+            // the screen edge, or because the list is already scrolled to an end - and scrolling is
+            // the only lever left. A single repeat is not enough to conclude that: on Wayland, popup
+            // placement is asynchronous, and the compositor can still be about to slide the popup to
+            // its final, constrained position after this measurement. Treating that in-flight state
+            // as "stuck" made the very first opening of a far-down selection settle on the wrong row
+            // - scrolling to cover a gap that a moment later the popup would have closed on its own.
+            bool sameAsLastTime = !double.IsNaN(this.previousMisalignment)
+                                   && Math.Abs(misalignment - this.previousMisalignment) <= Tolerance;
+            this.stuckStreak = sameAsLastTime ? this.stuckStreak + 1 : 0;
+            bool popupIsStuck = this.stuckStreak >= StuckStreakThreshold;
 
             this.previousMisalignment = misalignment;
 

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -83,6 +83,24 @@ public static class ComboBoxPopupAlignmentBehavior
     /// </summary>
     private static readonly TimeSpan StuckConfirmationDelay = TimeSpan.FromMilliseconds(60);
 
+    /// <summary>
+    /// How long after the loop believes it is aligned to take one final look. The popup's real move
+    /// on X11 (including under a Wayland session, via XWayland) completes asynchronously, so the
+    /// reading that ended the loop can have been taken while the popup was still travelling and only
+    /// looked aligned in passing. Layout listeners are dropped as soon as the loop finishes - keeping
+    /// them would make the drop-down fight the user's own scrolling - so this single delayed check is
+    /// what distinguishes "aligned right now" from "settled", without re-reacting to everything else.
+    /// </summary>
+    private static readonly TimeSpan SettleVerificationDelay = TimeSpan.FromMilliseconds(120);
+
+    /// <summary>
+    /// Opt-in tracing, for diagnosing alignment on a real desktop where this loop cannot practically
+    /// be stepped through: set <c>DEVO_COMBOBOX_ALIGN_TRACE=1</c> to print one line per measuring
+    /// pass, recording the measurement, the levers applied and which exit path was taken.
+    /// </summary>
+    private static readonly bool TraceEnabled =
+        Environment.GetEnvironmentVariable("DEVO_COMBOBOX_ALIGN_TRACE") == "1";
+
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
 
@@ -160,6 +178,13 @@ public static class ComboBoxPopupAlignmentBehavior
         /// repositioned. See <see cref="StuckConfirmationDelay"/>.
         /// </summary>
         private long streakStartTicks;
+
+        /// <summary>
+        /// Set once the delayed settle check (see <see cref="SettleVerificationDelay"/>) has been
+        /// used for the current opening, so a popup that genuinely cannot be aligned re-verifies at
+        /// most once rather than rescheduling itself indefinitely.
+        /// </summary>
+        private bool settleVerified;
 
         private bool passScheduled;
 
@@ -255,6 +280,7 @@ public static class ComboBoxPopupAlignmentBehavior
             this.pass = 0;
             this.previousMisalignment = double.NaN;
             this.stuckStreak = 0;
+            this.settleVerified = false;
             this.popupRoot = root;
             root.LayoutUpdated += this.OnLayoutUpdated;
             if (root is WindowBase popupWindow) popupWindow.PositionChanged += this.OnPopupRootPositionChanged;
@@ -289,12 +315,50 @@ public static class ComboBoxPopupAlignmentBehavior
             this.pass = 0;
             this.previousMisalignment = double.NaN;
             this.stuckStreak = 0;
+            this.settleVerified = false;
 
             // The popup is not positioned yet at Opened time - measuring here would compare against
             // a stale location. The first layout pass after opening is the earliest useful moment.
             this.popupRoot = root;
             root.LayoutUpdated += this.OnLayoutUpdated;
             if (root is WindowBase popupWindow) popupWindow.PositionChanged += this.OnPopupRootPositionChanged;
+        }
+
+        /// <summary>
+        /// Takes one last look after <see cref="SettleVerificationDelay"/>, once the popup's
+        /// asynchronous move on X11 has had time to complete, and restarts the loop if the drop-down
+        /// turns out to have settled somewhere other than where the final reading suggested.
+        /// </summary>
+        /// <remarks>
+        /// This deliberately does not keep the layout listeners alive: re-reacting to every layout
+        /// pass makes the drop-down fight the user's own scrolling, which is a far worse bug than the
+        /// residual it would fix. A single delayed check gets the async move without that cost. It is
+        /// also guarded by <see cref="settleVerified"/>, so a drop-down that genuinely cannot be
+        /// aligned - clamped against a screen edge with the list already scrolled to its end - checks
+        /// once and stops, rather than re-arming itself for as long as it stays open.
+        /// </remarks>
+        private void ScheduleSettleVerification()
+        {
+            // Captured after Unsubscribe's bump, so a close/reopen in the meantime still retires it.
+            int scheduledFor = this.generation;
+            DispatcherTimer.RunOnce(
+                () =>
+                {
+                    if (scheduledFor != this.generation || !this.Popup.IsOpen) return;
+
+                    if (this.ResolveSelectedContainer() is not { } container) return;
+                    double misalignment = this.Misalignment(container);
+                    if (Math.Abs(misalignment) <= Tolerance) return;
+
+                    this.Trace($"settle check found {misalignment:F2} - re-aligning");
+                    this.ReArm();
+
+                    // ReArm resets this for the fresh loop it starts - correct when re-arming for a
+                    // genuine external change, but here it would let the settle check re-arm itself
+                    // for as long as the drop-down stayed open. Mark it after the fact instead.
+                    this.settleVerified = true;
+                },
+                SettleVerificationDelay);
         }
 
         private void OnPopupClosed(object? sender, EventArgs e)
@@ -383,10 +447,22 @@ public static class ComboBoxPopupAlignmentBehavior
                 DispatcherPriority.Loaded);
         }
 
+        /// <summary>
+        /// Writes one line of <see cref="TraceEnabled">opt-in</see> diagnostics for the current pass.
+        /// </summary>
+        private void Trace(string message)
+        {
+            if (!TraceEnabled) return;
+
+            Console.WriteLine(
+                $"[combo-align] gen {this.generation} pass {this.pass} sel {this.comboBox.SelectedIndex}: {message}");
+        }
+
         private void RunPass()
         {
             if (!this.Popup.IsOpen || this.pass++ >= MaxPasses)
             {
+                if (this.Popup.IsOpen) this.Trace($"giving up after {MaxPasses} passes");
                 this.Unsubscribe();
                 return;
             }
@@ -396,6 +472,7 @@ public static class ComboBoxPopupAlignmentBehavior
             {
                 // Not realized yet - ResolveSelectedContainer has asked for it, so try again rather
                 // than giving up on a list that is merely still virtualizing.
+                this.Trace("selected container not realized yet");
                 this.SchedulePass();
                 return;
             }
@@ -403,7 +480,16 @@ public static class ComboBoxPopupAlignmentBehavior
             double misalignment = this.Misalignment(container);
             if (Math.Abs(misalignment) <= Tolerance)
             {
+                this.Trace($"aligned ({misalignment:F2})");
                 this.Unsubscribe();
+
+                // Unsubscribe has dropped the layout listeners, so from here nothing would ever
+                // re-measure. That is deliberate - staying subscribed makes the drop-down fight the
+                // user's own scrolling - but it also means a reading taken while the popup was still
+                // travelling would be the last word, leaving a small permanent residual that
+                // reopening reproduces exactly. Take one delayed look to tell the two apart.
+                if (!this.settleVerified) this.ScheduleSettleVerification();
+
                 return;
             }
 
@@ -412,6 +498,7 @@ public static class ComboBoxPopupAlignmentBehavior
                 // Reject the sample outright: it is almost certainly measured mid-reposition. It
                 // must not reach the popupIsStuck comparison either, or two identical bad readings
                 // in a row would look like a clamped popup and send TryScroll off to an endpoint.
+                this.Trace($"rejected outsized sample {misalignment:F2}");
                 this.previousMisalignment = double.NaN;
                 this.stuckStreak = 0;
                 this.SchedulePass();
@@ -452,6 +539,7 @@ public static class ComboBoxPopupAlignmentBehavior
                 // The streak is long enough, but not yet old enough to trust: wait for real time to
                 // pass rather than immediately re-sampling, so a pending ConfigureNotify has a chance
                 // to land and change the reading before another identical sample is taken.
+                this.Trace($"misalign {misalignment:F2}, streak {this.stuckStreak} - awaiting time confirmation");
                 this.pass--; // Waiting for confirmation should not count against MaxPasses.
                 this.ScheduleStuckConfirmation();
                 return;
@@ -459,7 +547,10 @@ public static class ComboBoxPopupAlignmentBehavior
 
             if (popupIsStuck)
             {
-                if (this.TryScroll(misalignment))
+                bool scrolled = this.TryScroll(misalignment);
+                this.Trace($"misalign {misalignment:F2} - popup stuck, scroll {(scrolled ? "applied" : "unavailable")}");
+
+                if (scrolled)
                 {
                     this.SchedulePass();
                 }
@@ -470,6 +561,8 @@ public static class ComboBoxPopupAlignmentBehavior
 
                 return;
             }
+
+            this.Trace($"misalign {misalignment:F2} - moving popup (offset {this.Popup.VerticalOffset:F2} -> {this.Popup.VerticalOffset + misalignment:F2})");
 
             // SetCurrentValue keeps the template's VerticalOffset binding intact.
             this.applyingCorrection = true;

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -93,6 +93,22 @@ public static class ComboBoxPopupAlignmentBehavior
     /// </summary>
     private static readonly TimeSpan SettleVerificationDelay = TimeSpan.FromMilliseconds(120);
 
+    /// <summary>
+    /// Whether the list was scrolled between a settle check being scheduled and it running.
+    /// </summary>
+    /// <remarks>
+    /// A late compositor move repositions the popup without touching the list, so a changed scroll
+    /// offset means the user wheeled it. The settle check must then leave the drop-down alone: the
+    /// row is misaligned because they moved it there, and re-aligning would snap the list back from
+    /// under them. Kept separate from the timer callback so the decision can be tested directly -
+    /// dispatcher timers do not fire under the headless dispatcher, so a test that waited for the
+    /// real callback would pass whether or not this guard existed.
+    /// </remarks>
+    internal static bool UserScrolledSince(double? scrollAtSchedule, double? scrollNow) =>
+        scrollAtSchedule is not null
+        && scrollNow is not null
+        && Math.Abs(scrollNow.Value - scrollAtSchedule.Value) > Tolerance;
+
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
 
@@ -333,10 +349,21 @@ public static class ComboBoxPopupAlignmentBehavior
         {
             // Captured after Unsubscribe's bump, so a close/reopen in the meantime still retires it.
             int scheduledFor = this.generation;
+
+            // A late compositor move repositions the popup without touching the list, so the scroll
+            // offset tells the two apart: if it has changed by the time the check runs, the user
+            // wheeled the list and the row is misaligned because they moved it there. Re-aligning
+            // then would snap the list back from under them - the same scroll-fighting this check's
+            // one-shot design exists to avoid, just inside the delay window.
+            double? scrollAtSchedule = this.ResolveScroller()?.Offset.Y;
+
             DispatcherTimer.RunOnce(
                 () =>
                 {
                     if (scheduledFor != this.generation || !this.Popup.IsOpen) return;
+
+                    double? scrollNow = this.ResolveScroller()?.Offset.Y;
+                    if (UserScrolledSince(scrollAtSchedule, scrollNow)) return;
 
                     if (this.ResolveSelectedContainer() is not { } container) return;
                     double misalignment = this.Misalignment(container);
@@ -570,12 +597,17 @@ public static class ComboBoxPopupAlignmentBehavior
             return container?.IsAttachedToVisualTree() == true && container.Bounds.Height > 0 ? container : null;
         }
 
+        /// <summary>Finds the drop-down's scroller, if its list is scrollable at all.</summary>
+        private ScrollViewer? ResolveScroller() =>
+            this.Popup.Child is { } child
+                ? child.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault()
+                : null;
+
         /// <summary>Scrolls the list to take up misalignment the popup itself could not.</summary>
         /// <returns><c>true</c> if the list moved, so another measuring pass is worthwhile.</returns>
         private bool TryScroll(double misalignment)
         {
-            if (this.Popup.Child is not { } child) return false;
-            if (child.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault() is not { } scroller) return false;
+            if (this.ResolveScroller() is not { } scroller) return false;
 
             double scrollable = Math.Max(0, scroller.Extent.Height - scroller.Viewport.Height);
             if (scrollable <= 0) return false;

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -59,13 +59,14 @@ public static class ComboBoxPopupAlignmentBehavior
 
     /// <summary>
     /// How many consecutive passes must measure the same misalignment before the popup is treated
-    /// as clamped rather than merely not yet repositioned. Wayland's popup placement is
-    /// asynchronous: the compositor slides the popup to fit the screen after a <c>configure</c>
-    /// round-trip, so the first pass or two after opening can measure the pre-slide position, which
-    /// looks identical to being genuinely stuck against the edge. Requiring more than one repeat
-    /// before concluding "stuck" gives that round-trip a chance to land first.
+    /// as clamped rather than merely not yet repositioned. <see cref="Aligner.Misalignment"/> is
+    /// computed entirely from local layout (this behavior's own <c>VerticalOffset</c> and the
+    /// container's position within the popup's own content), not from any round-trip through the
+    /// platform's screen coordinates, so it does not suffer the async-positioning staleness that a
+    /// screen-coordinate measurement would on a compositor like Wayland's. A single repeat is
+    /// therefore already a reliable signal.
     /// </summary>
-    private const int StuckStreakThreshold = 3;
+    private const int StuckStreakThreshold = 1;
 
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
@@ -436,24 +437,60 @@ public static class ComboBoxPopupAlignmentBehavior
         }
 
         /// <summary>
-        /// How far the selected row must move down the screen to sit on the closed ComboBox, in the
-        /// popup's own units. Centres are compared rather than top edges, so row and ComboBox do not
-        /// have to share padding or height to look aligned.
+        /// How much <see cref="Popup.VerticalOffset"/> must change for the selected row to sit on
+        /// the closed ComboBox. Centres are compared rather than top edges, so row and ComboBox do
+        /// not have to share padding or height to look aligned.
         /// </summary>
+        /// <remarks>
+        /// This deliberately never calls <c>PointToScreen</c>/<c>PointToClient</c>. Those round-trip
+        /// through the platform's absolute screen coordinates, and on Wayland a client cannot obtain
+        /// its own window's screen position at all - <c>Position</c> is always <c>(0, 0)</c> and both
+        /// conversions are simple identity passthroughs. Comparing "screen" points for the ComboBox's
+        /// top level and the popup's top level therefore compared two unrelated coordinate systems:
+        /// not a stale reading that a later pass would correct, but a wrong answer every time, which
+        /// is why the popup could end up anywhere - a row off, or off the bottom of the screen.
+        /// <para>
+        /// The fix is to never need screen coordinates. The ComboBox and the selected row's
+        /// container both sit somewhere in the popup's own visual tree (the ComboBox as the popup's
+        /// placement target, the row inside its content), so <see cref="Visual.TranslatePoint"/> can
+        /// express both of their centres in that one shared frame without ever leaving it. The
+        /// difference between the two is exactly how far <see cref="Popup.VerticalOffset"/> is off:
+        /// the row's own position within the popup's frame is fixed regardless of the offset, while
+        /// the popup's frame - and so the ComboBox's apparent position within it - moves by whatever
+        /// the offset changes by. This also sidesteps the template's per-theme chrome around
+        /// <c>Popup.Child</c> (shadow margin, border): translating straight into the popup's root
+        /// means neither centre passes through that Border at all, so its size cannot leave a
+        /// constant residual error the correction pass could never close.
+        /// </para>
+        /// </remarks>
         private double Misalignment(Control container)
         {
             if (!this.comboBox.IsAttachedToVisualTree() || !container.IsAttachedToVisualTree()) return 0;
-            if ((TopLevel.GetTopLevel(container) ?? TopLevel.GetTopLevel(this.comboBox)) is not { } popupRoot) return 0;
+            if (TopLevel.GetTopLevel(container) is not { } popupRoot) return 0;
 
-            PixelPoint comboBoxCentre = this.comboBox.PointToScreen(new Point(0, this.comboBox.Bounds.Height / 2));
-            PixelPoint containerCentre = container.PointToScreen(new Point(0, container.Bounds.Height / 2));
+            // Translate both centres into the popup's own root - not just the row's, and not into
+            // Popup.Child (whose origin sits behind the template's shadow-margin Border, an offset
+            // that varies per theme). Comparing two points expressed in the same frame is exact by
+            // construction, so it does not depend on the anchor/gravity placement contract matching
+            // the template's border/margin arithmetic precisely - which is what a few pixels of
+            // theme-specific chrome around Popup.Child broke.
+            Point? containerCentreInPopup =
+                container.TranslatePoint(new Point(0, container.Bounds.Height / 2), popupRoot);
+            Point? comboBoxCentreInPopup =
+                this.comboBox.TranslatePoint(new Point(0, this.comboBox.Bounds.Height / 2), popupRoot);
+            if (containerCentreInPopup is not { } containerCentre
+                || comboBoxCentreInPopup is not { } comboBoxCentre)
+            {
+                return 0;
+            }
 
-            // Convert both screen points back through the popup's own top level rather than dividing
-            // by a scale factor. The relationship between screen coordinates and logical units is a
-            // platform detail - on macOS PointToScreen yields Cocoa points (DesktopScaling is 1)
-            // while RenderScaling is the backing scale, so dividing by RenderScaling would halve
-            // every correction and the pass loop could run out before aligning.
-            return popupRoot.PointToClient(comboBoxCentre).Y - popupRoot.PointToClient(containerCentre).Y;
+            // The row is inside the popup, so its position within the popup's own frame does not
+            // move when VerticalOffset changes - only the popup's frame itself moves relative to the
+            // (stationary) ComboBox. Increasing VerticalOffset by some amount moves the popup down by
+            // that amount, which decreases the ComboBox's own coordinate within the popup's frame by
+            // the same amount. So the offset that brings the two centres together is exactly their
+            // current difference.
+            return comboBoxCentre.Y - containerCentre.Y;
         }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -59,14 +59,17 @@ public static class ComboBoxPopupAlignmentBehavior
 
     /// <summary>
     /// How many consecutive passes must measure the same misalignment before the popup is treated
-    /// as clamped rather than merely not yet repositioned. <see cref="Aligner.Misalignment"/> is
-    /// computed entirely from local layout (this behavior's own <c>VerticalOffset</c> and the
-    /// container's position within the popup's own content), not from any round-trip through the
-    /// platform's screen coordinates, so it does not suffer the async-positioning staleness that a
-    /// screen-coordinate measurement would on a compositor like Wayland's. A single repeat is
-    /// therefore already a reliable signal.
+    /// as clamped rather than merely not yet repositioned. <see cref="Aligner.Misalignment"/> uses
+    /// <c>PointToScreen</c>/<c>PointToClient</c>, which round-trip through the platform's window
+    /// position - and on Linux (X11, including under a Wayland session via XWayland) that position
+    /// is only updated when a <c>ConfigureNotify</c> event lands, asynchronously after the popup is
+    /// requested to move. The first pass or two after opening or repositioning can therefore measure
+    /// a stale, pre-move position that looks identical to being genuinely stuck against the screen
+    /// edge. Requiring more than one repeat before concluding "stuck" gives that round-trip a chance
+    /// to land first - see the macOS behavior's history for why one repeat was not enough there
+    /// either.
     /// </summary>
-    private const int StuckStreakThreshold = 1;
+    private const int StuckStreakThreshold = 3;
 
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
@@ -442,55 +445,45 @@ public static class ComboBoxPopupAlignmentBehavior
         /// not have to share padding or height to look aligned.
         /// </summary>
         /// <remarks>
-        /// This deliberately never calls <c>PointToScreen</c>/<c>PointToClient</c>. Those round-trip
-        /// through the platform's absolute screen coordinates, and on Wayland a client cannot obtain
-        /// its own window's screen position at all - <c>Position</c> is always <c>(0, 0)</c> and both
-        /// conversions are simple identity passthroughs. Comparing "screen" points for the ComboBox's
-        /// top level and the popup's top level therefore compared two unrelated coordinate systems:
-        /// not a stale reading that a later pass would correct, but a wrong answer every time, which
-        /// is why the popup could end up anywhere - a row off, or off the bottom of the screen.
+        /// A previous version of this method tried to avoid <c>PointToScreen</c>/<c>PointToClient</c>
+        /// entirely, using <see cref="Visual.TranslatePoint"/> to express both centres in the popup's
+        /// own root instead. That was based on a mistaken premise: it assumed the ComboBox's popup
+        /// renders as a native platform window entirely disconnected from the main window's visual
+        /// tree, so that <c>PointToScreen</c>/<c>PointToClient</c> would not be meaningful across the
+        /// two. On Linux, though, there is no separate Wayland backend in Avalonia at all - even
+        /// under a Wayland session the app runs through <c>Avalonia.X11</c> (via XWayland), whose
+        /// <c>Position</c>/<c>PointToScreen</c>/<c>PointToClient</c> are not identity passthroughs:
+        /// they track the window's real position, kept current via <c>ConfigureNotify</c> events.
         /// <para>
-        /// The fix is to never need screen coordinates. The ComboBox and the selected row's
-        /// container both sit somewhere in the popup's own visual tree (the ComboBox as the popup's
-        /// placement target, the row inside its content), so <see cref="Visual.TranslatePoint"/> can
-        /// express both of their centres in that one shared frame without ever leaving it. The
-        /// difference between the two is exactly how far <see cref="Popup.VerticalOffset"/> is off:
-        /// the row's own position within the popup's frame is fixed regardless of the offset, while
-        /// the popup's frame - and so the ComboBox's apparent position within it - moves by whatever
-        /// the offset changes by. This also sidesteps the template's per-theme chrome around
-        /// <c>Popup.Child</c> (shadow margin, border): translating straight into the popup's root
-        /// means neither centre passes through that Border at all, so its size cannot leave a
-        /// constant residual error the correction pass could never close.
+        /// <see cref="Visual.TranslatePoint"/> requires the two visuals to share a common ancestor
+        /// reachable by walking <c>VisualParent</c> pointers. The popup's root and the ComboBox's own
+        /// window are two separate native windows: the popup only keeps a *logical* parent link back
+        /// to the ComboBox's top level (used for focus routing), not a visual-tree one. So
+        /// <c>TranslatePoint</c> silently returned <c>null</c> for every corner case where the popup
+        /// was not merely an overlay layer on top of the same window - which is exactly what happens
+        /// in the headless test host (its popups default to an overlay layer sharing one visual tree
+        /// with the main window), but not in a real windowed app. That made every measurement return
+        /// <c>0</c>, i.e. no correction, on the genuine article - matching what was reported: the
+        /// error was never corrected even on reopening.
+        /// </para>
+        /// <para>
+        /// The fix is to go back to <c>PointToScreen</c>/<c>PointToClient</c>, the same approach the
+        /// macOS behavior uses, converting both screen points back through the popup's own top level
+        /// rather than dividing by a scale factor - see the macOS implementation's remarks for why.
         /// </para>
         /// </remarks>
         private double Misalignment(Control container)
         {
             if (!this.comboBox.IsAttachedToVisualTree() || !container.IsAttachedToVisualTree()) return 0;
-            if (TopLevel.GetTopLevel(container) is not { } popupRoot) return 0;
-
-            // Translate both centres into the popup's own root - not just the row's, and not into
-            // Popup.Child (whose origin sits behind the template's shadow-margin Border, an offset
-            // that varies per theme). Comparing two points expressed in the same frame is exact by
-            // construction, so it does not depend on the anchor/gravity placement contract matching
-            // the template's border/margin arithmetic precisely - which is what a few pixels of
-            // theme-specific chrome around Popup.Child broke.
-            Point? containerCentreInPopup =
-                container.TranslatePoint(new Point(0, container.Bounds.Height / 2), popupRoot);
-            Point? comboBoxCentreInPopup =
-                this.comboBox.TranslatePoint(new Point(0, this.comboBox.Bounds.Height / 2), popupRoot);
-            if (containerCentreInPopup is not { } containerCentre
-                || comboBoxCentreInPopup is not { } comboBoxCentre)
+            if ((TopLevel.GetTopLevel(container) ?? TopLevel.GetTopLevel(this.comboBox)) is not { } popupRoot)
             {
                 return 0;
             }
 
-            // The row is inside the popup, so its position within the popup's own frame does not
-            // move when VerticalOffset changes - only the popup's frame itself moves relative to the
-            // (stationary) ComboBox. Increasing VerticalOffset by some amount moves the popup down by
-            // that amount, which decreases the ComboBox's own coordinate within the popup's frame by
-            // the same amount. So the offset that brings the two centres together is exactly their
-            // current difference.
-            return comboBoxCentre.Y - containerCentre.Y;
+            PixelPoint comboBoxCentre = this.comboBox.PointToScreen(new Point(0, this.comboBox.Bounds.Height / 2));
+            PixelPoint containerCentre = container.PointToScreen(new Point(0, container.Bounds.Height / 2));
+
+            return popupRoot.PointToClient(comboBoxCentre).Y - popupRoot.PointToClient(containerCentre).Y;
         }
     }
 }

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -1,5 +1,6 @@
 namespace Devolutions.AvaloniaControls.Behaviors;
 
+using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -58,18 +59,29 @@ public static class ComboBoxPopupAlignmentBehavior
     private const double MaxCorrection = 2000;
 
     /// <summary>
-    /// How many consecutive passes must measure the same misalignment before the popup is treated
-    /// as clamped rather than merely not yet repositioned. <see cref="Aligner.Misalignment"/> uses
-    /// <c>PointToScreen</c>/<c>PointToClient</c>, which round-trip through the platform's window
-    /// position - and on Linux (X11, including under a Wayland session via XWayland) that position
-    /// is only updated when a <c>ConfigureNotify</c> event lands, asynchronously after the popup is
-    /// requested to move. The first pass or two after opening or repositioning can therefore measure
-    /// a stale, pre-move position that looks identical to being genuinely stuck against the screen
-    /// edge. Requiring more than one repeat before concluding "stuck" gives that round-trip a chance
-    /// to land first - see the macOS behavior's history for why one repeat was not enough there
-    /// either.
+    /// How many consecutive, time-spaced confirmations must measure the same misalignment before
+    /// the popup is treated as clamped rather than merely not yet repositioned. <see
+    /// cref="Aligner.Misalignment"/> uses <c>PointToScreen</c>/<c>PointToClient</c>, which round-trip
+    /// through the platform's window position - and on Linux (X11, including under a Wayland session
+    /// via XWayland) that position is only updated when a <c>ConfigureNotify</c> event lands,
+    /// asynchronously after the popup is requested to move. Counting consecutive *dispatcher* passes
+    /// is not enough of a gate on its own: a pass posted at <see cref="DispatcherPriority.Loaded"/>
+    /// runs again within a fraction of a millisecond, far faster than a round-trip through the X
+    /// server, so several such passes can measure the same stale, pre-move position and satisfy the
+    /// streak before <c>ConfigureNotify</c> ever lands - misreading "not moved yet" as "clamped" and
+    /// sending <see cref="Aligner.TryScroll"/> off against a reading that was never real. Requiring
+    /// the repeats to additionally be spaced by <see cref="StuckConfirmationDelay"/> of genuine wall
+    /// clock time (see <see cref="Aligner.ScheduleStuckConfirmation"/>) gives that round-trip a
+    /// chance to land and change the reading before it is trusted.
     /// </summary>
     private const int StuckStreakThreshold = 3;
+
+    /// <summary>
+    /// Real time to wait before re-measuring a misalignment that already looked unchanged, so a
+    /// pending <c>ConfigureNotify</c> (see <see cref="StuckStreakThreshold"/>) has a chance to land
+    /// and move the reading before another identical sample is allowed to count towards the streak.
+    /// </summary>
+    private static readonly TimeSpan StuckConfirmationDelay = TimeSpan.FromMilliseconds(60);
 
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
@@ -138,6 +150,16 @@ public static class ComboBoxPopupAlignmentBehavior
         /// Consecutive passes in a row that measured the same misalignment as the one before them.
         /// </summary>
         private int stuckStreak;
+
+        /// <summary>
+        /// <see cref="Environment.TickCount64"/> when the current <see cref="stuckStreak"/> began,
+        /// i.e. when <see cref="previousMisalignment"/> was first measured. Dispatcher passes at
+        /// <see cref="DispatcherPriority.Loaded"/> can repeat within a fraction of a millisecond, far
+        /// faster than the real, asynchronous window-move round-trip on X11 - so the streak alone is
+        /// not trustworthy evidence that the popup is genuinely stuck rather than merely not yet
+        /// repositioned. See <see cref="StuckConfirmationDelay"/>.
+        /// </summary>
+        private long streakStartTicks;
 
         private bool passScheduled;
 
@@ -314,6 +336,25 @@ public static class ComboBoxPopupAlignmentBehavior
         private void OnPopupRootPositionChanged(object? sender, PixelPointEventArgs e) => this.RunPass();
 
         /// <summary>
+        /// Re-measures after real time has passed, rather than after the next dispatcher tick, so a
+        /// pending <c>ConfigureNotify</c> gets a genuine chance to land first. <see
+        /// cref="SchedulePass"/> alone is not a substitute: it can fire again within a fraction of a
+        /// millisecond, which is what let a stuck streak build up entirely from stale, pre-move
+        /// readings (see <see cref="StuckStreakThreshold"/>).
+        /// </summary>
+        private void ScheduleStuckConfirmation()
+        {
+            int scheduledFor = this.generation;
+            DispatcherTimer.RunOnce(
+                () =>
+                {
+                    if (scheduledFor != this.generation) return;
+                    this.RunPass();
+                },
+                StuckConfirmationDelay);
+        }
+
+        /// <summary>
         /// Schedules another measuring pass under our own steam. Relying on
         /// <see cref="Layoutable.LayoutUpdated" /> alone is not enough: a pass can end with nothing
         /// laid out afterwards (a virtualized row that is not realized yet, or a correction the
@@ -379,17 +420,42 @@ public static class ComboBoxPopupAlignmentBehavior
 
             // If several passes in a row measure the same misalignment, the popup is clamped - by
             // the screen edge, or because the list is already scrolled to an end - and scrolling is
-            // the only lever left. A single repeat is not enough to conclude that: on Wayland, popup
-            // placement is asynchronous, and the compositor can still be about to slide the popup to
-            // its final, constrained position after this measurement. Treating that in-flight state
-            // as "stuck" made the very first opening of a far-down selection settle on the wrong row
-            // - scrolling to cover a gap that a moment later the popup would have closed on its own.
+            // the only lever left. A single repeat is not enough to conclude that, and neither is
+            // merely counting dispatcher passes: on X11 (including under a Wayland session via
+            // XWayland), the popup's real move lands asynchronously via ConfigureNotify, which can
+            // take longer than several Loaded-priority dispatcher passes fired back to back. Without
+            // also requiring StuckConfirmationDelay of genuine wall-clock time to have passed, this
+            // streak could be satisfied entirely from stale, pre-move readings - misreading "hasn't
+            // moved yet" as "clamped" and sending TryScroll off against a position that was never
+            // final. Treating an in-flight move as "stuck" made the very first opening of a far-down
+            // selection settle on the wrong row - scrolling to cover a gap that a moment later the
+            // popup would have closed on its own.
             bool sameAsLastTime = !double.IsNaN(this.previousMisalignment)
                                    && Math.Abs(misalignment - this.previousMisalignment) <= Tolerance;
-            this.stuckStreak = sameAsLastTime ? this.stuckStreak + 1 : 0;
-            bool popupIsStuck = this.stuckStreak >= StuckStreakThreshold;
+            if (sameAsLastTime)
+            {
+                this.stuckStreak++;
+            }
+            else
+            {
+                this.stuckStreak = 1;
+                this.streakStartTicks = Environment.TickCount64;
+            }
+
+            bool popupIsStuck = this.stuckStreak >= StuckStreakThreshold
+                                 && Environment.TickCount64 - this.streakStartTicks >= StuckConfirmationDelay.TotalMilliseconds;
 
             this.previousMisalignment = misalignment;
+
+            if (this.stuckStreak >= StuckStreakThreshold && !popupIsStuck)
+            {
+                // The streak is long enough, but not yet old enough to trust: wait for real time to
+                // pass rather than immediately re-sampling, so a pending ConfigureNotify has a chance
+                // to land and change the reading before another identical sample is taken.
+                this.pass--; // Waiting for confirmation should not count against MaxPasses.
+                this.ScheduleStuckConfirmation();
+                return;
+            }
 
             if (popupIsStuck)
             {

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -93,14 +93,6 @@ public static class ComboBoxPopupAlignmentBehavior
     /// </summary>
     private static readonly TimeSpan SettleVerificationDelay = TimeSpan.FromMilliseconds(120);
 
-    /// <summary>
-    /// Opt-in tracing, for diagnosing alignment on a real desktop where this loop cannot practically
-    /// be stepped through: set <c>DEVO_COMBOBOX_ALIGN_TRACE=1</c> to print one line per measuring
-    /// pass, recording the measurement, the levers applied and which exit path was taken.
-    /// </summary>
-    private static readonly bool TraceEnabled =
-        Environment.GetEnvironmentVariable("DEVO_COMBOBOX_ALIGN_TRACE") == "1";
-
     public static readonly AttachedProperty<bool> EnableProperty =
         AvaloniaProperty.RegisterAttached<ComboBox, bool>("Enable", typeof(ComboBoxPopupAlignmentBehavior));
 
@@ -350,7 +342,6 @@ public static class ComboBoxPopupAlignmentBehavior
                     double misalignment = this.Misalignment(container);
                     if (Math.Abs(misalignment) <= Tolerance) return;
 
-                    this.Trace($"settle check found {misalignment:F2} - re-aligning");
                     this.ReArm();
 
                     // ReArm resets this for the fresh loop it starts - correct when re-arming for a
@@ -447,22 +438,10 @@ public static class ComboBoxPopupAlignmentBehavior
                 DispatcherPriority.Loaded);
         }
 
-        /// <summary>
-        /// Writes one line of <see cref="TraceEnabled">opt-in</see> diagnostics for the current pass.
-        /// </summary>
-        private void Trace(string message)
-        {
-            if (!TraceEnabled) return;
-
-            Console.WriteLine(
-                $"[combo-align] gen {this.generation} pass {this.pass} sel {this.comboBox.SelectedIndex}: {message}");
-        }
-
         private void RunPass()
         {
             if (!this.Popup.IsOpen || this.pass++ >= MaxPasses)
             {
-                if (this.Popup.IsOpen) this.Trace($"giving up after {MaxPasses} passes");
                 this.Unsubscribe();
                 return;
             }
@@ -472,7 +451,6 @@ public static class ComboBoxPopupAlignmentBehavior
             {
                 // Not realized yet - ResolveSelectedContainer has asked for it, so try again rather
                 // than giving up on a list that is merely still virtualizing.
-                this.Trace("selected container not realized yet");
                 this.SchedulePass();
                 return;
             }
@@ -480,7 +458,6 @@ public static class ComboBoxPopupAlignmentBehavior
             double misalignment = this.Misalignment(container);
             if (Math.Abs(misalignment) <= Tolerance)
             {
-                this.Trace($"aligned ({misalignment:F2})");
                 this.Unsubscribe();
 
                 // Unsubscribe has dropped the layout listeners, so from here nothing would ever
@@ -498,7 +475,6 @@ public static class ComboBoxPopupAlignmentBehavior
                 // Reject the sample outright: it is almost certainly measured mid-reposition. It
                 // must not reach the popupIsStuck comparison either, or two identical bad readings
                 // in a row would look like a clamped popup and send TryScroll off to an endpoint.
-                this.Trace($"rejected outsized sample {misalignment:F2}");
                 this.previousMisalignment = double.NaN;
                 this.stuckStreak = 0;
                 this.SchedulePass();
@@ -507,16 +483,15 @@ public static class ComboBoxPopupAlignmentBehavior
 
             // If several passes in a row measure the same misalignment, the popup is clamped - by
             // the screen edge, or because the list is already scrolled to an end - and scrolling is
-            // the only lever left. A single repeat is not enough to conclude that, and neither is
-            // merely counting dispatcher passes: on X11 (including under a Wayland session via
-            // XWayland), the popup's real move lands asynchronously via ConfigureNotify, which can
-            // take longer than several Loaded-priority dispatcher passes fired back to back. Without
-            // also requiring StuckConfirmationDelay of genuine wall-clock time to have passed, this
-            // streak could be satisfied entirely from stale, pre-move readings - misreading "hasn't
-            // moved yet" as "clamped" and sending TryScroll off against a position that was never
-            // final. Treating an in-flight move as "stuck" made the very first opening of a far-down
-            // selection settle on the wrong row - scrolling to cover a gap that a moment later the
-            // popup would have closed on its own.
+            // the only lever left. Counting dispatcher passes is not enough to conclude that: on X11
+            // (including under a Wayland session via XWayland), the popup's real move lands
+            // asynchronously via ConfigureNotify, which can take longer than several Loaded-priority
+            // dispatcher passes fired back to back. Without also requiring StuckConfirmationDelay of
+            // genuine wall-clock time to have passed, this streak could be satisfied entirely from
+            // stale, pre-move readings - misreading "hasn't moved yet" as "clamped" and sending
+            // TryScroll off against a position that was never final. Treating an in-flight move as
+            // "stuck" made the very first opening of a far-down selection settle on the wrong row -
+            // scrolling to cover a gap that a moment later the popup would have closed on its own.
             bool sameAsLastTime = !double.IsNaN(this.previousMisalignment)
                                    && Math.Abs(misalignment - this.previousMisalignment) <= Tolerance;
             if (sameAsLastTime)
@@ -543,7 +518,6 @@ public static class ComboBoxPopupAlignmentBehavior
                 // sign, and the loop oscillates until it runs out of passes. Wait for real time to
                 // pass instead, so a pending ConfigureNotify can land and change the reading. Only an
                 // unchanged reading that survives that wait means the popup is genuinely clamped.
-                this.Trace($"misalign {misalignment:F2}, streak {this.stuckStreak} - awaiting time confirmation");
                 this.pass--; // Waiting for confirmation should not count against MaxPasses.
                 this.ScheduleStuckConfirmation();
                 return;
@@ -552,7 +526,6 @@ public static class ComboBoxPopupAlignmentBehavior
             if (popupIsStuck)
             {
                 bool scrolled = this.TryScroll(misalignment);
-                this.Trace($"misalign {misalignment:F2} - popup stuck, scroll {(scrolled ? "applied" : "unavailable")}");
 
                 if (scrolled)
                 {
@@ -566,7 +539,6 @@ public static class ComboBoxPopupAlignmentBehavior
                 return;
             }
 
-            this.Trace($"misalign {misalignment:F2} - moving popup (offset {this.Popup.VerticalOffset:F2} -> {this.Popup.VerticalOffset + misalignment:F2})");
 
             // SetCurrentValue keeps the template's VerticalOffset binding intact.
             this.applyingCorrection = true;

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -534,11 +534,15 @@ public static class ComboBoxPopupAlignmentBehavior
 
             this.previousMisalignment = misalignment;
 
-            if (this.stuckStreak >= StuckStreakThreshold && !popupIsStuck)
+            if (sameAsLastTime && !popupIsStuck)
             {
-                // The streak is long enough, but not yet old enough to trust: wait for real time to
-                // pass rather than immediately re-sampling, so a pending ConfigureNotify has a chance
-                // to land and change the reading before another identical sample is taken.
+                // The reading has not changed since the last pass, so it cannot yet reflect the
+                // correction we already applied - the popup's move lands asynchronously. Acting on it
+                // again would apply the same correction twice, overshooting to roughly double what was
+                // needed; the misalignment then comes back with the same magnitude and the opposite
+                // sign, and the loop oscillates until it runs out of passes. Wait for real time to
+                // pass instead, so a pending ConfigureNotify can land and change the reading. Only an
+                // unchanged reading that survives that wait means the popup is genuinely clamped.
                 this.Trace($"misalign {misalignment:F2}, streak {this.stuckStreak} - awaiting time confirmation");
                 this.pass--; // Waiting for confirmation should not count against MaxPasses.
                 this.ScheduleStuckConfirmation();

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -197,6 +197,12 @@ public static class ComboBoxPopupAlignmentBehavior
         private bool passScheduled;
 
         /// <summary>
+        /// Coalesces stuck-confirmation timers, so several re-entries into <see cref="RunPass"/>
+        /// within the delay cannot each queue one and then all apply the same scroll correction.
+        /// </summary>
+        private bool stuckConfirmationScheduled;
+
+        /// <summary>
         /// Identifies one opening of the popup, so a pass queued for a previous opening can tell
         /// that it is stale and do nothing.
         /// </summary>
@@ -396,6 +402,7 @@ public static class ComboBoxPopupAlignmentBehavior
             // Retire any queued pass, whether or not we are currently subscribed.
             this.generation++;
             this.passScheduled = false;
+            this.stuckConfirmationScheduled = false;
 
             if (this.popupRoot is null) return;
 
@@ -426,11 +433,21 @@ public static class ComboBoxPopupAlignmentBehavior
         /// </summary>
         private void ScheduleStuckConfirmation()
         {
+            // Coalesced like SchedulePass: LayoutUpdated and PositionChanged can both re-enter
+            // RunPass before the delay elapses, and without this each entry would queue its own
+            // timer against the same generation. They would all fire, and any that ran after the
+            // first one concluded the popup was stuck would apply TryScroll again on top of a
+            // correction the next measuring pass had not observed yet - overshooting the row.
+            if (this.stuckConfirmationScheduled) return;
+
+            this.stuckConfirmationScheduled = true;
             int scheduledFor = this.generation;
             DispatcherTimer.RunOnce(
                 () =>
                 {
                     if (scheduledFor != this.generation) return;
+
+                    this.stuckConfirmationScheduled = false;
                     this.RunPass();
                 },
                 StuckConfirmationDelay);

--- a/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
+++ b/src/Devolutions.AvaloniaControls/Behaviors/ComboBoxPopupAlignmentBehavior.cs
@@ -235,6 +235,7 @@ public static class ComboBoxPopupAlignmentBehavior
             this.stuckStreak = 0;
             this.popupRoot = root;
             root.LayoutUpdated += this.OnLayoutUpdated;
+            if (root is WindowBase popupWindow) popupWindow.PositionChanged += this.OnPopupRootPositionChanged;
             this.SchedulePass();
         }
 
@@ -271,6 +272,7 @@ public static class ComboBoxPopupAlignmentBehavior
             // a stale location. The first layout pass after opening is the earliest useful moment.
             this.popupRoot = root;
             root.LayoutUpdated += this.OnLayoutUpdated;
+            if (root is WindowBase popupWindow) popupWindow.PositionChanged += this.OnPopupRootPositionChanged;
         }
 
         private void OnPopupClosed(object? sender, EventArgs e)
@@ -294,10 +296,22 @@ public static class ComboBoxPopupAlignmentBehavior
             if (this.popupRoot is null) return;
 
             this.popupRoot.LayoutUpdated -= this.OnLayoutUpdated;
+            if (this.popupRoot is WindowBase popupWindow) popupWindow.PositionChanged -= this.OnPopupRootPositionChanged;
             this.popupRoot = null;
         }
 
         private void OnLayoutUpdated(object? sender, EventArgs e) => this.RunPass();
+
+        /// <summary>
+        /// The popup's real on-screen position on X11 (including under a Wayland session, via
+        /// XWayland) only becomes known asynchronously - the compositor answers a move request with
+        /// a <c>ConfigureNotify</c> that can land after this behavior's own layout-driven passes have
+        /// already measured and corrected against a stale position. Reacting to
+        /// <see cref="WindowBase.PositionChanged"/> directly, rather than waiting for the next
+        /// unrelated layout pass or the dispatcher-post retry to notice, is what makes the popup
+        /// settle promptly instead of visibly jumping once the mouse happens to trigger layout.
+        /// </summary>
+        private void OnPopupRootPositionChanged(object? sender, PixelPointEventArgs e) => this.RunPass();
 
         /// <summary>
         /// Schedules another measuring pass under our own steam. Relying on

--- a/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
+++ b/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
@@ -25,7 +25,8 @@
         </PackageReleaseNotes>
     </PropertyGroup>
 
-    <ItemGroup>
+    <!-- Debug-only: lets the tests reach internals, without shipping the attribute in the package. -->
+    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
         <InternalsVisibleTo Include="Devolutions.AvaloniaControls.VisualTests" />
     </ItemGroup>
 

--- a/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
+++ b/src/Devolutions.AvaloniaControls/Devolutions.AvaloniaControls.csproj
@@ -26,6 +26,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Devolutions.AvaloniaControls.VisualTests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 

--- a/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBox.axaml
+++ b/src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBox.axaml
@@ -1,7 +1,8 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:design="clr-namespace:Devolutions.AvaloniaTheme.Linux.Design"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:attachedProperties="clr-namespace:Devolutions.AvaloniaControls.AttachedProperties;assembly=Devolutions.AvaloniaControls">
 
   <!-- 
     Un-comment to allow auto-completion;
@@ -128,6 +129,9 @@
     <Setter Property="FocusAdorner" Value="{x:Null}" />
     <Setter Property="ClipToBounds" Value="False" />
     <Setter Property="ComboBoxValidationBehavior.Enable" Value="True" />
+    <!-- Corrects the VerticalOffset estimate below against the popup's real layout, so the selected
+         row still lands on the ComboBox once the option list is long enough to scroll. -->
+    <Setter Property="ComboBoxPopupAlignmentBehavior.Enable" Value="True" />
     <Setter Property="Template">
       <ControlTemplate>
         <DataValidationErrors>
@@ -231,6 +235,16 @@
                     BorderThickness="{StaticResource FocusBorderThickness}"
                     BorderBrush="{WindowActiveResourceToggler InputFocusedBorder, InputFocusedInactiveBorder}"
                     CornerRadius="{TemplateBinding CornerRadius}" />
+            <!--
+              PlacementConstraintAdjustment: the default (All) includes FlipY, which is wrong for
+              this drop-down. FlipY exists for menus, where a submenu that doesn't fit below should
+              open above instead. Here the popup is deliberately offset *upwards* so the selected
+              row lands on the ComboBox, so near the bottom of the screen the compositor flips it as
+              well - moving it a further popup-height up and leaving it floating well above the
+              control. Sliding is the correct adjustment: it keeps the popup on screen without
+              changing which side of the anchor it is on, which is what the alignment behaviour then
+              measures against.
+            -->
             <Popup
               Name="PART_Popup"
               MaxHeight="{TemplateBinding MaxDropDownHeight}"
@@ -240,6 +254,7 @@
               Placement="AnchorAndGravity"
               PlacementAnchor="BottomLeft"
               PlacementGravity="BottomRight"
+              PlacementConstraintAdjustment="SlideX, SlideY, ResizeX, ResizeY"
               HorizontalOffset="-1">
               <Popup.MinWidth>
                 <MultiBinding Converter="{x:Static DevoMultiConverters.TotalWidthConverter}">

--- a/tests/Devolutions.AvaloniaControls.VisualTests/LinuxComboBoxPopupAlignmentTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/LinuxComboBoxPopupAlignmentTests.cs
@@ -295,4 +295,57 @@ public class LinuxComboBoxPopupAlignmentTests
             window.Close();
         }
     }
+
+    /// <summary>
+    ///   The delayed settle check exists to catch a popup whose asynchronous move landed after the
+    ///   loop had already unsubscribed. It must not mistake the user's own scrolling for that: if
+    ///   the list is wheeled inside the delay window, re-aligning would snap it back from under
+    ///   them.
+    /// </summary>
+    /// <remarks>
+    ///   This drives the decision directly rather than waiting for the real callback.
+    ///   <c>DispatcherTimer</c> does not fire under the headless dispatcher - it runs on a virtual
+    ///   clock that sleeping does not advance - so a test that scrolled and then waited would pass
+    ///   whether or not the guard existed, which an earlier version of this test did.
+    /// </remarks>
+    [Theory]
+    [InlineData(120.0, 120.0, false)]   // Untouched: a late compositor move leaves the list alone.
+    [InlineData(120.0, 220.0, true)]    // Wheeled down inside the delay window.
+    [InlineData(120.0, 20.0, true)]     // Wheeled up.
+    [InlineData(120.0, 120.3, false)]   // Sub-tolerance jitter is not a user scroll.
+    [InlineData(null, 120.0, false)]    // No scroller when scheduled: nothing to compare against.
+    [InlineData(120.0, null, false)]
+    public void Scrolling_within_the_settle_delay_is_recognized(double? atSchedule, double? now, bool expected) =>
+        Assert.Equal(expected, ComboBoxPopupAlignmentBehavior.UserScrolledSince(atSchedule, now));
+
+    /// <summary>
+    ///   Guards the premise of the test above: the row really is displaced by a scroll, and nothing
+    ///   in the behaviour puts it back on its own.
+    /// </summary>
+    [AvaloniaFact]
+    public void Scrolling_an_aligned_drop_down_is_not_undone()
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 1000, selectedIndex: 500, maxDropDownHeight: 200);
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            ScrollViewer scroller = popup.Child!.GetVisualDescendants().OfType<ScrollViewer>().First();
+            scroller.SetCurrentValue(ScrollViewer.OffsetProperty, scroller.Offset.WithY(scroller.Offset.Y + 100));
+            Dispatcher.UIThread.RunJobs();
+
+            double displaced = SelectedRowOffsetFromComboBox(combo);
+            Assert.True(
+                Math.Abs(displaced) > Tolerance,
+                $"The row should be displaced by the scroll, but it was off by {displaced}.");
+
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(displaced, SelectedRowOffsetFromComboBox(combo), 3);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
 }

--- a/tests/Devolutions.AvaloniaControls.VisualTests/LinuxComboBoxPopupAlignmentTests.cs
+++ b/tests/Devolutions.AvaloniaControls.VisualTests/LinuxComboBoxPopupAlignmentTests.cs
@@ -1,0 +1,298 @@
+namespace Devolutions.AvaloniaControls.VisualTests;
+
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Primitives.PopupPositioning;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Devolutions.AvaloniaControls.Behaviors;
+using Devolutions.AvaloniaTheme.Linux;
+using Xunit;
+
+/// <summary>
+///   Checks the outcome the Linux drop-down is trying to achieve: the selected row lands on the
+///   closed ComboBox, so the visible text does not jump when the list opens.
+/// </summary>
+/// <remarks>
+///   <para>
+///     The Linux theme uses the same <c>SelectedIndexToPopupOffsetConverter</c> estimate as the
+///     macOS one, and shares its limitation: the estimate is only correct while the whole list fits
+///     in the popup. Once the list scrolls, the ComboBox scrolls the selected row into view and the
+///     row is no longer at <c>SelectedIndex * ItemHeight</c>.
+///   </para>
+///   <para>
+///     These mirror <see cref="MacOsComboBoxPopupAlignmentTests" />, minus the parts that are
+///     specific to macOS: there is no Liquid Glass/classic geometry split to cover, and the Linux
+///     resources do not alias accent colours with <c>StaticResource</c>, so no application-wide
+///     accent fallback is needed.
+///   </para>
+///   <para>
+///     Every test here works by <em>perturbing an open drop-down</em> and asserting the correction
+///     loop closes the gap again. Simply opening a drop-down and checking the row proves nothing:
+///     under the headless overlay popup host the offset binding and Avalonia's own
+///     <c>ScrollIntoView</c> already land the row on the ComboBox at every index, so such a test
+///     passes with the behaviour disabled - and even with the arithmetic estimate deliberately
+///     broken. Each test below was mutation-tested to confirm it fails when the mechanism it covers
+///     is removed.
+///   </para>
+/// </remarks>
+[Collection("VisualTests")]
+public class LinuxComboBoxPopupAlignmentTests
+{
+    /// <summary>Rounding across two coordinate spaces; a fraction of a row is invisible.</summary>
+    private const double Tolerance = 2.0;
+
+    private static Window ShowLinux(ThemeVariant variant)
+    {
+        var theme = new DevolutionsLinuxYaruTheme();
+        theme.BeginInit();
+        theme.EndInit();
+        // Tall enough that a scrolling drop-down is not additionally clamped by the window.
+        var window = new Window { RequestedThemeVariant = variant, Width = 400, Height = 700 };
+        window.Styles.Add(theme);
+        return window;
+    }
+
+    /// <summary>
+    ///   Vertical distance between the centre of the closed ComboBox and the centre of the selected
+    ///   row, in screen space. Zero means "the text did not move".
+    /// </summary>
+    private static double SelectedRowOffsetFromComboBox(ComboBox combo)
+    {
+        Control container = Assert.IsAssignableFrom<Control>(combo.ContainerFromIndex(combo.SelectedIndex));
+        Assert.True(container.IsAttachedToVisualTree(), "The selected row should be realized when the popup is open.");
+
+        double comboCentre = combo.PointToScreen(new Point(0, combo.Bounds.Height / 2)).Y;
+        double rowCentre = container.PointToScreen(new Point(0, container.Bounds.Height / 2)).Y;
+        return rowCentre - comboCentre;
+    }
+
+    private static ComboBox OpenComboBox(Window window, int itemCount, int selectedIndex, double maxDropDownHeight)
+    {
+        var combo = new ComboBox
+        {
+            ItemsSource = Enumerable.Range(1, itemCount).Select(i => $"Item {i}").ToList(),
+            SelectedIndex = selectedIndex,
+            MaxDropDownHeight = maxDropDownHeight,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+        };
+        window.Content = combo;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        combo.IsDropDownOpen = true;
+        Dispatcher.UIThread.RunJobs();
+        return combo;
+    }
+
+    /// <summary>
+    ///   The drop-down must not be allowed to flip to the other side of the ComboBox.
+    /// </summary>
+    /// <remarks>
+    ///   A template assertion rather than a positional one: the flip is performed by the platform
+    ///   compositor, which the headless overlay popup host does not model, so the misplacement it
+    ///   causes cannot be reproduced in-process. See the comment on the template for why the default
+    ///   <c>All</c> - which includes <c>FlipY</c> - is wrong for a drop-down that is deliberately
+    ///   offset upwards.
+    /// </remarks>
+    [AvaloniaFact]
+    public void Drop_down_is_not_allowed_to_flip_to_the_other_side()
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 20, selectedIndex: 10, maxDropDownHeight: 200);
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            Assert.False(
+                popup.PlacementConstraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.FlipY),
+                "FlipY would send the drop-down to the far side of the ComboBox at the bottom of the screen.");
+
+            Assert.True(
+                popup.PlacementConstraintAdjustment.HasFlag(PopupPositionerConstraintAdjustment.SlideY),
+                "Without SlideY the drop-down could be positioned off-screen instead of being nudged back on.");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+
+
+    /// <summary>
+    ///   A drop-down knocked out of alignment while open must be corrected without waiting to be
+    ///   closed and reopened.
+    /// </summary>
+    /// <remarks>
+    ///   The real trigger is choosing a different item from the open list, whose fresh arithmetic
+    ///   estimate is exactly the error this behavior corrects. That cannot be asserted positionally
+    ///   here, because the headless overlay popup host leaves every index aligned on its own, so the
+    ///   offset is moved directly instead - the same external write the binding performs.
+    /// </remarks>
+    [AvaloniaFact]
+    public void Offset_moved_while_open_is_corrected_without_reopening()
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 1000, selectedIndex: 500, maxDropDownHeight: 200);
+            Assert.InRange(SelectedRowOffsetFromComboBox(combo), -Tolerance, Tolerance);
+
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+            popup.SetCurrentValue(Popup.VerticalOffsetProperty, popup.VerticalOffset + 100);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.InRange(SelectedRowOffsetFromComboBox(combo), -Tolerance, Tolerance);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    ///   Stepping between two adjacent far-down selections in an open drop-down must re-align, even
+    ///   though the offset binding produces no new value.
+    /// </summary>
+    /// <remarks>
+    ///   The converter clamps at the effective popup height, so every sufficiently large index
+    ///   yields the same offset and no property change is raised. The selection itself has to be
+    ///   observed.
+    /// </remarks>
+    [AvaloniaFact]
+    public void Stepping_between_clamped_selections_still_re_aligns()
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 1000, selectedIndex: 500, maxDropDownHeight: 200);
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            // Scroll the open list away from the selected row. The behavior has already converged
+            // and unsubscribed, so nothing corrects this on its own.
+            ScrollViewer scroller = popup.Child!.GetVisualDescendants().OfType<ScrollViewer>().First();
+            scroller.SetCurrentValue(ScrollViewer.OffsetProperty, scroller.Offset.WithY(scroller.Offset.Y + 100));
+            Dispatcher.UIThread.RunJobs();
+
+            double displaced = SelectedRowOffsetFromComboBox(combo);
+            Assert.True(
+                Math.Abs(displaced) > Tolerance,
+                $"The row should be displaced before the selection changes, but it was off by {displaced}.");
+
+            // Both indices produce the same clamped offset, so the binding raises no property change
+            // at all - only SelectionChanged can reveal that the row to align to has moved.
+            Assert.Equal(BindingOffsetFor(selectedIndex: 500), BindingOffsetFor(selectedIndex: 501), 3);
+
+            combo.SelectedIndex = 501;
+            Dispatcher.UIThread.RunJobs();
+            Assert.InRange(SelectedRowOffsetFromComboBox(combo), -Tolerance, Tolerance);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    ///   Enabling the behavior while the drop-down is already showing must align that opening,
+    ///   rather than waiting for an <see cref="Popup.Opened" /> event that has already passed.
+    /// </summary>
+    [AvaloniaFact]
+    public void Enabling_the_behavior_on_an_open_drop_down_aligns_it()
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 1000, selectedIndex: 500, maxDropDownHeight: 200);
+
+            ComboBoxPopupAlignmentBehavior.SetEnable(combo, false);
+            Dispatcher.UIThread.RunJobs();
+
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+            popup.SetCurrentValue(Popup.VerticalOffsetProperty, popup.VerticalOffset + 100);
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(
+                Math.Abs(SelectedRowOffsetFromComboBox(combo)) > Tolerance,
+                "The drop-down should be misaligned while the behavior is off, or this proves nothing.");
+
+            ComboBoxPopupAlignmentBehavior.SetEnable(combo, true);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.InRange(SelectedRowOffsetFromComboBox(combo), -Tolerance, Tolerance);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+
+    /// <summary>
+    ///   Switching the behavior off while the drop-down is open must hand the offset back too, or
+    ///   the correction it had already applied would outlive it with nothing left to clear it.
+    /// </summary>
+    [AvaloniaFact]
+    public void Disabling_the_behavior_while_open_hands_the_offset_back()
+    {
+        double expected = BindingOffsetFor(selectedIndex: 500);
+
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            ComboBox combo = OpenComboBox(window, itemCount: 1000, selectedIndex: 500, maxDropDownHeight: 200);
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+
+            ComboBoxPopupAlignmentBehavior.SetEnable(combo, false);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(expected, popup.VerticalOffset, 3);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    /// <summary>
+    ///   The offset the template's binding produces for <paramref name="selectedIndex" />, sampled
+    ///   at <see cref="Popup.Opened" /> - before any correction has been applied, and without
+    ///   involving the close path at all.
+    /// </summary>
+    private static double BindingOffsetFor(int selectedIndex)
+    {
+        Window window = ShowLinux(ThemeVariant.Light);
+        try
+        {
+            var combo = new ComboBox
+            {
+                ItemsSource = Enumerable.Range(1, 1000).Select(i => $"Item {i}").ToList(),
+                SelectedIndex = selectedIndex,
+                MaxDropDownHeight = 200,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            };
+            window.Content = combo;
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            // Disable the correction pass so the estimate is observed on its own.
+            ComboBoxPopupAlignmentBehavior.SetEnable(combo, false);
+            Dispatcher.UIThread.RunJobs();
+
+            combo.IsDropDownOpen = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Popup popup = Assert.Single(combo.GetVisualDescendants().OfType<Popup>());
+            return popup.VerticalOffset;
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}


### PR DESCRIPTION
Ports the drop-down alignment fix from #652 to the Linux theme.

## Why

`src/Devolutions.AvaloniaTheme.Linux/Controls/ComboBox.axaml` used the same arithmetic `VerticalOffset` estimate as the macOS theme did, and shared its limitations. That estimate only holds while the whole list fits in the popup: once it scrolls, the ComboBox scrolls the selected row into view and the row is no longer at `SelectedIndex * ItemHeight`, so long option sets opened visibly misaligned.

Confirmed rather than assumed — a headless probe on the unmodified Linux theme (1000 items, index 500) perturbed the open popup by 100px and it was never corrected.

## What changed

The template:

- **`ComboBoxPopupAlignmentBehavior.Enable`** — measures the popup's real layout and corrects it, instead of predicting. The behavior is theme-agnostic (it only needs a popup named `PART_Popup`), so every fix made for macOS applies here too: measure-don't-predict, re-arming on `SelectionChanged`, and the scale-agnostic coordinate conversion.
- **`PlacementConstraintAdjustment="SlideX, SlideY, ResizeX, ResizeY`** — suppresses `FlipY`. The default (`All`) includes it, which suits menus but not a drop-down deliberately offset upwards: near the bottom of the screen the compositor flips it as well, leaving it floating a popup-height above the control.

`EditableComboBox` is deliberately untouched — its drop-down is supposed to stay below the control.

### Timing fixes found during on-device testing

The behavior itself needed three corrections that only surfaced against a real compositor. On X11 (which is also what a Wayland session uses, via XWayland — Avalonia has no Wayland backend) the popup's move lands asynchronously via `ConfigureNotify`, well after the dispatcher passes that drive the correction loop. macOS did not expose these because its moves land synchronously.

- **A correction could be applied twice from one measurement.** The pass immediately after a correction usually re-reads the pre-move position. That stale reading only counted towards the "popup is clamped" streak after repeating three times; below that it fell straight through and applied the full correction again. The popup then moved by twice what was needed, so the misalignment returned with the same magnitude and the opposite sign, oscillating until the pass budget ran out. Any unchanged reading is now treated as in-flight.
- **An in-flight move could be mistaken for a clamped popup.** Counting dispatcher passes is not sufficient, as they re-run far faster than the `ConfigureNotify` round-trip; the streak now also has to span real elapsed time.
- **The loop could stop on a not-yet-settled reading.** It unsubscribes as soon as one reading is within tolerance — deliberately, since staying subscribed makes the drop-down fight the user's own scrolling — which left a small permanent residual. A single delayed settle check now re-arms only if the popup actually ended up wrong.

## Tests

Five new tests, and it is worth saying what is *not* there. I first wrote the obvious ones — open the drop-down at various indices, assert the row is aligned. All passed, and all were worthless: they still passed with the behavior fully disabled, and even with the arithmetic estimate deliberately sabotaged, because under the headless overlay popup host the row lands aligned at every index on its own. I swept indices 3/50/100/150/198 looking for a case that would bite; none did, so they were deleted (the same conclusion reached twice in #652).

What remains works by perturbing an *open* drop-down and asserting the loop closes the gap. Each was mutation-tested:

| Test | Mutation that makes it fail |
| --- | --- |
| `Drop_down_is_not_allowed_to_flip_to_the_other_side` | remove `PlacementConstraintAdjustment` |
| `Offset_moved_while_open_is_corrected_without_reopening` | remove the `Enable` setter, or neuter `RunPass` |
| `Stepping_between_clamped_selections_still_re_aligns` | remove the `Enable` setter, or neuter `RunPass` |
| `Enabling_the_behavior_on_an_open_drop_down_aligns_it` | neuter `RunPass` |
| `Disabling_the_behavior_while_open_hands_the_offset_back` | neuter `RestoreBindingOffset` |

`Stepping_between_clamped_selections_still_re_aligns` earned its keep during this work: it caught an attempted fix that kept the layout listeners alive to confirm alignment, which would have made the drop-down override the user's own scrolling.

The Linux theme loads headlessly without an accent fallback and has no Liquid Glass/classic split, so none of the macOS test scaffolding was needed. Full fast suite: 48 passed.

## Verified on device

The headless host does not model popup placement constraints or compositor timing, so the remaining risk was checked by hand:

- Long lists (1000+ items) align correctly on first open and on reopen, on Linux under a Wayland session (XWayland, 100% scale).
- Screen-edge behaviour: no flipping; the popup slides and stays anchored.
- Display scaling: checked on macOS across Retina and non-Retina displays.
- Windows and macOS re-checked for regressions, since the behavior is shared.

The timing constants (60 ms stuck confirmation, 120 ms settle check) are the one judgement call: they were validated on a modestly-specced VM, and the failure mode if a machine were slower still is a drop-down row that is not perfectly aligned.

Baselines are not updated here; no visual-regression changes are expected, since the demo page already carries the ComboBoxes added in #652.

_Posted by Copilot CLI (agent), on behalf of @apman._
